### PR TITLE
Initial Spotter prototype: CLI, core, config, adapters, tests, and CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{md,yml,yaml}]
+indent_size = 2
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[dev]'
+      - run: ruff format --check .
+      - run: ruff check .
+      - run: mypy src tests
+      - run: pytest
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.coverage
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+.venv/
+build/
+dist/
+

--- a/README.md
+++ b/README.md
@@ -132,9 +132,48 @@ Spotter is intended as a reference implementation for exploring that layer.
 - [Research](docs/research.md) — related work and ideas Spotter borrows
 - [Roadmap](docs/roadmap.md) — staged implementation and evaluation plan
 
+## Development
+
+Spotter's initial implementation uses Python 3.11 or newer and has no runtime
+dependencies. Create an isolated environment, install the project with its development
+tools, and run every local check with:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e '.[dev]'
+ruff format --check .
+ruff check .
+mypy src tests
+pytest
+spotter --config spotter.example.toml
+```
+
+The example configuration selects the main-agent adapter and reviewer model and defaults
+to safe, passive observation:
+
+```toml
+observation_only = true
+
+[main_agent]
+adapter = "codex"
+
+[reviewer]
+model = "gpt-5.3-spark"
+```
+
+`gpt-5.3-spark` is the default Spotter reviewer model, so the `[reviewer]` table may be
+omitted unless a different reviewer model is required.
+
+The package deliberately keeps normalized trace events and orchestration separate from
+the Codex adapter. The current command is a runnable scaffold: it validates configuration,
+starts an in-memory adapter, and records a session-start event. Event streaming and
+model-backed review are the next implementation milestone.
+
 ## Status
 
-**Research / design stage.** The repository currently documents the concept and planned architecture before implementation begins.
+**Prototype scaffold.** The repository now includes the runnable observation-only foundation;
+Codex event ingestion and reviewer decisions are not implemented yet.
 
 The first milestone is deliberately small: observe a Codex trajectory with a separate reviewer model, identify high-confidence misbehavior, and measure whether intervention helps more than it harms.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["hatchling>=1.24"]
+build-backend = "hatchling.build"
+
+[project]
+name = "spotter-agent"
+version = "0.1.0"
+description = "Runtime trajectory supervision for coding agents"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Spotter contributors" }]
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+  "mypy>=1.10,<2",
+  "pytest>=8,<9",
+  "ruff>=0.5,<1",
+]
+
+[project.scripts]
+spotter = "spotter.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/spotter"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+files = ["src", "tests"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]
+

--- a/spotter.example.toml
+++ b/spotter.example.toml
@@ -1,0 +1,7 @@
+observation_only = true
+
+[main_agent]
+adapter = "codex"
+
+[reviewer]
+model = "gpt-5.3-spark"

--- a/src/spotter/__init__.py
+++ b/src/spotter/__init__.py
@@ -1,0 +1,6 @@
+"""Spotter runtime supervision prototype."""
+
+from spotter.config import SpotterConfig
+from spotter.core import SpotterRuntime
+
+__all__ = ["SpotterConfig", "SpotterRuntime"]

--- a/src/spotter/__main__.py
+++ b/src/spotter/__main__.py
@@ -1,0 +1,3 @@
+from spotter.cli import main
+
+raise SystemExit(main())

--- a/src/spotter/adapters.py
+++ b/src/spotter/adapters.py
@@ -1,0 +1,12 @@
+"""Boundaries between Spotter core and agent runtimes."""
+
+from typing import Protocol
+
+from spotter.trace import TraceEvent
+
+
+class AgentAdapter(Protocol):
+    """Minimal interface supplied by a runtime-specific integration."""
+
+    def record(self, event: TraceEvent) -> None:
+        """Record a normalized trajectory event."""

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -1,0 +1,36 @@
+"""Command-line entry point for the passive-observation prototype."""
+
+import argparse
+import tomllib
+from collections.abc import Sequence
+from pathlib import Path
+
+from spotter.codex import CodexAdapter
+from spotter.config import ConfigurationError, SpotterConfig
+from spotter.core import SpotterRuntime
+from spotter.trace import TraceEvent
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Observe a coding-agent trajectory")
+    parser.add_argument("--config", type=Path, required=True, help="path to Spotter TOML config")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        config = SpotterConfig.from_toml(args.config)
+    except (OSError, tomllib.TOMLDecodeError, ConfigurationError) as error:
+        parser.error(str(error))
+
+    adapter = CodexAdapter()
+    runtime = SpotterRuntime(config=config, adapter=adapter)
+    runtime.observe(TraceEvent(kind="session_start"))
+    mode = "observation-only" if config.observation_only else "active"
+    print(
+        f"Spotter ready: adapter={config.main_agent.adapter}, "
+        f"reviewer={config.reviewer.model}, mode={mode}"
+    )
+    return 0

--- a/src/spotter/codex.py
+++ b/src/spotter/codex.py
@@ -1,0 +1,15 @@
+"""Placeholder Codex adapter kept outside the supervision core."""
+
+from dataclasses import dataclass, field
+
+from spotter.trace import TraceEvent
+
+
+@dataclass
+class CodexAdapter:
+    """In-memory event sink until Codex event ingestion is implemented."""
+
+    events: list[TraceEvent] = field(default_factory=list)
+
+    def record(self, event: TraceEvent) -> None:
+        self.events.append(event)

--- a/src/spotter/config.py
+++ b/src/spotter/config.py
@@ -1,0 +1,78 @@
+"""Configuration loading and validation."""
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class ConfigurationError(ValueError):
+    """Raised when a Spotter configuration is malformed."""
+
+
+DEFAULT_REVIEWER_MODEL = "gpt-5.3-spark"
+
+
+@dataclass(frozen=True)
+class MainAgentConfig:
+    adapter: str
+
+
+@dataclass(frozen=True)
+class ReviewerConfig:
+    model: str = DEFAULT_REVIEWER_MODEL
+
+
+@dataclass(frozen=True)
+class SpotterConfig:
+    main_agent: MainAgentConfig
+    reviewer: ReviewerConfig
+    observation_only: bool = True
+
+    @classmethod
+    def from_toml(cls, path: Path) -> "SpotterConfig":
+        with path.open("rb") as config_file:
+            raw = tomllib.load(config_file)
+        return cls.from_mapping(raw)
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any]) -> "SpotterConfig":
+        main_agent = _table(raw, "main_agent")
+        reviewer = _optional_table(raw, "reviewer")
+        observation_only = raw.get("observation_only", True)
+        if not isinstance(observation_only, bool):
+            raise ConfigurationError("observation_only must be a boolean")
+        return cls(
+            main_agent=MainAgentConfig(adapter=_string(main_agent, "adapter")),
+            reviewer=ReviewerConfig(
+                model=_optional_string(reviewer, "model", DEFAULT_REVIEWER_MODEL)
+            ),
+            observation_only=observation_only,
+        )
+
+
+def _table(raw: dict[str, Any], key: str) -> dict[str, Any]:
+    value = raw.get(key)
+    if not isinstance(value, dict):
+        raise ConfigurationError(f"{key} must be a table")
+    return value
+
+
+def _optional_table(raw: dict[str, Any], key: str) -> dict[str, Any]:
+    value = raw.get(key, {})
+    if not isinstance(value, dict):
+        raise ConfigurationError(f"{key} must be a table")
+    return value
+
+
+def _string(raw: dict[str, Any], key: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigurationError(f"{key} must be a non-empty string")
+    return value
+
+
+def _optional_string(raw: dict[str, Any], key: str, default: str) -> str:
+    if key not in raw:
+        return default
+    return _string(raw, key)

--- a/src/spotter/core.py
+++ b/src/spotter/core.py
@@ -1,0 +1,19 @@
+"""Runtime-neutral supervision orchestration."""
+
+from dataclasses import dataclass
+
+from spotter.adapters import AgentAdapter
+from spotter.config import SpotterConfig
+from spotter.trace import TraceEvent
+
+
+@dataclass
+class SpotterRuntime:
+    """Receive normalized events without depending on a specific agent runtime."""
+
+    config: SpotterConfig
+    adapter: AgentAdapter
+
+    def observe(self, event: TraceEvent) -> None:
+        """Accept an event; active intervention is intentionally not implemented yet."""
+        self.adapter.record(event)

--- a/src/spotter/reviewer.py
+++ b/src/spotter/reviewer.py
@@ -1,0 +1,10 @@
+"""Reviewer boundary for future model-backed trajectory review."""
+
+from typing import Protocol
+
+from spotter.trace import TraceEvent
+
+
+class Reviewer(Protocol):
+    def review(self, event: TraceEvent) -> str:
+        """Return a structured decision for a normalized event."""

--- a/src/spotter/trace.py
+++ b/src/spotter/trace.py
@@ -1,0 +1,10 @@
+"""Small runtime-independent trace representation."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class TraceEvent:
+    kind: str
+    payload: dict[str, Any] = field(default_factory=dict)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pytest
+
+from spotter.config import ConfigurationError, SpotterConfig
+
+
+def test_loads_example_configuration() -> None:
+    config = SpotterConfig.from_toml(Path("spotter.example.toml"))
+
+    assert config.main_agent.adapter == "codex"
+    assert config.reviewer.model == "gpt-5.3-spark"
+    assert config.observation_only is True
+
+
+def test_uses_default_reviewer_model_when_reviewer_is_omitted() -> None:
+    config = SpotterConfig.from_mapping({"main_agent": {"adapter": "codex"}})
+
+    assert config.reviewer.model == "gpt-5.3-spark"
+
+
+def test_rejects_invalid_reviewer_table() -> None:
+    with pytest.raises(ConfigurationError, match="reviewer must be a table"):
+        SpotterConfig.from_mapping({"main_agent": {"adapter": "codex"}, "reviewer": "invalid"})

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,15 @@
+from spotter.codex import CodexAdapter
+from spotter.config import MainAgentConfig, ReviewerConfig, SpotterConfig
+from spotter.core import SpotterRuntime
+from spotter.trace import TraceEvent
+
+
+def test_runtime_forwards_normalized_events() -> None:
+    adapter = CodexAdapter()
+    config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig("reviewer"))
+    runtime = SpotterRuntime(config, adapter)
+    event = TraceEvent("tool_result", {"exit_code": 0})
+
+    runtime.observe(event)
+
+    assert adapter.events == [event]


### PR DESCRIPTION
### Motivation

- Provide a small, runnable observation-only prototype of the Spotter runtime to validate basic design and developer workflow.
- Add project metadata and developer tooling so contributors can run static checks and tests consistently.

### Description

- Add a minimal package under `src/spotter` implementing `SpotterConfig`, `SpotterRuntime`, `TraceEvent`, and interfaces for `AgentAdapter` and `Reviewer`, plus a simple in-memory `CodexAdapter` and a CLI in `spotter.cli`.
- Add `spotter.example.toml`, a development-focused `README` section, and a `spotter` console entry point via `pyproject.toml`.
- Add project-level configuration files: `pyproject.toml`, `.editorconfig`, `.gitignore`, and a GitHub Actions workflow at `.github/workflows/ci.yml` to run formatting, linting, type checks, and tests.
- Add unit tests in `tests/test_config.py` and `tests/test_runtime.py` that validate configuration loading and that the runtime forwards normalized events.

### Testing

- Ran `pytest` which executed the configuration and runtime tests in `tests/` and they passed.
- Ran static checks `ruff format --check .` and `ruff check .` and type checks `mypy src tests` as configured in CI and they passed.
- The CI workflow `CI` was added to reproduce these checks on push and pull requests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79d198e7248329b0fd9f0de3a6b304)