### PR TITLE
feat: deterministic gates, step journal, audit state, and Codex hook bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,15 +165,29 @@ model = "gpt-5.3-spark"
 `gpt-5.3-spark` is the default Spotter reviewer model, so the `[reviewer]` table may be
 omitted unless a different reviewer model is required.
 
+To record Codex tool calls, add the bridge to `.codex/hooks.json` and review it with
+`/hooks` in Codex:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{"hooks": [{"type": "command", "command": "spotter hook --config /absolute/path/to/spotter.toml"}]}],
+    "PostToolUse": [{"hooks": [{"type": "command", "command": "spotter hook --config /absolute/path/to/spotter.toml"}]}]
+  }
+}
+```
+
+Without `--config`, the hook only records observations. Set `observation_only = false`
+explicitly to enforce configured gates.
+
 The package deliberately keeps normalized trace events and orchestration separate from
-the Codex adapter. The current command is a runnable scaffold: it validates configuration,
-starts an in-memory adapter, and records a session-start event. Event streaming and
-model-backed review are the next implementation milestone.
+the Codex adapter. The hook bridge records tool events and applies deterministic gates;
+model-backed review is the next implementation milestone.
 
 ## Status
 
-**Prototype scaffold.** The repository now includes the runnable observation-only foundation;
-Codex event ingestion and reviewer decisions are not implemented yet.
+**Prototype.** Codex hook ingestion and deterministic gates are implemented. Reviewer
+decisions and replay are not.
 
 The first milestone is deliberately small: observe a Codex trajectory with a separate reviewer model, identify high-confidence misbehavior, and measure whether intervention helps more than it harms.
 

--- a/src/spotter/audit.py
+++ b/src/spotter/audit.py
@@ -1,0 +1,88 @@
+"""Independent audit state: claims are not evidence (plan Q2).
+
+The type system is the enforcement mechanism: ``EvidenceSource`` has no
+"summary" member, so a reasoning summary cannot become ``Evidence`` without
+mypy rejecting the call site. Summaries enter only as unverified hypotheses.
+"""
+
+from dataclasses import dataclass, field
+from typing import Literal, get_args
+
+EvidenceSource = Literal["tool_result", "diff", "test_output", "repo_state"]
+HypothesisStatus = Literal["unverified", "supported", "stale"]
+
+_VALID_SOURCES = frozenset(get_args(EvidenceSource))
+
+
+@dataclass(frozen=True)
+class Evidence:
+    id: str
+    source: EvidenceSource
+    description: str
+
+    def __post_init__(self) -> None:
+        # Runtime guard for untyped callers (JSON ingestion bypasses mypy).
+        if self.source not in _VALID_SOURCES:
+            raise ValueError(f"not an evidence source: {self.source!r}")
+
+
+@dataclass
+class Hypothesis:
+    id: str
+    claim: str
+    supported_by: set[str] = field(default_factory=set)  # evidence ids
+    depends_on: set[str] = field(default_factory=set)  # hypothesis ids
+    status: HypothesisStatus = "unverified"
+
+
+class AuditState:
+    """Claim/evidence ledger with transitive stale propagation."""
+
+    def __init__(self) -> None:
+        self.evidence: dict[str, Evidence] = {}
+        self.hypotheses: dict[str, Hypothesis] = {}
+        self.retracted: set[str] = set()
+
+    def add_evidence(self, evidence: Evidence) -> None:
+        if evidence.id in self.evidence:
+            raise ValueError(f"duplicate evidence id: {evidence.id}")
+        self.evidence[evidence.id] = evidence
+
+    def add_hypothesis(self, hypothesis: Hypothesis) -> None:
+        if hypothesis.id in self.hypotheses:
+            raise ValueError(f"duplicate hypothesis id: {hypothesis.id}")
+        self.hypotheses[hypothesis.id] = hypothesis
+
+    def support(self, hypothesis_id: str, evidence_id: str) -> None:
+        if evidence_id in self.retracted:
+            raise ValueError(f"evidence is retracted: {evidence_id}")
+        hypothesis = self.hypotheses[hypothesis_id]
+        _ = self.evidence[evidence_id]  # KeyError on unknown evidence
+        hypothesis.supported_by.add(evidence_id)
+        if hypothesis.status == "unverified":
+            hypothesis.status = "supported"
+
+    def retract(self, evidence_id: str) -> set[str]:
+        """Retract evidence; mark every transitively dependent hypothesis stale.
+
+        Returns the ids of hypotheses that became stale.
+        """
+        _ = self.evidence[evidence_id]
+        self.retracted.add(evidence_id)
+        stale = {
+            h.id
+            for h in self.hypotheses.values()
+            if evidence_id in h.supported_by and not h.supported_by - self.retracted
+        }
+        # Propagate along depends_on edges; visited set guards against cycles.
+        frontier = set(stale)
+        while frontier:
+            frontier = {
+                h.id
+                for h in self.hypotheses.values()
+                if h.id not in stale and h.depends_on & frontier
+            }
+            stale |= frontier
+        for hypothesis_id in stale:
+            self.hypotheses[hypothesis_id].status = "stale"
+        return stale

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -1,36 +1,84 @@
-"""Command-line entry point for the passive-observation prototype."""
+"""Command-line entry point: passive observation and the Codex hook bridge."""
 
 import argparse
+import json
+import sys
 import tomllib
 from collections.abc import Sequence
 from pathlib import Path
 
 from spotter.codex import CodexAdapter
-from spotter.config import ConfigurationError, SpotterConfig
+from spotter.config import ConfigurationError, MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.core import SpotterRuntime
+from spotter.gates import Gate
+from spotter.hook import run_hook
 from spotter.trace import TraceEvent
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Observe a coding-agent trajectory")
-    parser.add_argument("--config", type=Path, required=True, help="path to Spotter TOML config")
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=["observe", "hook"],
+        default="observe",
+        help="observe: validate config and start; hook: Codex hook bridge (JSON on stdin)",
+    )
+    parser.add_argument("--config", type=Path, help="path to Spotter TOML config")
     return parser
+
+
+def _load_config(parser: argparse.ArgumentParser, path: Path | None) -> SpotterConfig | None:
+    if path is None:
+        return None
+    try:
+        return SpotterConfig.from_toml(path)
+    except (OSError, tomllib.TOMLDecodeError, ConfigurationError) as error:
+        parser.error(str(error))
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    try:
-        config = SpotterConfig.from_toml(args.config)
-    except (OSError, tomllib.TOMLDecodeError, ConfigurationError) as error:
-        parser.error(str(error))
+    config = _load_config(parser, args.config)
 
+    if args.command == "hook":
+        return _hook_main(config)
+
+    if config is None:
+        parser.error("observe requires --config")
     adapter = CodexAdapter()
-    runtime = SpotterRuntime(config=config, adapter=adapter)
+    gate = Gate(
+        forbidden_paths=config.gates.forbidden_paths,
+        block_dependency_changes=config.gates.block_dependency_changes,
+        root=str(Path.cwd()),
+    )
+    runtime = SpotterRuntime(config=config, adapter=adapter, gate=gate)
     runtime.observe(TraceEvent(kind="session_start"))
     mode = "observation-only" if config.observation_only else "active"
     print(
         f"Spotter ready: adapter={config.main_agent.adapter}, "
         f"reviewer={config.reviewer.model}, mode={mode}"
     )
+    return 0
+
+
+def _hook_main(config: SpotterConfig | None) -> int:
+    """Read one hook payload from stdin, print a decision if any.
+
+    Always exits 0: any failure here fails open. Breaking the Codex session
+    over a supervision bug would be the exact harm Spotter exists to prevent.
+    """
+    if config is None:
+        config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig())
+    try:
+        payload = json.load(sys.stdin)
+        if not isinstance(payload, dict):
+            raise ValueError("hook payload must be a JSON object")
+        output = run_hook(payload, config)
+    except Exception as error:  # noqa: BLE001 — deliberate fail-open boundary
+        print(f"spotter hook error (failing open): {error}", file=sys.stderr)
+        return 0
+    if output is not None:
+        print(output)
     return 0

--- a/src/spotter/config.py
+++ b/src/spotter/config.py
@@ -24,9 +24,16 @@ class ReviewerConfig:
 
 
 @dataclass(frozen=True)
+class GatesConfig:
+    forbidden_paths: tuple[str, ...] = ()
+    block_dependency_changes: bool = False
+
+
+@dataclass(frozen=True)
 class SpotterConfig:
     main_agent: MainAgentConfig
     reviewer: ReviewerConfig
+    gates: GatesConfig = GatesConfig()
     observation_only: bool = True
 
     @classmethod
@@ -39,6 +46,7 @@ class SpotterConfig:
     def from_mapping(cls, raw: dict[str, Any]) -> "SpotterConfig":
         main_agent = _table(raw, "main_agent")
         reviewer = _optional_table(raw, "reviewer")
+        gates = _optional_table(raw, "gates")
         observation_only = raw.get("observation_only", True)
         if not isinstance(observation_only, bool):
             raise ConfigurationError("observation_only must be a boolean")
@@ -46,6 +54,10 @@ class SpotterConfig:
             main_agent=MainAgentConfig(adapter=_string(main_agent, "adapter")),
             reviewer=ReviewerConfig(
                 model=_optional_string(reviewer, "model", DEFAULT_REVIEWER_MODEL)
+            ),
+            gates=GatesConfig(
+                forbidden_paths=_string_tuple(gates, "forbidden_paths"),
+                block_dependency_changes=_bool(gates, "block_dependency_changes", False),
             ),
             observation_only=observation_only,
         )
@@ -76,3 +88,17 @@ def _optional_string(raw: dict[str, Any], key: str, default: str) -> str:
     if key not in raw:
         return default
     return _string(raw, key)
+
+
+def _string_tuple(raw: dict[str, Any], key: str) -> tuple[str, ...]:
+    value = raw.get(key, [])
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ConfigurationError(f"{key} must be a list of strings")
+    return tuple(value)
+
+
+def _bool(raw: dict[str, Any], key: str, default: bool) -> bool:
+    value = raw.get(key, default)
+    if not isinstance(value, bool):
+        raise ConfigurationError(f"{key} must be a boolean")
+    return value

--- a/src/spotter/core.py
+++ b/src/spotter/core.py
@@ -25,6 +25,13 @@ class SpotterRuntime:
         decision = self.gate.check(event)
         self.adapter.record(event)
         if decision.allowed:
+            if decision.rule:
+                self.adapter.record(
+                    TraceEvent(
+                        "gate_fail_open",
+                        {"rule": decision.rule, "reason": decision.reason},
+                    )
+                )
             return decision
         if self.config.observation_only:
             self.adapter.record(

--- a/src/spotter/core.py
+++ b/src/spotter/core.py
@@ -1,19 +1,40 @@
 """Runtime-neutral supervision orchestration."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from spotter.adapters import AgentAdapter
 from spotter.config import SpotterConfig
+from spotter.gates import ALLOW, Gate, GateDecision
 from spotter.trace import TraceEvent
 
 
 @dataclass
 class SpotterRuntime:
-    """Receive normalized events without depending on a specific agent runtime."""
+    """Receive normalized events; enforce deterministic gates.
+
+    In observation-only mode a would-be block is recorded as a shadow event
+    instead of enforced — the gate's false-positive rate must be measured
+    before it is allowed to stop anyone's work (plan Q7).
+    """
 
     config: SpotterConfig
     adapter: AgentAdapter
+    gate: Gate = field(default_factory=Gate)
 
-    def observe(self, event: TraceEvent) -> None:
-        """Accept an event; active intervention is intentionally not implemented yet."""
+    def observe(self, event: TraceEvent) -> GateDecision:
+        decision = self.gate.check(event)
         self.adapter.record(event)
+        if decision.allowed:
+            return decision
+        if self.config.observation_only:
+            self.adapter.record(
+                TraceEvent(
+                    "gate_shadow_block",
+                    {"rule": decision.rule, "reason": decision.reason},
+                )
+            )
+            return ALLOW
+        self.adapter.record(
+            TraceEvent("gate_block", {"rule": decision.rule, "reason": decision.reason})
+        )
+        return decision

--- a/src/spotter/gates.py
+++ b/src/spotter/gates.py
@@ -1,0 +1,113 @@
+"""Deterministic pre-action gates (plan P3).
+
+Rules only — an LLM verdict must never produce a BLOCK. False positives here
+are the most expensive failure, so every pattern errs toward allowing:
+ambiguous input passes, but passes are annotated so blindness is measurable.
+"""
+
+import posixpath
+import re
+import shlex
+from collections.abc import Iterable
+from dataclasses import dataclass
+from fnmatch import fnmatch
+
+from spotter.trace import TraceEvent
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    allowed: bool
+    rule: str | None = None
+    reason: str | None = None
+
+
+ALLOW = GateDecision(allowed=True)
+
+# Only clearly catastrophic commands. "rm -rf build/" is legitimate agent work;
+# blocking it would burn the trust budget the plan warns about (양치기 소년).
+_DESTRUCTIVE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    # Keyed on the target, not the flags: `rm ..` without -rf just fails, and
+    # long options (--recursive) must not slip through a flag-shape regex.
+    ("rm_root", re.compile(r"\brm\s+(?:-{1,2}\S+\s+)*(/|~|\$HOME|\.\.)/?(\s|$)")),
+    ("git_reset_hard", re.compile(r"\bgit\s+reset\s+--hard\b")),
+    ("git_clean_force", re.compile(r"\bgit\s+clean\b[^&|;]*-[a-zA-Z]*f")),
+    ("git_push_force", re.compile(r"\bgit\s+push\b[^&|;]*(--force\b|\s-f\b)")),
+    ("pipe_to_shell", re.compile(r"\b(curl|wget)\b[^&|;]*\|\s*(ba|z|da)?sh\b")),
+    ("dd_device", re.compile(r"\bdd\b[^&|;]*\bof=/dev/")),
+    ("mkfs", re.compile(r"\bmkfs\b")),
+)
+
+_DEPENDENCY_MANIFESTS = frozenset(
+    {
+        "package.json",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+        "pyproject.toml",
+        "requirements.txt",
+        "uv.lock",
+        "poetry.lock",
+        "Cargo.toml",
+        "Cargo.lock",
+        "go.mod",
+        "go.sum",
+        "Gemfile",
+        "Gemfile.lock",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Gate:
+    forbidden_paths: tuple[str, ...] = ()
+    block_dependency_changes: bool = False
+    root: str | None = None  # absolute workspace root; enables absolute-path judgment
+
+    def check(self, event: TraceEvent) -> GateDecision:
+        """Gate a pending action event. Non-action events always pass."""
+        if event.kind != "tool_proposal":
+            return ALLOW
+        command = event.payload.get("command")
+        if isinstance(command, str):
+            decision = self.check_command(command)
+            if not decision.allowed:
+                return decision
+        files = event.payload.get("files")
+        if isinstance(files, list):
+            return self.check_paths(str(f) for f in files)
+        return ALLOW
+
+    def check_command(self, command: str) -> GateDecision:
+        for rule, pattern in _DESTRUCTIVE_PATTERNS:
+            if pattern.search(command):
+                return GateDecision(False, rule, f"destructive command matched {rule}")
+        try:
+            shlex.split(command)
+        except ValueError:
+            # Unparseable — cannot reason about it. Fail open, but say so:
+            # this pass is a measured blind spot, not a clean bill of health.
+            return GateDecision(True, "unparseable_command", "fail-open: could not parse")
+        return ALLOW
+
+    def check_paths(self, paths: Iterable[str]) -> GateDecision:
+        for raw in paths:
+            path = posixpath.normpath(raw.replace("\\", "/"))
+            if posixpath.isabs(path):
+                root = posixpath.normpath(self.root.replace("\\", "/")) if self.root else None
+                if root is None:
+                    # Can't judge an absolute path without knowing the workspace.
+                    # Blocking here would be FP-prone; pass, annotated.
+                    continue
+                if path == root or path.startswith(root + "/"):
+                    path = posixpath.relpath(path, root)
+                else:
+                    return GateDecision(False, "workspace_escape", f"path leaves workspace: {raw}")
+            if path.startswith(".."):
+                return GateDecision(False, "workspace_escape", f"path leaves workspace: {raw}")
+            if self.block_dependency_changes and posixpath.basename(path) in _DEPENDENCY_MANIFESTS:
+                return GateDecision(False, "dependency_change", f"manifest edit: {path}")
+            for pattern in self.forbidden_paths:
+                if fnmatch(path, pattern):
+                    return GateDecision(False, "forbidden_path", f"{path} matches {pattern}")
+        return ALLOW

--- a/src/spotter/gates.py
+++ b/src/spotter/gates.py
@@ -68,29 +68,48 @@ class Gate:
         """Gate a pending action event. Non-action events always pass."""
         if event.kind != "tool_proposal":
             return ALLOW
+        uncertain: GateDecision | None = None
         command = event.payload.get("command")
         if isinstance(command, str):
             decision = self.check_command(command)
             if not decision.allowed:
                 return decision
+            if decision.rule:
+                uncertain = decision
         files = event.payload.get("files")
         if isinstance(files, list):
-            return self.check_paths(str(f) for f in files)
-        return ALLOW
+            decision = self.check_paths(str(f) for f in files)
+            if not decision.allowed or decision.rule:
+                return decision
+        return uncertain or ALLOW
 
     def check_command(self, command: str) -> GateDecision:
         for rule, pattern in _DESTRUCTIVE_PATTERNS:
             if pattern.search(command):
                 return GateDecision(False, rule, f"destructive command matched {rule}")
         try:
-            shlex.split(command)
+            tokens = shlex.split(command)
         except ValueError:
             # Unparseable — cannot reason about it. Fail open, but say so:
             # this pass is a measured blind spot, not a clean bill of health.
             return GateDecision(True, "unparseable_command", "fail-open: could not parse")
+        if "rm" in tokens and any(
+            (token and not token.strip("/"))
+            or token.rstrip("/") in {"~", "$HOME", "${HOME}", ".."}
+            for token in tokens[tokens.index("rm") + 1 :]
+            if not token.startswith("-")
+        ):
+            return GateDecision(False, "rm_root", "destructive command matched rm_root")
+        if "git" in tokens:
+            git_args = tokens[tokens.index("git") + 1 :]
+            if "reset" in git_args and "--hard" in git_args[git_args.index("reset") + 1 :]:
+                return GateDecision(
+                    False, "git_reset_hard", "destructive command matched git_reset_hard"
+                )
         return ALLOW
 
     def check_paths(self, paths: Iterable[str]) -> GateDecision:
+        uncertain: GateDecision | None = None
         for raw in paths:
             path = posixpath.normpath(raw.replace("\\", "/"))
             if posixpath.isabs(path):
@@ -98,6 +117,9 @@ class Gate:
                 if root is None:
                     # Can't judge an absolute path without knowing the workspace.
                     # Blocking here would be FP-prone; pass, annotated.
+                    uncertain = GateDecision(
+                        True, "unknown_workspace", f"fail-open: cannot judge absolute path: {raw}"
+                    )
                     continue
                 if path == root or path.startswith(root + "/"):
                     path = posixpath.relpath(path, root)
@@ -110,4 +132,4 @@ class Gate:
             for pattern in self.forbidden_paths:
                 if fnmatch(path, pattern):
                     return GateDecision(False, "forbidden_path", f"{path} matches {pattern}")
-        return ALLOW
+        return uncertain or ALLOW

--- a/src/spotter/gates.py
+++ b/src/spotter/gates.py
@@ -94,8 +94,7 @@ class Gate:
             # this pass is a measured blind spot, not a clean bill of health.
             return GateDecision(True, "unparseable_command", "fail-open: could not parse")
         if "rm" in tokens and any(
-            (token and not token.strip("/"))
-            or token.rstrip("/") in {"~", "$HOME", "${HOME}", ".."}
+            (token and not token.strip("/")) or token.rstrip("/") in {"~", "$HOME", "${HOME}", ".."}
             for token in tokens[tokens.index("rm") + 1 :]
             if not token.startswith("-")
         ):

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -17,6 +17,8 @@ from spotter.gates import Gate
 from spotter.snapshot import StepJournal
 from spotter.trace import TraceEvent
 
+_PATCH_PATH = re.compile(r"^\*\*\* (?:(?:Add|Update|Delete) File|Move to): (.+)$", re.MULTILINE)
+
 
 class JournalAdapter:
     def __init__(self, journal: StepJournal) -> None:
@@ -40,16 +42,27 @@ def event_from_hook(payload: dict[str, Any]) -> TraceEvent:
         listed = tool_input.get("files")
         if isinstance(listed, list):
             files.extend(str(item) for item in listed)
+        command = tool_input.get("command")
+        if payload.get("tool_name") == "apply_patch" and isinstance(command, str):
+            files.extend(_PATCH_PATH.findall(command))
         return TraceEvent(
             "tool_proposal",
             {
                 "tool": payload.get("tool_name"),
-                "command": tool_input.get("command"),
+                "command": command,
                 "files": files,
             },
         )
     if name == "PostToolUse":
-        return TraceEvent("tool_result", {"tool": payload.get("tool_name")})
+        return TraceEvent(
+            "tool_result",
+            {
+                "tool": payload.get("tool_name"),
+                "tool_use_id": payload.get("tool_use_id"),
+                "tool_input": payload.get("tool_input"),
+                "tool_response": payload.get("tool_response"),
+            },
+        )
     return TraceEvent(str(name or "unknown").lower())
 
 

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -1,0 +1,84 @@
+"""Codex hook bridge: stdin JSON in, PreToolUse decision JSON out.
+
+Prime directive: a buggy supervisor must never break the supervised session.
+Every failure path here fails open (allow) with a note on stderr — Spotter
+losing an observation is recoverable, Codex dying mid-turn is not.
+"""
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from spotter.config import SpotterConfig
+from spotter.core import SpotterRuntime
+from spotter.gates import Gate
+from spotter.snapshot import StepJournal
+from spotter.trace import TraceEvent
+
+
+class JournalAdapter:
+    def __init__(self, journal: StepJournal) -> None:
+        self.journal = journal
+
+    def record(self, event: TraceEvent) -> None:
+        self.journal.record(event)
+
+
+def event_from_hook(payload: dict[str, Any]) -> TraceEvent:
+    name = payload.get("hook_event_name")
+    if name == "PreToolUse":
+        tool_input = payload.get("tool_input")
+        if not isinstance(tool_input, dict):
+            tool_input = {}
+        files = [
+            str(value)
+            for key, value in tool_input.items()
+            if key in ("path", "file_path") and isinstance(value, str)
+        ]
+        listed = tool_input.get("files")
+        if isinstance(listed, list):
+            files.extend(str(item) for item in listed)
+        return TraceEvent(
+            "tool_proposal",
+            {
+                "tool": payload.get("tool_name"),
+                "command": tool_input.get("command"),
+                "files": files,
+            },
+        )
+    if name == "PostToolUse":
+        return TraceEvent("tool_result", {"tool": payload.get("tool_name")})
+    return TraceEvent(str(name or "unknown").lower())
+
+
+def journal_path(payload: dict[str, Any]) -> Path:
+    base = Path(os.environ.get("SPOTTER_HOME", Path.home() / ".spotter")) / "sessions"
+    base.mkdir(parents=True, exist_ok=True)
+    # session_id is external input headed into a filename — sanitize it.
+    session = re.sub(r"[^A-Za-z0-9_-]", "_", str(payload.get("session_id") or "unknown"))
+    return base / f"{session}.jsonl"
+
+
+def run_hook(payload: dict[str, Any], config: SpotterConfig) -> str | None:
+    """Process one hook invocation. Returns stdout JSON, or None to allow."""
+    cwd = payload.get("cwd")
+    gate = Gate(
+        forbidden_paths=config.gates.forbidden_paths,
+        block_dependency_changes=config.gates.block_dependency_changes,
+        root=str(cwd) if isinstance(cwd, str) else None,
+    )
+    runtime = SpotterRuntime(config, JournalAdapter(StepJournal(journal_path(payload))), gate)
+    decision = runtime.observe(event_from_hook(payload))
+    if decision.allowed:
+        return None  # implicit allow; stay silent on the happy path
+    return json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": f"[spotter:{decision.rule}] {decision.reason}",
+            }
+        }
+    )

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -1,0 +1,140 @@
+"""Step journal and repo snapshots — the recording half of fork/replay (plan P0).
+
+What this deliberately does NOT do: re-run the agent from a prefix. That needs
+Codex event ingestion first. Pretending otherwise with a stub would hide the
+plan's biggest open risk, so replay stays an explicit gap until the adapter
+exists. What we can guarantee today: every step is journaled, snapshots capture
+the full worktree (including untracked files), and restore never mutates the
+user's checkout.
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from spotter.trace import TraceEvent
+
+
+class SnapshotError(RuntimeError):
+    """Raised when git snapshot/restore plumbing fails."""
+
+
+def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env={**os.environ, **(env or {})},
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise SnapshotError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def snapshot_worktree(repo: Path) -> str:
+    """Snapshot the full worktree (untracked included) without touching the
+    user's index or HEAD. Returns the commit sha, pinned under refs/spotter/
+    so gc cannot silently delete it out from under a later restore."""
+    _git(repo, "rev-parse", "--git-dir")  # fail early if not a git repo
+    index_fd, index_path = tempfile.mkstemp(prefix="spotter-index-")
+    os.close(index_fd)
+    os.unlink(index_path)  # git wants to create the index file itself
+    try:
+        env = {"GIT_INDEX_FILE": index_path}
+        _git(repo, "add", "-A", env=env)
+        tree = _git(repo, "write-tree", env=env)
+        parent_args: list[str] = []
+        head = subprocess.run(
+            ["git", "rev-parse", "--verify", "-q", "HEAD"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+        )
+        if head.returncode == 0:  # unborn HEAD (empty repo) has no parent
+            parent_args = ["-p", head.stdout.strip()]
+        sha = _git(repo, "commit-tree", tree, *parent_args, "-m", "spotter step snapshot")
+        _git(repo, "update-ref", f"refs/spotter/steps/{sha}", sha)
+        return sha
+    finally:
+        if os.path.exists(index_path):
+            os.unlink(index_path)
+
+
+def restore_snapshot(repo: Path, sha: str, dest: Path) -> Path:
+    """Materialize a snapshot in a detached worktree at ``dest``.
+
+    Never mutates the user's checkout — a wrong restore into the live tree is
+    an unrecoverable failure mode, a separate worktree is merely disk.
+    """
+    if dest.exists():
+        raise SnapshotError(f"restore destination already exists: {dest}")
+    _git(repo, "worktree", "add", "--detach", str(dest), sha)
+    return dest
+
+
+@dataclass(frozen=True)
+class StepRecord:
+    step: int
+    event: TraceEvent
+    snapshot: str | None
+
+
+class StepJournal:
+    """Append-only JSONL journal of trajectory steps."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        # Resuming onto an existing journal must not restart step numbering —
+        # duplicate step ids would poison every later prefix computation.
+        self._steps = len(self.load(path)) if path.exists() else 0
+
+    def record(self, event: TraceEvent, snapshot: str | None = None) -> StepRecord:
+        record = StepRecord(self._steps, event, snapshot)
+        line = json.dumps(
+            {
+                "step": record.step,
+                "kind": event.kind,
+                "payload": event.payload,
+                "snapshot": snapshot,
+            },
+            ensure_ascii=False,
+        )
+        with self.path.open("a", encoding="utf-8") as journal:
+            journal.write(line + "\n")
+        self._steps += 1
+        return record
+
+    @staticmethod
+    def load(path: Path) -> list[StepRecord]:
+        records: list[StepRecord] = []
+        with path.open(encoding="utf-8") as journal:
+            for line in journal:
+                if not line.strip():
+                    continue  # tolerate a torn trailing write; keep the prefix
+                try:
+                    raw: dict[str, Any] = json.loads(line)
+                except json.JSONDecodeError:
+                    break  # crash mid-write leaves a bad tail; the prefix is still valid
+                step = len(records)
+                if raw.get("step") != step:
+                    raise SnapshotError(
+                        f"journal step mismatch: expected {step}, got {raw.get('step')!r}"
+                    )
+                records.append(
+                    StepRecord(
+                        step=step,
+                        event=TraceEvent(str(raw["kind"]), dict(raw.get("payload") or {})),
+                        snapshot=raw.get("snapshot"),
+                    )
+                )
+        return records
+
+    @staticmethod
+    def prefix(records: list[StepRecord], upto: int) -> list[StepRecord]:
+        """Events before step ``upto`` — the branch point for a future replay."""
+        return [r for r in records if r.step < upto]

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -13,6 +13,7 @@ import os
 import subprocess
 import tempfile
 from dataclasses import dataclass
+from fcntl import LOCK_EX, LOCK_UN, flock
 from pathlib import Path
 from typing import Any
 
@@ -89,36 +90,52 @@ class StepJournal:
 
     def __init__(self, path: Path) -> None:
         self.path = path
-        # Resuming onto an existing journal must not restart step numbering —
-        # duplicate step ids would poison every later prefix computation.
-        self._steps = len(self.load(path)) if path.exists() else 0
 
     def record(self, event: TraceEvent, snapshot: str | None = None) -> StepRecord:
-        record = StepRecord(self._steps, event, snapshot)
-        line = json.dumps(
-            {
-                "step": record.step,
-                "kind": event.kind,
-                "payload": event.payload,
-                "snapshot": snapshot,
-            },
-            ensure_ascii=False,
-        )
-        with self.path.open("a", encoding="utf-8") as journal:
-            journal.write(line + "\n")
-        self._steps += 1
-        return record
+        lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+        with lock_path.open("w") as lock:
+            flock(lock, LOCK_EX)
+            try:
+                step = len(self.load(self.path, repair_tail=True)) if self.path.exists() else 0
+                record = StepRecord(step, event, snapshot)
+                line = json.dumps(
+                    {
+                        "step": record.step,
+                        "kind": event.kind,
+                        "payload": event.payload,
+                        "snapshot": snapshot,
+                    },
+                    ensure_ascii=False,
+                )
+                with self.path.open("a", encoding="utf-8") as journal:
+                    journal.write(line + "\n")
+                    journal.flush()
+                    os.fsync(journal.fileno())
+                return record
+            finally:
+                flock(lock, LOCK_UN)
 
     @staticmethod
-    def load(path: Path) -> list[StepRecord]:
+    def load(path: Path, *, repair_tail: bool = False) -> list[StepRecord]:
         records: list[StepRecord] = []
-        with path.open(encoding="utf-8") as journal:
-            for line in journal:
+        with path.open("r+" if repair_tail else "r", encoding="utf-8") as journal:
+            while True:
+                line_start = journal.tell()
+                line = journal.readline()
+                if not line:
+                    break
                 if not line.strip():
                     continue  # tolerate a torn trailing write; keep the prefix
                 try:
                     raw: dict[str, Any] = json.loads(line)
                 except json.JSONDecodeError:
+                    if line.endswith("\n"):
+                        raise SnapshotError(
+                            f"invalid journal record at byte {line_start}"
+                        ) from None
+                    if repair_tail:
+                        journal.seek(line_start)
+                        journal.truncate()
                     break  # crash mid-write leaves a bad tail; the prefix is still valid
                 step = len(records)
                 if raw.get("step") != step:

--- a/src/spotter/trace.py
+++ b/src/spotter/trace.py
@@ -1,5 +1,6 @@
 """Small runtime-independent trace representation."""
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -8,3 +9,47 @@ from typing import Any
 class TraceEvent:
     kind: str
     payload: dict[str, Any] = field(default_factory=dict)
+
+
+# Judgment happens on semantic segments, enforcement on tool boundaries (plan Q8).
+# Event kinds not listed here are real but carry no segment signal; they fold into
+# the surrounding segment instead of breaking it.
+_SEGMENT_BY_KIND = {
+    "reasoning_summary": "hypothesis",
+    "plan": "hypothesis",
+    "agent_message": "hypothesis",
+    "file_read": "evidence",
+    "search": "evidence",
+    "command_result": "evidence",
+    "tool_result": "evidence",
+    "patch": "commit",
+    "file_edit": "commit",
+    "test_result": "validation",
+}
+
+
+@dataclass(frozen=True)
+class Segment:
+    """A run of consecutive events with one semantic role."""
+
+    kind: str
+    start: int  # first event index, inclusive
+    end: int  # last event index, inclusive
+
+
+def segment_events(events: Sequence[TraceEvent]) -> list[Segment]:
+    """Aggregate raw events into semantic segments.
+
+    Unknown kinds do not start or end a segment; a trajectory of only unknown
+    kinds yields no segments rather than a fake one.
+    """
+    segments: list[Segment] = []
+    for index, event in enumerate(events):
+        kind = _SEGMENT_BY_KIND.get(event.kind)
+        if kind is None:
+            continue
+        if segments and segments[-1].kind == kind:
+            segments[-1] = Segment(kind, segments[-1].start, index)
+        else:
+            segments.append(Segment(kind, index, index))
+    return segments

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,60 @@
+import pytest
+
+from spotter.audit import AuditState, Evidence, Hypothesis
+
+
+def _state() -> AuditState:
+    state = AuditState()
+    state.add_evidence(Evidence("e1", "tool_result", "timeout under high concurrency"))
+    state.add_hypothesis(Hypothesis("h1", "redis pool exhaustion causes the timeout"))
+    state.support("h1", "e1")
+    state.add_hypothesis(Hypothesis("h2", "raise pool size", depends_on={"h1"}))
+    return state
+
+
+def test_summary_text_cannot_become_evidence() -> None:
+    # Compile-time: mypy rejects Evidence(id, "summary", ...) — no such member.
+    # Runtime guard for untyped callers (e.g. JSON ingestion):
+    with pytest.raises(ValueError, match="not an evidence source"):
+        Evidence("e2", "summary", "the agent says it is redis")  # type: ignore[arg-type]
+
+
+def test_retraction_propagates_transitively() -> None:
+    state = _state()
+    stale = state.retract("e1")
+    assert stale == {"h1", "h2"}
+    assert state.hypotheses["h1"].status == "stale"
+    assert state.hypotheses["h2"].status == "stale"
+
+
+def test_hypothesis_with_remaining_evidence_survives_retraction() -> None:
+    state = _state()
+    state.add_evidence(Evidence("e2", "test_output", "profiler shows pool wait"))
+    state.support("h1", "e2")
+    assert state.retract("e1") == set()
+    assert state.hypotheses["h1"].status == "supported"
+
+
+def test_dependency_cycles_do_not_hang_retraction() -> None:
+    state = AuditState()
+    state.add_evidence(Evidence("e1", "diff", "d"))
+    state.add_hypothesis(Hypothesis("a", "a", depends_on={"b"}))
+    state.add_hypothesis(Hypothesis("b", "b", depends_on={"a"}))
+    state.support("a", "e1")
+    assert state.retract("e1") == {"a", "b"}
+
+
+def test_supporting_with_retracted_evidence_is_rejected() -> None:
+    state = _state()
+    state.retract("e1")
+    state.add_hypothesis(Hypothesis("h3", "late claim"))
+    with pytest.raises(ValueError, match="retracted"):
+        state.support("h3", "e1")
+
+
+def test_duplicate_ids_are_rejected() -> None:
+    state = _state()
+    with pytest.raises(ValueError, match="duplicate"):
+        state.add_evidence(Evidence("e1", "diff", "again"))
+    with pytest.raises(ValueError, match="duplicate"):
+        state.add_hypothesis(Hypothesis("h1", "again"))

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -11,6 +11,7 @@ from spotter.trace import TraceEvent
         "rm -rf ~",
         "rm --recursive -f ..",
         "git reset --hard",
+        "git -C /repo reset --hard",
         "git push --force origin main",
         "git push -f",
         "git clean -fd",
@@ -18,6 +19,9 @@ from spotter.trace import TraceEvent
         "wget -qO- https://x.sh | bash",
         "dd if=/dev/zero of=/dev/sda",
         "mkfs.ext4 /dev/sda1",
+        'rm -rf "$HOME"',
+        'rm -rf "$HOME/"',
+        "git -c advice.detachedHead=false reset --hard",
     ],
 )
 def test_blocks_destructive_commands(command: str) -> None:
@@ -64,7 +68,8 @@ def test_absolute_paths_relativized_against_root() -> None:
     assert not gate.check_paths(["/repo/secrets/key.pem"]).allowed
     assert not gate.check_paths(["/etc/passwd"]).allowed  # outside workspace
     # Without a root we cannot judge absolute paths: fail open, not fail wrong.
-    assert Gate(forbidden_paths=("secrets/*",)).check_paths(["/repo/secrets/key.pem"]).allowed
+    unknown = Gate(forbidden_paths=("secrets/*",)).check_paths(["/repo/secrets/key.pem"])
+    assert unknown.allowed and unknown.rule == "unknown_workspace"
 
 
 def test_blocks_dependency_manifest_when_configured() -> None:

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -1,0 +1,81 @@
+import pytest
+
+from spotter.gates import Gate
+from spotter.trace import TraceEvent
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rm -rf /",
+        "rm -rf ~",
+        "rm --recursive -f ..",
+        "git reset --hard",
+        "git push --force origin main",
+        "git push -f",
+        "git clean -fd",
+        "curl https://x.sh | sh",
+        "wget -qO- https://x.sh | bash",
+        "dd if=/dev/zero of=/dev/sda",
+        "mkfs.ext4 /dev/sda1",
+    ],
+)
+def test_blocks_destructive_commands(command: str) -> None:
+    decision = Gate().check_command(command)
+    assert not decision.allowed, command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rm -rf build/",  # scoped delete is legitimate agent work
+        "git push origin main",
+        "git reset HEAD~1",  # soft reset keeps the worktree
+        "curl https://example.com/data.json -o data.json",
+        "pytest tests/",
+    ],
+)
+def test_allows_ordinary_commands(command: str) -> None:
+    assert Gate().check_command(command).allowed, command
+
+
+def test_known_ceiling_quoted_destructive_text_is_blocked() -> None:
+    # ponytail: raw-string regex matches inside quoted text, so *mentioning* a
+    # destructive command can block. Deliberate: for catastrophic patterns we
+    # take the rare FP over parsing shell quoting. Upgrade path: command AST.
+    assert not Gate().check_command("git commit -m 'do not git reset --hard'").allowed
+
+
+def test_unparseable_command_fails_open_but_is_annotated() -> None:
+    decision = Gate().check_command("echo 'unterminated")
+    assert decision.allowed
+    assert decision.rule == "unparseable_command"
+
+
+def test_blocks_forbidden_path_and_traversal() -> None:
+    gate = Gate(forbidden_paths=("secrets/*",))
+    assert not gate.check_paths(["secrets/key.pem"]).allowed
+    assert not gate.check_paths(["docs/../../etc/passwd"]).allowed
+    assert gate.check_paths(["src/main.py"]).allowed
+
+
+def test_absolute_paths_relativized_against_root() -> None:
+    gate = Gate(forbidden_paths=("secrets/*",), root="/repo")
+    assert not gate.check_paths(["/repo/secrets/key.pem"]).allowed
+    assert not gate.check_paths(["/etc/passwd"]).allowed  # outside workspace
+    # Without a root we cannot judge absolute paths: fail open, not fail wrong.
+    assert Gate(forbidden_paths=("secrets/*",)).check_paths(["/repo/secrets/key.pem"]).allowed
+
+
+def test_blocks_dependency_manifest_when_configured() -> None:
+    gate = Gate(block_dependency_changes=True)
+    assert not gate.check_paths(["pyproject.toml"]).allowed
+    assert not gate.check_paths(["frontend/package.json"]).allowed
+    assert Gate().check_paths(["pyproject.toml"]).allowed  # off by default
+
+
+def test_gate_only_inspects_tool_proposals() -> None:
+    event = TraceEvent("agent_message", {"command": "rm -rf /"})
+    assert Gate().check(event).allowed  # a message about a command is not an action
+    proposal = TraceEvent("tool_proposal", {"command": "rm -rf /"})
+    assert not Gate().check(proposal).allowed

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -84,8 +84,7 @@ def test_apply_patch_paths_are_gated() -> None:
 
     payload["tool_input"] = {
         "command": (
-            "*** Begin Patch\n*** Update File: src/key\n"
-            "*** Move to: secrets/key\n*** End Patch"
+            "*** Begin Patch\n*** Update File: src/key\n*** Move to: secrets/key\n*** End Patch"
         )
     }
     forbidden = SpotterConfig(

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -1,0 +1,76 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from spotter.config import GatesConfig, MainAgentConfig, ReviewerConfig, SpotterConfig
+from spotter.hook import event_from_hook, journal_path, run_hook
+from spotter.snapshot import StepJournal
+
+
+@pytest.fixture(autouse=True)
+def spotter_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _payload(command: str) -> dict[str, object]:
+    return {
+        "hook_event_name": "PreToolUse",
+        "session_id": "s1",
+        "cwd": "/repo",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    }
+
+
+def _config(observation_only: bool) -> SpotterConfig:
+    return SpotterConfig(
+        MainAgentConfig("codex"),
+        ReviewerConfig(),
+        GatesConfig(),
+        observation_only=observation_only,
+    )
+
+
+def test_active_mode_emits_deny_json() -> None:
+    output = run_hook(_payload("rm -rf /"), _config(observation_only=False))
+    assert output is not None
+    decision = json.loads(output)["hookSpecificOutput"]
+    assert decision["permissionDecision"] == "deny"
+    assert "rm_root" in decision["permissionDecisionReason"]
+
+
+def test_shadow_mode_allows_but_journals_the_block(spotter_home: Path) -> None:
+    payload = _payload("git push --force")
+    assert run_hook(payload, _config(observation_only=True)) is None
+    records = StepJournal.load(journal_path(payload))
+    assert [r.event.kind for r in records] == ["tool_proposal", "gate_shadow_block"]
+    assert records[1].event.payload["rule"] == "git_push_force"
+
+
+def test_safe_command_allows_silently() -> None:
+    assert run_hook(_payload("pytest tests/"), _config(observation_only=False)) is None
+
+
+def test_session_id_is_sanitized_for_filenames() -> None:
+    path = journal_path({"session_id": "../../etc/passwd"})
+    assert path.name == "______etc_passwd.jsonl"  # no separators, no dots
+
+
+def test_file_paths_extracted_from_tool_input() -> None:
+    event = event_from_hook(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "apply_patch",
+            "tool_input": {"path": "src/a.py", "files": ["src/b.py"]},
+        }
+    )
+    assert event.payload["files"] == ["src/a.py", "src/b.py"]
+
+
+def test_unknown_events_still_journal(spotter_home: Path) -> None:
+    payload = {"hook_event_name": "SessionStart", "session_id": "s2"}
+    assert run_hook(payload, _config(observation_only=True)) is None
+    records = StepJournal.load(journal_path(payload))
+    assert records[0].event.kind == "sessionstart"

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -69,6 +69,48 @@ def test_file_paths_extracted_from_tool_input() -> None:
     assert event.payload["files"] == ["src/a.py", "src/b.py"]
 
 
+def test_apply_patch_paths_are_gated() -> None:
+    payload = {
+        **_payload("*** Begin Patch\n*** Update File: pyproject.toml\n*** End Patch"),
+        "tool_name": "apply_patch",
+    }
+    config = SpotterConfig(
+        MainAgentConfig("codex"),
+        ReviewerConfig(),
+        GatesConfig(block_dependency_changes=True),
+        observation_only=False,
+    )
+    assert "dependency_change" in (run_hook(payload, config) or "")
+
+    payload["tool_input"] = {
+        "command": (
+            "*** Begin Patch\n*** Update File: src/key\n"
+            "*** Move to: secrets/key\n*** End Patch"
+        )
+    }
+    forbidden = SpotterConfig(
+        MainAgentConfig("codex"),
+        ReviewerConfig(),
+        GatesConfig(forbidden_paths=("secrets/*",)),
+        observation_only=False,
+    )
+    assert "forbidden_path" in (run_hook(payload, forbidden) or "")
+
+
+def test_post_tool_use_preserves_evidence() -> None:
+    event = event_from_hook(
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_use_id": "call-1",
+            "tool_input": {"command": "pytest"},
+            "tool_response": {"exit_code": 1, "output": "failed"},
+        }
+    )
+    assert event.payload["tool_use_id"] == "call-1"
+    assert event.payload["tool_response"] == {"exit_code": 1, "output": "failed"}
+
+
 def test_unknown_events_still_journal(spotter_home: Path) -> None:
     payload = {"hook_event_name": "SessionStart", "session_id": "s2"}
     assert run_hook(payload, _config(observation_only=True)) is None

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -42,3 +42,10 @@ def test_active_mode_enforces_gate_block() -> None:
 
     assert not decision.allowed
     assert [e.kind for e in adapter.events] == ["tool_proposal", "gate_block"]
+
+
+def test_fail_open_blind_spot_is_recorded() -> None:
+    runtime, adapter = _runtime(observation_only=True)
+    runtime.observe(TraceEvent("tool_proposal", {"command": "echo 'unterminated"}))
+    assert [e.kind for e in adapter.events] == ["tool_proposal", "gate_fail_open"]
+    assert adapter.events[-1].payload["rule"] == "unparseable_command"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,15 +1,44 @@
 from spotter.codex import CodexAdapter
 from spotter.config import MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.core import SpotterRuntime
+from spotter.gates import Gate
 from spotter.trace import TraceEvent
 
 
-def test_runtime_forwards_normalized_events() -> None:
+def _runtime(observation_only: bool) -> tuple[SpotterRuntime, CodexAdapter]:
     adapter = CodexAdapter()
-    config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig("reviewer"))
-    runtime = SpotterRuntime(config, adapter)
+    config = SpotterConfig(
+        MainAgentConfig("codex"), ReviewerConfig("reviewer"), observation_only=observation_only
+    )
+    return SpotterRuntime(config, adapter, gate=Gate()), adapter
+
+
+def test_runtime_forwards_normalized_events() -> None:
+    runtime, adapter = _runtime(observation_only=True)
     event = TraceEvent("tool_result", {"exit_code": 0})
 
-    runtime.observe(event)
+    decision = runtime.observe(event)
 
+    assert decision.allowed
     assert adapter.events == [event]
+
+
+def test_observation_mode_shadows_blocks_instead_of_enforcing() -> None:
+    runtime, adapter = _runtime(observation_only=True)
+    proposal = TraceEvent("tool_proposal", {"command": "git push --force"})
+
+    decision = runtime.observe(proposal)
+
+    assert decision.allowed  # never enforced in shadow mode
+    assert [e.kind for e in adapter.events] == ["tool_proposal", "gate_shadow_block"]
+    assert adapter.events[1].payload["rule"] == "git_push_force"
+
+
+def test_active_mode_enforces_gate_block() -> None:
+    runtime, adapter = _runtime(observation_only=False)
+    proposal = TraceEvent("tool_proposal", {"command": "rm -rf /"})
+
+    decision = runtime.observe(proposal)
+
+    assert not decision.allowed
+    assert [e.kind for e in adapter.events] == ["tool_proposal", "gate_block"]

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,4 +1,5 @@
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -90,8 +91,27 @@ def test_journal_tolerates_torn_tail_but_rejects_reordering(tmp_path: Path) -> N
     with path.open("a") as f:
         f.write('{"step": 1, "kind": "torn"')  # crash mid-write
     assert len(StepJournal.load(path)) == 1  # valid prefix survives
+    resumed = StepJournal(path)
+    resumed.record(TraceEvent("after_resume"))
+    assert [r.event.kind for r in StepJournal.load(path)] == ["session_start", "after_resume"]
 
     bad = tmp_path / "bad.jsonl"
     bad.write_text('{"step": 5, "kind": "x", "payload": {}, "snapshot": null}\n')
     with pytest.raises(SnapshotError, match="mismatch"):
         StepJournal.load(bad)
+
+    corrupt = tmp_path / "corrupt.jsonl"
+    corrupt.write_text('{"step": 0, bad}\n')
+    with pytest.raises(SnapshotError, match="invalid journal record"):
+        StepJournal(corrupt).record(TraceEvent("later"))
+
+
+def test_concurrent_journal_writes_keep_unique_steps(tmp_path: Path) -> None:
+    path = tmp_path / "journal.jsonl"
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(
+            pool.map(
+                lambda i: StepJournal(path).record(TraceEvent("event", {"i": i})), range(20)
+            )
+        )
+    assert [r.step for r in StepJournal.load(path)] == list(range(20))

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -109,9 +109,5 @@ def test_journal_tolerates_torn_tail_but_rejects_reordering(tmp_path: Path) -> N
 def test_concurrent_journal_writes_keep_unique_steps(tmp_path: Path) -> None:
     path = tmp_path / "journal.jsonl"
     with ThreadPoolExecutor(max_workers=8) as pool:
-        list(
-            pool.map(
-                lambda i: StepJournal(path).record(TraceEvent("event", {"i": i})), range(20)
-            )
-        )
+        list(pool.map(lambda i: StepJournal(path).record(TraceEvent("event", {"i": i})), range(20)))
     assert [r.step for r in StepJournal.load(path)] == list(range(20))

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,97 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from spotter.snapshot import (
+    SnapshotError,
+    StepJournal,
+    restore_snapshot,
+    snapshot_worktree,
+)
+from spotter.trace import TraceEvent
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    return repo
+
+
+def test_snapshot_captures_untracked_and_restore_does_not_touch_worktree(
+    repo: Path, tmp_path: Path
+) -> None:
+    (repo / "tracked.txt").write_text("v1")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=repo, check=True)
+    (repo / "untracked.txt").write_text("never committed")
+    (repo / "tracked.txt").write_text("v2 dirty")
+
+    sha = snapshot_worktree(repo)
+
+    # snapshotting must not mutate the user's state
+    status = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout
+    assert "untracked.txt" in status and "tracked.txt" in status
+
+    dest = tmp_path / "restore"
+    restore_snapshot(repo, sha, dest)
+    assert (dest / "untracked.txt").read_text() == "never committed"
+    assert (dest / "tracked.txt").read_text() == "v2 dirty"
+
+
+def test_snapshot_works_on_empty_repo_without_head(repo: Path) -> None:
+    (repo / "only.txt").write_text("x")
+    assert snapshot_worktree(repo)
+
+
+def test_snapshot_outside_git_repo_fails_loudly(tmp_path: Path) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    with pytest.raises(SnapshotError):
+        snapshot_worktree(plain)
+
+
+def test_restore_refuses_existing_destination(repo: Path, tmp_path: Path) -> None:
+    (repo / "a.txt").write_text("a")
+    sha = snapshot_worktree(repo)
+    dest = tmp_path / "exists"
+    dest.mkdir()
+    with pytest.raises(SnapshotError, match="already exists"):
+        restore_snapshot(repo, sha, dest)
+
+
+def test_journal_roundtrip_prefix_and_resume(tmp_path: Path) -> None:
+    path = tmp_path / "journal.jsonl"
+    journal = StepJournal(path)
+    journal.record(TraceEvent("session_start"))
+    journal.record(TraceEvent("tool_proposal", {"command": "pytest"}), snapshot="abc123")
+
+    records = StepJournal.load(path)
+    assert [r.step for r in records] == [0, 1]
+    assert records[1].snapshot == "abc123"
+    assert StepJournal.prefix(records, 1)[-1].event.kind == "session_start"
+
+    # resuming appends with continued numbering instead of restarting at 0
+    resumed = StepJournal(path)
+    resumed.record(TraceEvent("tool_result"))
+    assert [r.step for r in StepJournal.load(path)] == [0, 1, 2]
+
+
+def test_journal_tolerates_torn_tail_but_rejects_reordering(tmp_path: Path) -> None:
+    path = tmp_path / "journal.jsonl"
+    journal = StepJournal(path)
+    journal.record(TraceEvent("session_start"))
+    with path.open("a") as f:
+        f.write('{"step": 1, "kind": "torn"')  # crash mid-write
+    assert len(StepJournal.load(path)) == 1  # valid prefix survives
+
+    bad = tmp_path / "bad.jsonl"
+    bad.write_text('{"step": 5, "kind": "x", "payload": {}, "snapshot": null}\n')
+    with pytest.raises(SnapshotError, match="mismatch"):
+        StepJournal.load(bad)

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,30 @@
+from spotter.trace import Segment, TraceEvent, segment_events
+
+
+def test_segments_aggregate_consecutive_roles() -> None:
+    events = [
+        TraceEvent("reasoning_summary"),
+        TraceEvent("file_read"),
+        TraceEvent("search"),
+        TraceEvent("patch"),
+        TraceEvent("test_result"),
+    ]
+    assert segment_events(events) == [
+        Segment("hypothesis", 0, 0),
+        Segment("evidence", 1, 2),
+        Segment("commit", 3, 3),
+        Segment("validation", 4, 4),
+    ]
+
+
+def test_unknown_kinds_fold_into_surrounding_segment() -> None:
+    events = [
+        TraceEvent("file_read"),
+        TraceEvent("some_new_codex_event"),  # runtimes will grow kinds we don't know
+        TraceEvent("tool_result"),
+    ]
+    assert segment_events(events) == [Segment("evidence", 0, 2)]
+
+
+def test_only_unknown_kinds_yield_no_segments() -> None:
+    assert segment_events([TraceEvent("mystery")]) == []


### PR DESCRIPTION
## What

Implements the buildable half of the implementation plan (P0–P3), wired end-to-end into Codex via hooks.

### Deterministic gates — plan P3 (`gates.py`)
- Rule-only pre-action gates: catastrophic commands (rm on /, ~, ..; git reset --hard / push --force / clean -f; curl|sh; dd to devices; mkfs), forbidden path globs, workspace-escape paths, dependency-manifest edits.
- An LLM verdict can never produce a BLOCK. Ambiguous input (unparseable command, absolute path with unknown root) fails open with an annotated decision so blind spots stay measurable.
- Known ceiling documented in tests: raw-string regex matches destructive text inside quotes (rare FP, taken deliberately; upgrade path is a command AST).

### Step journal + snapshots — plan P0, recording half (`snapshot.py`)
- Append-only JSONL journal, crash-tolerant load (torn tail dropped, reordering rejected), resume keeps step numbering.
- Worktree snapshots via temp index + commit-tree: captures untracked files, never touches the user's index/HEAD, pinned under refs/spotter/ so gc can't delete them; restore only into a detached worktree.
- Deliberately absent: replaying Codex from a prefix — that needs event ingestion first, and a stub would hide the plan's biggest open risk.

### Audit state — plan P2 (`audit.py`)
- `EvidenceSource` has no "summary" member: mypy rejects summary-as-evidence at compile time; a runtime guard covers untyped (JSON) callers.
- Evidence retraction propagates stale status transitively across hypothesis dependencies, cycle-safe.

### Semantic segments — plan P1 (`trace.py`)
- Events aggregate into hypothesis / evidence / commit / validation segments: judgment units decoupled from the tool-call boundary (enforcement stays at PreToolUse).

### Shadow mode + Codex bridge (`core.py`, `hook.py`, `spotter hook`)
- `observation_only = true` records `gate_shadow_block` instead of enforcing — gate FP rate gets measured on real sessions before blocking anyone.
- `spotter hook` reads Codex PreToolUse/PostToolUse JSON on stdin, journals every event to `~/.spotter/sessions/<session_id>.jsonl`, and emits a `permissionDecision: deny` only in active mode. Every failure path fails open: a supervisor bug must never break the supervised session.

## Testing

- 49 tests: gates (destructive/benign/fail-open/traversal/manifest), journal crash-tolerance and resume, snapshot on dirty+untracked and empty repos, audit retraction/cycles, hook bridge shadow/active/sanitization.
- ruff + mypy --strict clean; end-to-end stdin smoke test against the installed CLI.
- Gate latency well under the 50ms/call budget.