### PR TITLE
Passive audit runtime: trace replay, reviewer, telemetry, and CLI findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,15 +165,23 @@ model = "gpt-5.3-spark"
 `gpt-5.3-spark` is the default Spotter reviewer model, so the `[reviewer]` table may be
 omitted unless a different reviewer model is required.
 
-The package deliberately keeps normalized trace events and orchestration separate from
-the Codex adapter. The current command is a runnable scaffold: it validates configuration,
-starts an in-memory adapter, and records a session-start event. Event streaming and
-model-backed review are the next implementation milestone.
+The package keeps normalized trace events and orchestration separate from the Codex
+adapter. The passive runtime maintains independent audit state, records reviewer telemetry,
+and can replay normalized JSONL traces through a separately configured reviewer:
+
+```bash
+spotter --config spotter.example.toml --replay trace.jsonl --findings findings.jsonl
+```
+
+`VERIFY` and `NUDGE` findings are logged alongside the triggering step. They never block,
+rewrite, steer, or otherwise modify the observed session. The included deterministic
+reviewer makes the prototype and tests runnable offline; the `Reviewer` protocol is the
+boundary for a model-backed implementation.
 
 ## Status
 
-**Prototype scaffold.** The repository now includes the runnable observation-only foundation;
-Codex event ingestion and reviewer decisions are not implemented yet.
+**First passive prototype.** Codex-shaped events can be normalized, observed, reviewed,
+and replayed. Active control remains deliberately out of scope.
 
 The first milestone is deliberately small: observe a Codex trajectory with a separate reviewer model, identify high-confidence misbehavior, and measure whether intervention helps more than it harms.
 

--- a/src/spotter/__init__.py
+++ b/src/spotter/__init__.py
@@ -1,6 +1,15 @@
 """Spotter runtime supervision prototype."""
 
+from spotter.audit import AuditSnapshot, AuditState
 from spotter.config import SpotterConfig
 from spotter.core import SpotterRuntime
+from spotter.reviewer import DecisionType, ReviewDecision
 
-__all__ = ["SpotterConfig", "SpotterRuntime"]
+__all__ = [
+    "AuditSnapshot",
+    "AuditState",
+    "DecisionType",
+    "ReviewDecision",
+    "SpotterConfig",
+    "SpotterRuntime",
+]

--- a/src/spotter/audit.py
+++ b/src/spotter/audit.py
@@ -1,0 +1,67 @@
+"""Independent, compact evidence state maintained by Spotter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from spotter.trace import TraceEvent
+
+
+@dataclass(frozen=True)
+class AuditSnapshot:
+    """Read-only reviewer view, preventing a reviewer from rewriting audit evidence."""
+
+    user_goal: str | None
+    constraints: frozenset[str]
+    hypotheses: tuple[str, ...]
+    touched_files: frozenset[str]
+    validation_status: str
+    recent_failures: tuple[str, ...]
+    consecutive_failures: int
+
+
+@dataclass
+class AuditState:
+    """Facts observed from events; agent claims are retained only as hypotheses."""
+
+    user_goal: str | None = None
+    constraints: set[str] = field(default_factory=set)
+    hypotheses: list[str] = field(default_factory=list)
+    touched_files: set[str] = field(default_factory=set)
+    validation_status: str = "unknown"
+    recent_failures: list[str] = field(default_factory=list)
+    consecutive_failures: int = 0
+
+    def update(self, event: TraceEvent) -> None:
+        if event.kind == "user_goal":
+            self.user_goal = event.intent or _string_payload(event, "goal")
+        self.constraints.update(event.constraints)
+        self.touched_files.update(event.files)
+
+        hypothesis = _string_payload(event, "hypothesis")
+        if hypothesis and hypothesis not in self.hypotheses:
+            self.hypotheses = [*self.hypotheses, hypothesis][-5:]
+        if event.validation:
+            self.validation_status = event.validation
+
+        if event.is_failed_result:
+            self.consecutive_failures += 1
+            self.recent_failures = [*self.recent_failures, event.result or "failure"][-5:]
+        elif event.is_result:
+            self.consecutive_failures = 0
+
+    def snapshot(self) -> AuditSnapshot:
+        return AuditSnapshot(
+            user_goal=self.user_goal,
+            constraints=frozenset(self.constraints),
+            hypotheses=tuple(self.hypotheses),
+            touched_files=frozenset(self.touched_files),
+            validation_status=self.validation_status,
+            recent_failures=tuple(self.recent_failures),
+            consecutive_failures=self.consecutive_failures,
+        )
+
+
+def _string_payload(event: TraceEvent, key: str) -> str | None:
+    value = event.payload.get(key)
+    return value if isinstance(value, str) and value else None

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -1,6 +1,7 @@
 """Command-line entry point for the passive-observation prototype."""
 
 import argparse
+import json
 import tomllib
 from collections.abc import Sequence
 from pathlib import Path
@@ -8,12 +9,15 @@ from pathlib import Path
 from spotter.codex import CodexAdapter
 from spotter.config import ConfigurationError, SpotterConfig
 from spotter.core import SpotterRuntime
-from spotter.trace import TraceEvent
+from spotter.reviewer import HeuristicReviewer
+from spotter.trace import TraceEvent, read_jsonl
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Observe a coding-agent trajectory")
     parser.add_argument("--config", type=Path, required=True, help="path to Spotter TOML config")
+    parser.add_argument("--replay", type=Path, help="replay normalized JSONL events")
+    parser.add_argument("--findings", type=Path, help="write passive findings as JSONL")
     return parser
 
 
@@ -26,11 +30,32 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.error(str(error))
 
     adapter = CodexAdapter()
-    runtime = SpotterRuntime(config=config, adapter=adapter)
-    runtime.observe(TraceEvent(kind="session_start"))
+    runtime = SpotterRuntime(
+        config=config,
+        adapter=adapter,
+        reviewer=HeuristicReviewer(config.reviewer.model),
+    )
+    events = read_jsonl(args.replay) if args.replay else [TraceEvent(kind="session_start")]
+    try:
+        for event in events:
+            runtime.observe(event)
+        if args.findings:
+            _write_findings(args.findings, runtime)
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
     mode = "observation-only" if config.observation_only else "active"
     print(
         f"Spotter ready: adapter={config.main_agent.adapter}, "
-        f"reviewer={config.reviewer.model}, mode={mode}"
+        f"reviewer={config.reviewer.model}, mode={mode}, "
+        f"invocations={runtime.invocations}, findings={len(runtime.findings)}"
     )
     return 0
+
+
+def _write_findings(path: Path, runtime: SpotterRuntime) -> None:
+    """Replace output atomically enough for repeatable CLI replay runs."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as output:
+        for finding in runtime.findings:
+            output.write(json.dumps(finding.to_dict()) + "\n")

--- a/src/spotter/codex.py
+++ b/src/spotter/codex.py
@@ -1,4 +1,4 @@
-"""Placeholder Codex adapter kept outside the supervision core."""
+"""Codex event normalization kept outside the supervision core."""
 
 from dataclasses import dataclass, field
 
@@ -7,9 +7,38 @@ from spotter.trace import TraceEvent
 
 @dataclass
 class CodexAdapter:
-    """In-memory event sink until Codex event ingestion is implemented."""
+    """In-memory sink and translator for Codex App Server-like event objects."""
 
     events: list[TraceEvent] = field(default_factory=list)
 
     def record(self, event: TraceEvent) -> None:
         self.events.append(event)
+
+    def normalize(self, raw: dict[str, object], step: int) -> TraceEvent:
+        """Normalize the useful public fields without requiring chain-of-thought."""
+
+        kind = str(raw.get("type", raw.get("kind", "unknown")))
+        files_value = raw.get("files", ())
+        files = tuple(str(path) for path in files_value) if isinstance(files_value, list) else ()
+        constraints_value = raw.get("constraints", ())
+        constraints = (
+            tuple(str(item) for item in constraints_value)
+            if isinstance(constraints_value, list)
+            else ()
+        )
+        payload = raw.get("payload", {})
+        return TraceEvent(
+            step=step,
+            kind=kind,
+            intent=_optional_text(raw.get("intent")),
+            operation=_optional_text(raw.get("operation") or raw.get("command")),
+            files=files,
+            result=_optional_text(raw.get("result") or raw.get("output_summary")),
+            validation=_optional_text(raw.get("validation")),
+            constraints=constraints,
+            payload=dict(payload) if isinstance(payload, dict) else {},
+        )
+
+
+def _optional_text(value: object) -> str | None:
+    return str(value) if value is not None else None

--- a/src/spotter/core.py
+++ b/src/spotter/core.py
@@ -1,19 +1,59 @@
-"""Runtime-neutral supervision orchestration."""
+"""Runtime-neutral passive supervision orchestration."""
 
-from dataclasses import dataclass
+from __future__ import annotations
+
+import time
+from collections import Counter
+from dataclasses import asdict, dataclass, field
 
 from spotter.adapters import AgentAdapter
+from spotter.audit import AuditState
 from spotter.config import SpotterConfig
+from spotter.reviewer import DecisionType, ReviewDecision, Reviewer
 from spotter.trace import TraceEvent
 
 
 @dataclass
+class Finding:
+    step: int
+    decision: ReviewDecision
+    latency_ms: float
+    token_usage: int | None = None
+    human_judgment: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass
 class SpotterRuntime:
-    """Receive normalized events without depending on a specific agent runtime."""
+    """Observe events and log advice; never block or mutate the main session."""
 
     config: SpotterConfig
     adapter: AgentAdapter
+    reviewer: Reviewer | None = None
+    state: AuditState = field(default_factory=AuditState)
+    invocations: int = 0
+    decision_counts: Counter[DecisionType] = field(default_factory=Counter)
+    findings: list[Finding] = field(default_factory=list)
 
-    def observe(self, event: TraceEvent) -> None:
-        """Accept an event; active intervention is intentionally not implemented yet."""
+    def observe(self, event: TraceEvent) -> ReviewDecision | None:
         self.adapter.record(event)
+        self.state.update(event)
+        if self.reviewer is None:
+            return None
+        started = time.perf_counter()
+        decision = self.reviewer.review(event, self.state.snapshot())
+        latency = (time.perf_counter() - started) * 1000
+        self.invocations += 1
+        self.decision_counts[decision.decision] += 1
+        if decision.decision is not DecisionType.CONTINUE:
+            self.findings.append(Finding(event.step, decision, latency))
+        return decision
+
+    def telemetry(self) -> dict[str, object]:
+        return {
+            "reviewer_invocations": self.invocations,
+            "decisions": {kind.value: self.decision_counts[kind] for kind in DecisionType},
+            "findings": len(self.findings),
+        }

--- a/src/spotter/reviewer.py
+++ b/src/spotter/reviewer.py
@@ -1,10 +1,80 @@
-"""Reviewer boundary for future model-backed trajectory review."""
+"""Independent reviewer boundary and passive structured decisions."""
 
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import StrEnum
 from typing import Protocol
 
+from spotter.audit import AuditSnapshot
 from spotter.trace import TraceEvent
 
 
+class DecisionType(StrEnum):
+    CONTINUE = "CONTINUE"
+    VERIFY = "VERIFY"
+    NUDGE = "NUDGE"
+
+
+@dataclass(frozen=True)
+class ReviewDecision:
+    decision: DecisionType
+    target: str
+    reason: str
+    probe: str | None
+    confidence: float
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
 class Reviewer(Protocol):
-    def review(self, event: TraceEvent) -> str:
-        """Return a structured decision for a normalized event."""
+    """A separately configured implementation may call any reviewer model."""
+
+    def review(self, event: TraceEvent, state: AuditSnapshot) -> ReviewDecision:
+        """Review the execution path without controlling the main agent."""
+
+
+@dataclass
+class HeuristicReviewer:
+    """Deterministic reference reviewer useful for local runs and replay tests."""
+
+    model: str
+
+    def review(self, event: TraceEvent, state: AuditSnapshot) -> ReviewDecision:
+        payload = event.payload
+        if state.consecutive_failures >= 2:
+            return ReviewDecision(
+                DecisionType.NUDGE,
+                "recent tool failures",
+                "The same operation is failing repeatedly without new evidence.",
+                "Change the diagnostic approach or inspect the first failure's root cause.",
+                0.95,
+            )
+        if payload.get("unsupported_assumption") is True:
+            return ReviewDecision(
+                DecisionType.VERIFY,
+                "current hypothesis",
+                "A consequential assumption has not been supported by external evidence.",
+                "Run the smallest check that can falsify the assumption before editing.",
+                0.92,
+            )
+        if payload.get("scope_drift") is True:
+            return ReviewDecision(
+                DecisionType.NUDGE,
+                "current task scope",
+                "The operation is outside the stated goal or known constraints.",
+                "Re-read the user goal and limit the next action to required files.",
+                0.94,
+            )
+        if event.kind in {"file_edit", "diff"} and event.validation == "missing":
+            return ReviewDecision(
+                DecisionType.VERIFY,
+                "edited files",
+                "The edit has no adequate validation evidence.",
+                "Run the narrowest relevant automated check.",
+                0.9,
+            )
+        return ReviewDecision(
+            DecisionType.CONTINUE, "trajectory", "No high-confidence issue.", None, 0.8
+        )

--- a/src/spotter/trace.py
+++ b/src/spotter/trace.py
@@ -42,8 +42,30 @@ class TraceEvent:
         kind = data.get("kind")
         if not isinstance(kind, str) or not kind:
             raise ValueError("kind must be a non-empty string")
-        data["files"] = tuple(data.get("files", ()))
-        data["constraints"] = tuple(data.get("constraints", ()))
+
+        payload = data.get("payload", {})
+        if not isinstance(payload, dict):
+            raise ValueError("payload must be an object")
+        data["payload"] = payload
+
+        step = data.get("step", 0)
+        if not isinstance(step, int) or isinstance(step, bool):
+            raise ValueError("step must be an integer")
+        data["step"] = step
+
+        for name in ("intent", "operation", "result", "validation"):
+            field_value = data.get(name)
+            if field_value is not None and not isinstance(field_value, str):
+                raise ValueError(f"{name} must be a string or null")
+
+        for name in ("files", "constraints"):
+            field_value = data.get(name, ())
+            if not isinstance(field_value, (list, tuple)) or not all(
+                isinstance(item, str) for item in field_value
+            ):
+                raise ValueError(f"{name} must be an array of strings")
+            data[name] = tuple(field_value)
+
         return cls(**data)
 
 

--- a/src/spotter/trace.py
+++ b/src/spotter/trace.py
@@ -1,10 +1,71 @@
-"""Small runtime-independent trace representation."""
+"""Backend-neutral trajectory events and replay serialization."""
 
-from dataclasses import dataclass, field
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import Any
 
 
 @dataclass(frozen=True)
 class TraceEvent:
+    """The small, stable interface between agent adapters and Spotter."""
+
     kind: str
     payload: dict[str, Any] = field(default_factory=dict)
+    step: int = 0
+    intent: str | None = None
+    operation: str | None = None
+    files: tuple[str, ...] = ()
+    result: str | None = None
+    validation: str | None = None
+    constraints: tuple[str, ...] = ()
+
+    @property
+    def is_result(self) -> bool:
+        return self.kind in {"tool_result", "validation"}
+
+    @property
+    def is_failed_result(self) -> bool:
+        return self.is_result and (
+            self.payload.get("success") is False or self.payload.get("exit_code") not in (None, 0)
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> TraceEvent:
+        data = dict(value)
+        kind = data.get("kind")
+        if not isinstance(kind, str) or not kind:
+            raise ValueError("kind must be a non-empty string")
+        data["files"] = tuple(data.get("files", ()))
+        data["constraints"] = tuple(data.get("constraints", ()))
+        return cls(**data)
+
+
+def read_jsonl(path: Path) -> Iterator[TraceEvent]:
+    """Read a replayable trace, rejecting malformed records with their line number."""
+
+    with path.open(encoding="utf-8") as stream:
+        for line_number, line in enumerate(stream, 1):
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+                if not isinstance(value, dict):
+                    raise TypeError("event must be an object")
+                yield TraceEvent.from_dict(value)
+            except (json.JSONDecodeError, TypeError, ValueError) as error:
+                raise ValueError(f"invalid trace at line {line_number}: {error}") from error
+
+
+def append_jsonl(path: Path, event: TraceEvent) -> None:
+    """Append one normalized event for later replay."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(event.to_dict(), sort_keys=True) + "\n")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,6 +1,7 @@
 from spotter.codex import CodexAdapter
 from spotter.config import MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.core import SpotterRuntime
+from spotter.reviewer import DecisionType, HeuristicReviewer
 from spotter.trace import TraceEvent
 
 
@@ -13,3 +14,56 @@ def test_runtime_forwards_normalized_events() -> None:
     runtime.observe(event)
 
     assert adapter.events == [event]
+
+
+def test_detects_unsupported_assumption_without_controlling_agent() -> None:
+    adapter = CodexAdapter()
+    config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig("independent-reviewer"))
+    runtime = SpotterRuntime(config, adapter, HeuristicReviewer(config.reviewer.model))
+    event = TraceEvent(
+        "tool_proposal", {"unsupported_assumption": True}, step=3, operation="edit config"
+    )
+
+    decision = runtime.observe(event)
+
+    assert decision is not None and decision.decision is DecisionType.VERIFY
+    assert adapter.events == [event]
+    assert runtime.findings[0].step == 3
+
+
+def test_detects_repeated_failures_and_tracks_telemetry() -> None:
+    config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig("reviewer"))
+    runtime = SpotterRuntime(config, CodexAdapter(), HeuristicReviewer("reviewer"))
+
+    runtime.observe(TraceEvent("tool_result", {"exit_code": 1}, step=1, result="failed"))
+    decision = runtime.observe(TraceEvent("tool_result", {"exit_code": 1}, step=2, result="failed"))
+
+    assert decision is not None and decision.decision is DecisionType.NUDGE
+    assert runtime.telemetry()["reviewer_invocations"] == 2
+    assert runtime.telemetry()["findings"] == 1
+    assert runtime.telemetry()["decisions"] == {"CONTINUE": 1, "VERIFY": 0, "NUDGE": 1}
+
+
+def test_audit_state_tracks_goal_constraints_files_and_validation() -> None:
+    runtime = SpotterRuntime(
+        SpotterConfig(MainAgentConfig("codex"), ReviewerConfig("reviewer")), CodexAdapter()
+    )
+    runtime.observe(TraceEvent("user_goal", intent="fix bug", constraints=("no deps",)))
+    runtime.observe(TraceEvent("file_edit", files=("src/app.py",), validation="missing"))
+
+    assert runtime.state.user_goal == "fix bug"
+    assert runtime.state.constraints == {"no deps"}
+    assert runtime.state.touched_files == {"src/app.py"}
+    assert runtime.state.validation_status == "missing"
+
+
+def test_reviewer_receives_an_immutable_audit_snapshot() -> None:
+    runtime = SpotterRuntime(
+        SpotterConfig(MainAgentConfig("codex"), ReviewerConfig("reviewer")), CodexAdapter()
+    )
+    runtime.observe(TraceEvent("user_goal", intent="fix bug", constraints=("no deps",)))
+
+    snapshot = runtime.state.snapshot()
+
+    assert snapshot.user_goal == "fix bug"
+    assert snapshot.constraints == frozenset({"no deps"})

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+
+from spotter.codex import CodexAdapter
+from spotter.trace import TraceEvent, append_jsonl, read_jsonl
+
+
+def test_trace_jsonl_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "trace.jsonl"
+    event = TraceEvent("file_edit", step=4, files=("src/a.py",), constraints=("small",))
+
+    append_jsonl(path, event)
+
+    assert list(read_jsonl(path)) == [event]
+
+
+def test_trace_reader_reports_bad_line(tmp_path: Path) -> None:
+    path = tmp_path / "trace.jsonl"
+    path.write_text('{"kind": "session_start"}\n{"broken"\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="line 2"):
+        list(read_jsonl(path))
+
+
+def test_trace_reader_rejects_missing_kind(tmp_path: Path) -> None:
+    path = tmp_path / "trace.jsonl"
+    path.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="kind must be a non-empty string"):
+        list(read_jsonl(path))
+
+
+def test_codex_adapter_normalizes_public_event_fields() -> None:
+    event = CodexAdapter().normalize(
+        {
+            "type": "tool_result",
+            "command": "pytest",
+            "files": ["tests/test_app.py"],
+            "output_summary": "passed",
+            "validation": "passed",
+            "payload": {"exit_code": 0},
+        },
+        7,
+    )
+
+    assert event == TraceEvent(
+        "tool_result",
+        {"exit_code": 0},
+        step=7,
+        operation="pytest",
+        files=("tests/test_app.py",),
+        result="passed",
+        validation="passed",
+    )

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -31,6 +31,26 @@ def test_trace_reader_rejects_missing_kind(tmp_path: Path) -> None:
         list(read_jsonl(path))
 
 
+@pytest.mark.parametrize(
+    ("record", "message"),
+    [
+        ('{"kind": "tool_result", "payload": null}', "payload must be an object"),
+        ('{"kind": "tool_result", "step": true}', "step must be an integer"),
+        ('{"kind": "tool_result", "operation": 3}', "operation must be a string or null"),
+        ('{"kind": "file_edit", "files": "src/app.py"}', "files must be an array"),
+        ('{"kind": "file_edit", "constraints": ["small", 3]}', "constraints must be an array"),
+    ],
+)
+def test_trace_reader_rejects_invalid_typed_fields(
+    tmp_path: Path, record: str, message: str
+) -> None:
+    path = tmp_path / "trace.jsonl"
+    path.write_text(f'{record}\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match=f"line 1: {message}"):
+        list(read_jsonl(path))
+
+
 def test_codex_adapter_normalizes_public_event_fields() -> None:
     event = CodexAdapter().normalize(
         {


### PR DESCRIPTION
### Motivation

- Provide a passive, observation-only runtime that keeps normalized trace events and reviewer evidence separate from the adapter. 
- Enable deterministic offline review and replay of normalized traces for testing and telemetry collection. 
- Surface reviewer findings non-invasively without steering or modifying the observed session.

### Description

- Add `spotter.audit` with `AuditState` and immutable `AuditSnapshot` to maintain compact reviewer-facing evidence and update it from events. 
- Extend `spotter.trace` with richer `TraceEvent` fields, JSONL `read_jsonl`/`append_jsonl` helpers, and serialization/validation logic. 
- Add `spotter/reviewer.py` that defines `DecisionType`, `ReviewDecision`, a `Reviewer` protocol, and a deterministic `HeuristicReviewer` reference implementation. 
- Update core and CLI: `SpotterRuntime` now invokes a reviewer, records findings and telemetry via a `Finding` dataclass, and the CLI supports `--replay` and `--findings` for JSONL replay and findings export; `CodexAdapter` gained `normalize` for public event translation; `__init__` exports new symbols.

### Testing

- Ran unit tests with `pytest` covering runtime behavior and trace round-trip, specifically `tests/test_runtime.py` and `tests/test_trace.py`. 
- The new and updated tests exercised review decisions, audit state updates, telemetry counts, replay error handling, and adapter normalization. 
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79d567df4083298bc2c73564a20765)