### PR TITLE
feat: session fork for counterfactual replay, plus spotter analyze

### DIFF
--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -11,7 +11,9 @@ from spotter.codex import CodexAdapter
 from spotter.config import ConfigurationError, MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.core import SpotterRuntime
 from spotter.gates import Gate
-from spotter.hook import run_hook
+from spotter.hook import journal_path, run_hook
+from spotter.replay import ReplayError, fork, plan_to_json
+from spotter.snapshot import SnapshotError, StepJournal
 from spotter.trace import TraceEvent
 
 
@@ -20,11 +22,18 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=["observe", "hook"],
+        choices=["observe", "hook", "analyze", "fork"],
         default="observe",
-        help="observe: validate config and start; hook: Codex hook bridge (JSON on stdin)",
+        help=(
+            "observe: validate config and start; hook: Codex hook bridge (JSON on stdin); "
+            "analyze: summarize journaled sessions; fork: branch a session at a step"
+        ),
     )
     parser.add_argument("--config", type=Path, help="path to Spotter TOML config")
+    parser.add_argument("--session", help="session id (fork; analyze filters to it)")
+    parser.add_argument("--step", type=int, help="journal step to branch at (fork)")
+    parser.add_argument("--repo", type=Path, help="repo override when the journal lacks cwd (fork)")
+    parser.add_argument("--guidance", help="course-correction text for the forked run (fork)")
     return parser
 
 
@@ -44,6 +53,18 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "hook":
         return _hook_main(config)
+    if args.command == "analyze":
+        return _analyze_main(args.session)
+    if args.command == "fork":
+        if not args.session or args.step is None:
+            parser.error("fork requires --session and --step")
+        try:
+            plan = fork(args.session, args.step, repo=args.repo, guidance=args.guidance)
+        except (ReplayError, SnapshotError) as error:
+            print(f"fork failed: {error}", file=sys.stderr)
+            return 1
+        print(plan_to_json(plan))
+        return 0
 
     if config is None:
         parser.error("observe requires --config")
@@ -60,6 +81,45 @@ def main(argv: Sequence[str] | None = None) -> int:
         f"Spotter ready: adapter={config.main_agent.adapter}, "
         f"reviewer={config.reviewer.model}, mode={mode}"
     )
+    return 0
+
+
+def _analyze_main(session: str | None) -> int:
+    """Summarize journaled sessions: the aggregation step of the FP-review loop.
+
+    This prints samples for a human to label; it deliberately does not label
+    anything itself — FP/TP judgment is exactly what must not be automated
+    away before the reviewer stage earns that trust.
+    """
+    sessions_dir = journal_path({"session_id": "probe"}).parent
+    journals = sorted(sessions_dir.glob("*.jsonl"))
+    if session:
+        wanted = journal_path({"session_id": session})
+        journals = [j for j in journals if j == wanted]
+    if not journals:
+        print(f"no journals found under {sessions_dir}", file=sys.stderr)
+        return 1
+    for journal in journals:
+        try:
+            records = StepJournal.load(journal)
+        except SnapshotError as error:
+            print(f"{journal.stem}: unreadable journal ({error})", file=sys.stderr)
+            continue
+        proposals = [r for r in records if r.event.kind == "tool_proposal"]
+        snapshots = sum(1 for r in records if r.snapshot)
+        flagged = [r for r in records if r.event.kind in ("gate_shadow_block", "gate_fail_open")]
+        print(
+            f"{journal.stem}: steps={len(records)} proposals={len(proposals)} "
+            f"snapshots={snapshots} flagged={len(flagged)}"
+        )
+        for record in flagged:
+            trigger = records[record.step - 1].event.payload if record.step > 0 else {}
+            summary = str(trigger.get("command") or trigger.get("patch") or trigger)
+            summary = " ".join(summary.split())[:120]
+            print(
+                f"  step {record.step:4d} {record.event.kind:17s} "
+                f"{record.event.payload.get('rule')}: {summary}"
+            )
     return 0
 
 

--- a/src/spotter/config.py
+++ b/src/spotter/config.py
@@ -35,6 +35,7 @@ class SpotterConfig:
     reviewer: ReviewerConfig
     gates: GatesConfig = GatesConfig()
     observation_only: bool = True
+    snapshot_on_patch: bool = True
 
     @classmethod
     def from_toml(cls, path: Path) -> "SpotterConfig":
@@ -60,6 +61,7 @@ class SpotterConfig:
                 block_dependency_changes=_bool(gates, "block_dependency_changes", False),
             ),
             observation_only=observation_only,
+            snapshot_on_patch=_bool(raw, "snapshot_on_patch", True),
         )
 
 

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -14,7 +14,7 @@ from typing import Any
 from spotter.config import SpotterConfig
 from spotter.core import SpotterRuntime
 from spotter.gates import Gate
-from spotter.snapshot import StepJournal
+from spotter.snapshot import SnapshotError, StepJournal, snapshot_worktree
 from spotter.trace import TraceEvent
 
 _PATCH_PATH = re.compile(r"^\*\*\* (?:(?:Add|Update|Delete) File|Move to): (.+)$", re.MULTILINE)
@@ -23,9 +23,11 @@ _PATCH_PATH = re.compile(r"^\*\*\* (?:(?:Add|Update|Delete) File|Move to): (.+)$
 class JournalAdapter:
     def __init__(self, journal: StepJournal) -> None:
         self.journal = journal
+        self.next_snapshot: str | None = None
 
     def record(self, event: TraceEvent) -> None:
-        self.journal.record(event)
+        self.journal.record(event, snapshot=self.next_snapshot)
+        self.next_snapshot = None  # attaches to the first (proposal) event only
 
 
 def event_from_hook(payload: dict[str, Any]) -> TraceEvent:
@@ -56,6 +58,10 @@ def event_from_hook(payload: dict[str, Any]) -> TraceEvent:
                 "command": command,
                 "patch": patch,
                 "files": files,
+                # Correlation keys for P0 fork: tool_use_id matches the rollout's
+                # call_id; cwd locates the repo to snapshot/restore.
+                "tool_use_id": payload.get("tool_use_id"),
+                "cwd": payload.get("cwd"),
             },
         )
     if name == "PostToolUse":
@@ -87,8 +93,22 @@ def run_hook(payload: dict[str, Any], config: SpotterConfig) -> str | None:
         block_dependency_changes=config.gates.block_dependency_changes,
         root=str(cwd) if isinstance(cwd, str) else None,
     )
-    runtime = SpotterRuntime(config, JournalAdapter(StepJournal(journal_path(payload))), gate)
-    decision = runtime.observe(event_from_hook(payload))
+    adapter = JournalAdapter(StepJournal(journal_path(payload)))
+    runtime = SpotterRuntime(config, adapter, gate)
+    event = event_from_hook(payload)
+    if (
+        config.snapshot_on_patch
+        and event.kind == "tool_proposal"
+        and event.payload.get("tool") == "apply_patch"
+        and isinstance(cwd, str)
+    ):
+        # Snapshot at the commit boundary so P0 fork has a repo state to
+        # restore. Fail open: losing a snapshot must not break the session.
+        try:
+            adapter.next_snapshot = snapshot_worktree(Path(cwd))
+        except SnapshotError:
+            adapter.next_snapshot = None
+    decision = runtime.observe(event)
     if decision.allowed:
         return None  # implicit allow; stay silent on the happy path
     return json.dumps(

--- a/src/spotter/replay.py
+++ b/src/spotter/replay.py
@@ -1,0 +1,147 @@
+"""Fork a supervised Codex session at a journal step — the replay half of P0.
+
+Mechanism (approximate replay, the plan's fallback path):
+1. Codex persists every session as a rollout JSONL under ~/.codex/sessions.
+2. The Spotter journal records tool_use_id per proposal, which matches the
+   rollout's call_id — that is the branch-point correlation key.
+3. Fork = copy the rollout truncated strictly before the branch call, rewrite
+   its session id to a fresh one, restore the nearest repo snapshot into a
+   detached worktree, and hand back a ready `codex exec resume` invocation.
+4. Run the same fork twice — once with injected guidance, once without — and
+   the pair is a same-prefix counterfactual (plan Q3).
+
+Honest limits, stated rather than papered over:
+- Whether `codex exec resume` accepts a truncated rollout is UNVERIFIED until
+  the first real run; that experiment IS the P0 exit criterion.
+- Sessions journaled before snapshots/tool_use_id existed cannot be forked;
+  the errors below say exactly which ingredient is missing.
+- This does not execute anything itself: launching costs money and runs an
+  agent, so the human stays on the trigger.
+"""
+
+import json
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from spotter.hook import journal_path
+from spotter.snapshot import StepJournal, StepRecord, restore_snapshot
+
+
+class ReplayError(RuntimeError):
+    """Raised when a fork cannot be assembled from the recorded ingredients."""
+
+
+@dataclass(frozen=True)
+class ForkPlan:
+    session_id: str  # fresh id of the forked session
+    branch_step: int
+    worktree: str
+    rollout: str
+    command: str  # suggested invocation; the human runs it
+
+
+def find_rollout(session_id: str, codex_home: Path | None = None) -> Path:
+    home = codex_home or Path.home() / ".codex"
+    matches = sorted((home / "sessions").rglob(f"rollout-*{session_id}.jsonl"))
+    if not matches:
+        raise ReplayError(f"no rollout found for session {session_id} under {home}/sessions")
+    return matches[-1]
+
+
+def fork_rollout(rollout: Path, call_id: str, new_id: str) -> Path:
+    """Write a truncated, re-identified copy of a rollout next to the original.
+
+    The copy ends strictly before the branch call so the resumed agent decides
+    that step fresh. The original file is never touched.
+    """
+    lines = rollout.read_text(encoding="utf-8").splitlines()
+    if not lines:
+        raise ReplayError(f"rollout is empty: {rollout}")
+    meta = json.loads(lines[0])
+    old_id = str(meta.get("payload", {}).get("session_id") or "")
+    if not old_id:
+        raise ReplayError("rollout has no session_meta session_id on line 1")
+    cut = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if f'"call_id":"{call_id}"' in line or f'"call_id": "{call_id}"' in line
+        ),
+        None,
+    )
+    if cut is None:
+        raise ReplayError(f"call_id {call_id} not found in rollout {rollout.name}")
+    if cut == 0:
+        raise ReplayError("branch point is the first record; nothing to resume from")
+    forked = [line.replace(old_id, new_id) for line in lines[:cut]]
+    dest = rollout.with_name(rollout.name.replace(old_id, new_id))
+    if dest.exists():
+        raise ReplayError(f"forked rollout already exists: {dest}")
+    dest.write_text("\n".join(forked) + "\n", encoding="utf-8")
+    return dest
+
+
+def fork(
+    session_id: str,
+    step: int,
+    *,
+    repo: Path | None = None,
+    codex_home: Path | None = None,
+    dest: Path | None = None,
+    guidance: str | None = None,
+) -> ForkPlan:
+    journal_file = journal_path({"session_id": session_id})
+    records = StepJournal.load(journal_file)
+    if not 0 <= step < len(records):
+        raise ReplayError(f"step {step} out of range (journal has {len(records)} steps)")
+    target = records[step]
+    if target.event.kind != "tool_proposal":
+        raise ReplayError(f"step {step} is {target.event.kind}; fork at a tool_proposal")
+    call_id = target.event.payload.get("tool_use_id")
+    if not isinstance(call_id, str) or not call_id:
+        raise ReplayError(f"step {step} has no tool_use_id (journaled before it was recorded)")
+
+    snapshot = _nearest_snapshot(records, step)
+    if snapshot is None:
+        raise ReplayError(
+            f"no snapshot at or before step {step} "
+            "(snapshots are taken at apply_patch boundaries; none happened yet)"
+        )
+    repo_path = repo or _recorded_repo(records, step)
+    if repo_path is None:
+        raise ReplayError("journal has no cwd for this step; pass repo explicitly")
+
+    new_id = str(uuid.uuid4())
+    worktree = dest or journal_file.parent.parent / "forks" / new_id
+    restore_snapshot(repo_path, snapshot, worktree)
+    forked_rollout = fork_rollout(find_rollout(session_id, codex_home), call_id, new_id)
+
+    prompt = f" {json.dumps(guidance)}" if guidance else ""
+    command = f"codex exec resume {new_id} -C {worktree} --json{prompt}"
+    return ForkPlan(
+        session_id=new_id,
+        branch_step=step,
+        worktree=str(worktree),
+        rollout=str(forked_rollout),
+        command=command,
+    )
+
+
+def plan_to_json(plan: ForkPlan) -> str:
+    return json.dumps(asdict(plan), indent=2)
+
+
+def _nearest_snapshot(records: list[StepRecord], step: int) -> str | None:
+    for record in reversed(records[: step + 1]):
+        if record.snapshot:
+            return record.snapshot
+    return None
+
+
+def _recorded_repo(records: list[StepRecord], step: int) -> Path | None:
+    for record in reversed(records[: step + 1]):
+        cwd = record.event.payload.get("cwd")
+        if isinstance(cwd, str) and cwd:
+            return Path(cwd)
+    return None

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -25,13 +25,16 @@ class SnapshotError(RuntimeError):
 
 
 def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> str:
-    result = subprocess.run(
-        ["git", *args],
-        cwd=repo,
-        env={**os.environ, **(env or {})},
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            env={**os.environ, **(env or {})},
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:  # missing cwd, missing git binary — same contract
+        raise SnapshotError(f"git {' '.join(args)} failed to start: {error}") from error
     if result.returncode != 0:
         raise SnapshotError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
     return result.stdout.strip()

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -115,3 +115,41 @@ def test_unknown_events_still_journal(spotter_home: Path) -> None:
     assert run_hook(payload, _config(observation_only=True)) is None
     records = StepJournal.load(journal_path(payload))
     assert records[0].event.kind == "sessionstart"
+
+
+def test_apply_patch_takes_snapshot_for_fork(tmp_path: Path, spotter_home: Path) -> None:
+    import subprocess
+
+    repo = tmp_path / "hookrepo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    (repo / "x.txt").write_text("x")
+
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "session_id": "snap1",
+        "cwd": str(repo),
+        "tool_name": "apply_patch",
+        "tool_use_id": "call_1",
+        "tool_input": {"command": "*** Begin Patch\n*** Update File: x.txt\n*** End Patch"},
+    }
+    assert run_hook(payload, _config(observation_only=True)) is None
+    record = StepJournal.load(journal_path(payload))[0]
+    assert record.snapshot  # repo state pinned at the commit boundary
+    assert record.event.payload["tool_use_id"] == "call_1"
+    assert record.event.payload["cwd"] == str(repo)
+
+
+def test_snapshot_failure_fails_open(tmp_path: Path, spotter_home: Path) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "session_id": "snap2",
+        "cwd": str(tmp_path / "not-a-git-repo"),
+        "tool_name": "apply_patch",
+        "tool_use_id": "call_1",
+        "tool_input": {"command": "*** Begin Patch\n*** End Patch"},
+    }
+    assert run_hook(payload, _config(observation_only=True)) is None  # session unharmed
+    assert StepJournal.load(journal_path(payload))[0].snapshot is None

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,110 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from spotter.hook import journal_path
+from spotter.replay import ReplayError, fork, fork_rollout
+from spotter.snapshot import StepJournal, snapshot_worktree
+from spotter.trace import TraceEvent
+
+OLD_ID = "aaaa1111-bbbb-2222-cccc-333344445555"
+
+
+@pytest.fixture(autouse=True)
+def spotter_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path / "spotter"))
+    return tmp_path / "spotter"
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    (repo / "a.txt").write_text("v1")
+    return repo
+
+
+@pytest.fixture()
+def codex_home(tmp_path: Path) -> Path:
+    home = tmp_path / "codex"
+    day = home / "sessions" / "2026" / "08" / "11"
+    day.mkdir(parents=True)
+    lines = [
+        {"ordinal": 0, "type": "session_meta", "payload": {"session_id": OLD_ID, "id": OLD_ID}},
+        {"ordinal": 1, "type": "response_item", "payload": {"call_id": "call_A", "name": "exec"}},
+        {"ordinal": 2, "type": "response_item", "payload": {"call_id": "call_A", "output": "ok"}},
+        {"ordinal": 3, "type": "response_item", "payload": {"call_id": "call_B", "name": "exec"}},
+    ]
+    rollout = day / f"rollout-2026-08-11T10-00-00-{OLD_ID}.jsonl"
+    rollout.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+    return home
+
+
+def _journal(session: str, records: list[tuple[TraceEvent, str | None]]) -> None:
+    journal = StepJournal(journal_path({"session_id": session}))
+    for event, snapshot in records:
+        journal.record(event, snapshot=snapshot)
+
+
+def test_fork_rollout_truncates_and_renames(codex_home: Path) -> None:
+    rollout = next((codex_home / "sessions").rglob("*.jsonl"))
+    forked = fork_rollout(rollout, "call_B", "new-id-1234")
+    lines = forked.read_text().splitlines()
+    assert len(lines) == 3  # cut strictly before call_B
+    assert OLD_ID not in forked.name and "new-id-1234" in forked.name
+    assert all(OLD_ID not in line for line in lines)
+    assert rollout.read_text().count("call_B") == 1  # original untouched
+
+
+def test_fork_rollout_unknown_call_id_fails_loudly(codex_home: Path) -> None:
+    rollout = next((codex_home / "sessions").rglob("*.jsonl"))
+    with pytest.raises(ReplayError, match="call_id call_X not found"):
+        fork_rollout(rollout, "call_X", "new-id")
+
+
+def test_fork_end_to_end(repo: Path, codex_home: Path) -> None:
+    sha = snapshot_worktree(repo)
+    _journal(
+        OLD_ID,
+        [
+            (TraceEvent("sessionstart"), None),
+            (
+                TraceEvent(
+                    "tool_proposal",
+                    {"tool": "apply_patch", "tool_use_id": "call_B", "cwd": str(repo)},
+                ),
+                sha,
+            ),
+        ],
+    )
+    plan = fork(OLD_ID, 1, codex_home=codex_home, guidance="check the stack trace first")
+    assert Path(plan.worktree, "a.txt").read_text() == "v1"
+    assert plan.session_id in plan.command and str(plan.worktree) in plan.command
+    assert "check the stack trace first" in plan.command
+    assert Path(plan.rollout).exists()
+
+
+def test_fork_without_snapshot_names_the_missing_ingredient(codex_home: Path) -> None:
+    _journal(
+        OLD_ID,
+        [(TraceEvent("tool_proposal", {"tool_use_id": "call_B", "cwd": "/x"}), None)],
+    )
+    with pytest.raises(ReplayError, match="no snapshot at or before"):
+        fork(OLD_ID, 0, codex_home=codex_home)
+
+
+def test_fork_without_tool_use_id_names_the_missing_ingredient(codex_home: Path) -> None:
+    _journal(OLD_ID, [(TraceEvent("tool_proposal", {"cwd": "/x"}), "deadbeef")])
+    with pytest.raises(ReplayError, match="no tool_use_id"):
+        fork(OLD_ID, 0, codex_home=codex_home)
+
+
+def test_fork_rejects_non_proposal_steps(codex_home: Path) -> None:
+    _journal(OLD_ID, [(TraceEvent("tool_result"), None)])
+    with pytest.raises(ReplayError, match="fork at a tool_proposal"):
+        fork(OLD_ID, 0, codex_home=codex_home)


### PR DESCRIPTION
## Plan progress — where this lands in the overall roadmap

| Phase | Plan | Status after this PR |
|---|---|---|
| **P0** fork/replay harness | record every step + branch from any prefix | 🟢 **~90%** — journal, snapshots at mutation boundaries, rollout fork, `spotter fork` CLI. Remaining: first real `codex exec resume` run against a truncated rollout (= the exit-criterion experiment; unverified by design, stated in `replay.py`) |
| **P1** passive observer + observability ceiling | event collection, semantic segments, ceiling measurement | 🟡 partial — hook-based collection + segments + `spotter analyze` aggregation. Remaining: labeling 50–100 failed trajectories for the ceiling number; richer events need App Server |
| **P2** audit state (claim/evidence ledger) | typed Hypothesis/Evidence, stale propagation | 🟡 built (`audit.py`, merged in #5) but **not wired to runtime** — becomes useful when the reviewer exists |
| **P3** deterministic gates | rules-only BLOCK, shadow → active | 🟢 deployed in shadow; first field data found 6/6 FPs, fixed by token-stream judgment (#10). Awaiting a clean shadow window before flipping active |
| **P4** reviewer LLM (NUDGE + counterfactual eval) | semantic judgment, gated behind P0 | 🔴 not started — deliberately blocked on P0's exit criterion |
| **P5** ablations (model diversity, FP budgets) | | 🔴 not started |

Related issues: addresses the core of **#9** (branch-point selection, snapshot resolution, detached-worktree restore, fork invocation; replay-mode taxonomy and observable-context reconstruction remain), and part of **#7** (mutation-boundary snapshots wired + step association; retention/pruning of `refs/spotter/*` remains). **#8**'s core was implemented by #10 (merged). **#6** (cross-process journal concurrency) is untouched by this PR and still open.

## What

Completes the recording→fork half of plan **P0** (되감기 장치) and the aggregation tool for **P1**'s FP-review loop.

### `spotter fork --session S --step K [--guidance TEXT]`

Grounded in verified Codex CLI facts (not assumptions): `codex exec resume <id>` exists, `-C <dir>` sets the working root, and rollouts persist as JSONL under `~/.codex/sessions` with `call_id` on every tool call — which matches the `tool_use_id` the hook journals. Fork therefore:

1. finds the branch call in the rollout via the journaled `tool_use_id`,
2. writes a **truncated copy** ending strictly before it, re-identified with a fresh session id (original untouched),
3. restores the nearest repo snapshot into a **detached worktree** (user's checkout never touched),
4. prints a ready `codex exec resume <new-id> -C <worktree> --json` invocation.

`--guidance` appends course-correction text — running the same fork **with and without it is a same-prefix counterfactual pair** (plan Q3). Nothing is executed automatically: launching an agent costs money and acts on a repo, so the human stays on the trigger.

Every missing ingredient fails with a named error (`no snapshot at or before step…`, `no tool_use_id…`), not a stack trace.

### Hook now records what fork needs

- `tool_use_id` + `cwd` on every `tool_proposal`
- a worktree snapshot at `apply_patch` boundaries (`snapshot_on_patch`, default on) — snapshot failure fails open and journals `snapshot: null`

### `spotter analyze`

Per-session summary plus every shadow-block/fail-open with its triggering command — the aggregation step of the FP loop done by hand until now. Deliberately does **not** label FP/TP: that judgment is exactly what must not be automated before the reviewer stage earns trust.

### Root-cause fix

git subprocess launch failures (missing cwd, missing binary) raised bare `OSError`, escaping the fail-open boundary — now `SnapshotError`. Found by a test, fixed in `_git()` where all callers route through.

## Verification

- 74 tests, ruff, mypy --strict clean
- E2E: `spotter analyze` against the real 82-step supervised session reproduces the 6 shadow blocks with context; `spotter fork` on a pre-snapshot session refuses with the exact missing ingredient

## Known limit (stated in `replay.py`)

Whether `codex exec resume` accepts a truncated rollout is **unverified until the first real run** — that experiment is the P0 exit criterion. Sessions journaled before this change lack snapshots/tool_use_id and cannot be forked; new sessions record everything.