### PR TITLE
feat: snapshot pruning, fork hardening, and cross-process journal stress test

### DIFF
--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -16,6 +16,8 @@ from spotter.replay import ReplayError, fork, plan_to_json
 from spotter.snapshot import (
     SnapshotError,
     StepJournal,
+    StepRecord,
+    global_lock,
     prune_snapshots,
     referenced_snapshots,
 )
@@ -126,7 +128,7 @@ def _analyze_main(session: str | None) -> int:
             f"snapshots={snapshots} flagged={len(flagged)}"
         )
         for record in flagged:
-            trigger = records[record.step - 1].event.payload if record.step > 0 else {}
+            trigger = _trigger_for(records, record)
             summary = str(trigger.get("command") or trigger.get("patch") or trigger)
             summary = " ".join(summary.split())[:120]
             print(
@@ -136,16 +138,39 @@ def _analyze_main(session: str | None) -> int:
     return 0
 
 
+def _trigger_for(records: list[StepRecord], flagged: StepRecord) -> dict[str, object]:
+    """Resolve the proposal that triggered a gate event.
+
+    Match by the tool_use_id the gate event carries; journal adjacency is not
+    trustworthy under concurrent hook processes. Falls back to the previous
+    record only for journals written before the id was recorded.
+    """
+    wanted = flagged.event.payload.get("tool_use_id")
+    if wanted:
+        for record in reversed(records[: flagged.step]):
+            if (
+                record.event.kind == "tool_proposal"
+                and record.event.payload.get("tool_use_id") == wanted
+            ):
+                return record.event.payload
+    if flagged.step > 0:
+        return records[flagged.step - 1].event.payload
+    return {}
+
+
 def _prune_main(repo: Path, *, apply: bool) -> int:
     """Drop refs/spotter/steps/* that no journal references (issue #7).
 
     Dry-run by default: deleting a snapshot is the one spotter operation that
-    can destroy fork-ability, so the human confirms with --apply.
+    can destroy fork-ability, so the human confirms with --apply. The global
+    lock serializes against a hook that has pinned a ref but not yet
+    journaled it.
     """
     sessions_dir = journal_path({"session_id": "probe"}).parent
     try:
-        referenced = referenced_snapshots(sessions_dir)
-        pruned = prune_snapshots(repo, referenced, apply=apply)
+        with global_lock():
+            referenced = referenced_snapshots(sessions_dir, repo)
+            pruned = prune_snapshots(repo, referenced, apply=apply)
     except SnapshotError as error:
         print(f"prune aborted: {error}", file=sys.stderr)
         return 1

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -13,7 +13,12 @@ from spotter.core import SpotterRuntime
 from spotter.gates import Gate
 from spotter.hook import journal_path, run_hook
 from spotter.replay import ReplayError, fork, plan_to_json
-from spotter.snapshot import SnapshotError, StepJournal
+from spotter.snapshot import (
+    SnapshotError,
+    StepJournal,
+    prune_snapshots,
+    referenced_snapshots,
+)
 from spotter.trace import TraceEvent
 
 
@@ -22,18 +27,24 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=["observe", "hook", "analyze", "fork"],
+        choices=["observe", "hook", "analyze", "fork", "prune"],
         default="observe",
         help=(
             "observe: validate config and start; hook: Codex hook bridge (JSON on stdin); "
-            "analyze: summarize journaled sessions; fork: branch a session at a step"
+            "analyze: summarize journaled sessions; fork: branch a session at a step; "
+            "prune: drop unreferenced refs/spotter snapshots (dry-run without --apply)"
         ),
     )
     parser.add_argument("--config", type=Path, help="path to Spotter TOML config")
     parser.add_argument("--session", help="session id (fork; analyze filters to it)")
     parser.add_argument("--step", type=int, help="journal step to branch at (fork)")
-    parser.add_argument("--repo", type=Path, help="repo override when the journal lacks cwd (fork)")
+    parser.add_argument(
+        "--repo", type=Path, help="repo path (prune; fork override when the journal lacks cwd)"
+    )
     parser.add_argument("--guidance", help="course-correction text for the forked run (fork)")
+    parser.add_argument(
+        "--apply", action="store_true", help="prune: actually delete (default is dry-run)"
+    )
     return parser
 
 
@@ -55,6 +66,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _hook_main(config)
     if args.command == "analyze":
         return _analyze_main(args.session)
+    if args.command == "prune":
+        return _prune_main(args.repo or Path.cwd(), apply=args.apply)
     if args.command == "fork":
         if not args.session or args.step is None:
             parser.error("fork requires --session and --step")
@@ -120,6 +133,26 @@ def _analyze_main(session: str | None) -> int:
                 f"  step {record.step:4d} {record.event.kind:17s} "
                 f"{record.event.payload.get('rule')}: {summary}"
             )
+    return 0
+
+
+def _prune_main(repo: Path, *, apply: bool) -> int:
+    """Drop refs/spotter/steps/* that no journal references (issue #7).
+
+    Dry-run by default: deleting a snapshot is the one spotter operation that
+    can destroy fork-ability, so the human confirms with --apply.
+    """
+    sessions_dir = journal_path({"session_id": "probe"}).parent
+    try:
+        referenced = referenced_snapshots(sessions_dir)
+        pruned = prune_snapshots(repo, referenced, apply=apply)
+    except SnapshotError as error:
+        print(f"prune aborted: {error}", file=sys.stderr)
+        return 1
+    verb = "deleted" if apply else "would delete (pass --apply)"
+    print(f"{len(referenced)} snapshots referenced by journals; {verb} {len(pruned)} refs")
+    for sha in pruned:
+        print(f"  {sha}")
     return 0
 
 

--- a/src/spotter/core.py
+++ b/src/spotter/core.py
@@ -24,24 +24,21 @@ class SpotterRuntime:
     def observe(self, event: TraceEvent) -> GateDecision:
         decision = self.gate.check(event)
         self.adapter.record(event)
+        # Concurrent hook processes can interleave records between the proposal
+        # and its gate event, so gate events carry the trigger identity instead
+        # of relying on journal adjacency (PR #12 review, P1).
+        gate_payload = {
+            "rule": decision.rule,
+            "reason": decision.reason,
+            "tool_use_id": event.payload.get("tool_use_id"),
+            "tool": event.payload.get("tool"),
+        }
         if decision.allowed:
             if decision.rule:
-                self.adapter.record(
-                    TraceEvent(
-                        "gate_fail_open",
-                        {"rule": decision.rule, "reason": decision.reason},
-                    )
-                )
+                self.adapter.record(TraceEvent("gate_fail_open", gate_payload))
             return decision
         if self.config.observation_only:
-            self.adapter.record(
-                TraceEvent(
-                    "gate_shadow_block",
-                    {"rule": decision.rule, "reason": decision.reason},
-                )
-            )
+            self.adapter.record(TraceEvent("gate_shadow_block", gate_payload))
             return ALLOW
-        self.adapter.record(
-            TraceEvent("gate_block", {"rule": decision.rule, "reason": decision.reason})
-        )
+        self.adapter.record(TraceEvent("gate_block", gate_payload))
         return decision

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -14,7 +14,7 @@ from typing import Any
 from spotter.config import SpotterConfig
 from spotter.core import SpotterRuntime
 from spotter.gates import Gate
-from spotter.snapshot import SnapshotError, StepJournal, snapshot_worktree
+from spotter.snapshot import SnapshotError, StepJournal, global_lock, snapshot_worktree
 from spotter.trace import TraceEvent
 
 _PATCH_PATH = re.compile(r"^\*\*\* (?:(?:Add|Update|Delete) File|Move to): (.+)$", re.MULTILINE)
@@ -104,11 +104,16 @@ def run_hook(payload: dict[str, Any], config: SpotterConfig) -> str | None:
     ):
         # PreToolUse captures the state before this patch; PostToolUse captures
         # the state after it, keeping later rollout prefixes aligned with disk.
-        try:
-            adapter.next_snapshot = snapshot_worktree(Path(cwd))
-        except SnapshotError:
-            adapter.next_snapshot = None
-    decision = runtime.observe(event)
+        # The global lock closes the ref-created-but-not-yet-journaled window
+        # a concurrent prune --apply could otherwise exploit.
+        with global_lock():
+            try:
+                adapter.next_snapshot = snapshot_worktree(Path(cwd))
+            except SnapshotError:
+                adapter.next_snapshot = None
+            decision = runtime.observe(event)
+    else:
+        decision = runtime.observe(event)
     if decision.allowed:
         return None  # implicit allow; stay silent on the happy path
     return json.dumps(

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -98,12 +98,12 @@ def run_hook(payload: dict[str, Any], config: SpotterConfig) -> str | None:
     event = event_from_hook(payload)
     if (
         config.snapshot_on_patch
-        and event.kind == "tool_proposal"
+        and event.kind in ("tool_proposal", "tool_result")
         and event.payload.get("tool") == "apply_patch"
         and isinstance(cwd, str)
     ):
-        # Snapshot at the commit boundary so P0 fork has a repo state to
-        # restore. Fail open: losing a snapshot must not break the session.
+        # PreToolUse captures the state before this patch; PostToolUse captures
+        # the state after it, keeping later rollout prefixes aligned with disk.
         try:
             adapter.next_snapshot = snapshot_worktree(Path(cwd))
         except SnapshotError:

--- a/src/spotter/replay.py
+++ b/src/spotter/replay.py
@@ -20,6 +20,7 @@ Honest limits, stated rather than papered over:
 """
 
 import json
+import shlex
 import uuid
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -43,7 +44,11 @@ class ForkPlan:
 
 def find_rollout(session_id: str, codex_home: Path | None = None) -> Path:
     home = codex_home or Path.home() / ".codex"
-    matches = sorted((home / "sessions").rglob(f"rollout-*{session_id}.jsonl"))
+    matches = sorted(
+        path
+        for path in (home / "sessions").rglob("rollout-*.jsonl")
+        if path.stem.endswith(session_id)
+    )
     if not matches:
         raise ReplayError(f"no rollout found for session {session_id} under {home}/sessions")
     return matches[-1]
@@ -58,23 +63,26 @@ def fork_rollout(rollout: Path, call_id: str, new_id: str) -> Path:
     lines = rollout.read_text(encoding="utf-8").splitlines()
     if not lines:
         raise ReplayError(f"rollout is empty: {rollout}")
-    meta = json.loads(lines[0])
-    old_id = str(meta.get("payload", {}).get("session_id") or "")
+    meta = _rollout_record(lines[0], 1)
+    payload = meta.get("payload")
+    if not isinstance(payload, dict):
+        raise ReplayError("rollout has no session_meta payload on line 1")
+    old_id = str(payload.get("session_id") or "")
     if not old_id:
         raise ReplayError("rollout has no session_meta session_id on line 1")
-    cut = next(
-        (
-            index
-            for index, line in enumerate(lines)
-            if f'"call_id":"{call_id}"' in line or f'"call_id": "{call_id}"' in line
-        ),
-        None,
-    )
+    cut = None
+    for index, line in enumerate(lines[1:], 1):
+        if _call_id(_rollout_record(line, index + 1)) == call_id:
+            cut = index
+            break
     if cut is None:
         raise ReplayError(f"call_id {call_id} not found in rollout {rollout.name}")
     if cut == 0:
         raise ReplayError("branch point is the first record; nothing to resume from")
-    forked = [line.replace(old_id, new_id) for line in lines[:cut]]
+    payload["session_id"] = new_id
+    if payload.get("id") == old_id:
+        payload["id"] = new_id
+    forked = [json.dumps(meta), *lines[1:cut]]
     dest = rollout.with_name(rollout.name.replace(old_id, new_id))
     if dest.exists():
         raise ReplayError(f"forked rollout already exists: {dest}")
@@ -114,11 +122,17 @@ def fork(
 
     new_id = str(uuid.uuid4())
     worktree = dest or journal_file.parent.parent / "forks" / new_id
-    restore_snapshot(repo_path, snapshot, worktree)
     forked_rollout = fork_rollout(find_rollout(session_id, codex_home), call_id, new_id)
+    try:
+        restore_snapshot(repo_path, snapshot, worktree)
+    except Exception:
+        forked_rollout.unlink(missing_ok=True)
+        raise
 
-    prompt = f" {json.dumps(guidance)}" if guidance else ""
-    command = f"codex exec resume {new_id} -C {worktree} --json{prompt}"
+    argv = ["codex", "exec", "-C", str(worktree), "resume", "--json", new_id]
+    if guidance:
+        argv.append(guidance)
+    command = shlex.join(argv)
     return ForkPlan(
         session_id=new_id,
         branch_step=step,
@@ -130,6 +144,21 @@ def fork(
 
 def plan_to_json(plan: ForkPlan) -> str:
     return json.dumps(asdict(plan), indent=2)
+
+
+def _rollout_record(line: str, number: int) -> dict[str, object]:
+    try:
+        record = json.loads(line)
+    except json.JSONDecodeError as error:
+        raise ReplayError(f"invalid rollout JSON on line {number}: {error.msg}") from error
+    if not isinstance(record, dict):
+        raise ReplayError(f"rollout line {number} is not a JSON object")
+    return record
+
+
+def _call_id(record: dict[str, object]) -> object:
+    payload = record.get("payload")
+    return payload.get("call_id") if isinstance(payload, dict) else None
 
 
 def _nearest_snapshot(records: list[StepRecord], step: int) -> str | None:

--- a/src/spotter/replay.py
+++ b/src/spotter/replay.py
@@ -11,8 +11,11 @@ Mechanism (approximate replay, the plan's fallback path):
    the pair is a same-prefix counterfactual (plan Q3).
 
 Honest limits, stated rather than papered over:
-- Whether `codex exec resume` accepts a truncated rollout is UNVERIFIED until
-  the first real run; that experiment IS the P0 exit criterion.
+- Resume compatibility VERIFIED 2026-08-11: `codex exec resume` accepted a
+  truncated rollout (fork of a real 104-step session at step 98). The agent
+  located its context at the branch point and reported the cut call as "my
+  last action was interrupted" — the exact branch semantics wanted. The cut
+  leaves one dangling call; Codex logs a warning and proceeds.
 - Sessions journaled before snapshots/tool_use_id existed cannot be forked;
   the errors below say exactly which ingredient is missing.
 - This does not execute anything itself: launching costs money and runs an
@@ -72,7 +75,7 @@ def fork_rollout(rollout: Path, call_id: str, new_id: str) -> Path:
         raise ReplayError("rollout has no session_meta session_id on line 1")
     cut = None
     for index, line in enumerate(lines[1:], 1):
-        if _call_id(_rollout_record(line, index + 1)) == call_id:
+        if call_id in _record_ids(_rollout_record(line, index + 1)):
             cut = index
             break
     if cut is None:
@@ -156,9 +159,27 @@ def _rollout_record(line: str, number: int) -> dict[str, object]:
     return record
 
 
-def _call_id(record: dict[str, object]) -> object:
+def _record_ids(record: dict[str, object]) -> set[object]:
+    """Ids under which a tool call appears in a rollout record.
+
+    The hook's tool_use_id surfaces as event_msg payload.item.id (harness id),
+    while response_item records carry the model-level payload.call_id — the
+    branch cut happens at whichever mentions the id first.
+
+    ponytail: cutting at the first *mention* can leave the proposal of the
+    branch call in history when only a completion event carries the id.
+    Good enough for the resume-compat experiment; tighten to turn boundaries
+    if resumed agents visibly double-apply the branch step.
+    """
     payload = record.get("payload")
-    return payload.get("call_id") if isinstance(payload, dict) else None
+    if not isinstance(payload, dict):
+        return set()
+    ids: set[object] = {payload.get("call_id")}
+    item = payload.get("item")
+    if isinstance(item, dict):
+        ids.add(item.get("id"))
+    ids.discard(None)
+    return ids
 
 
 def _nearest_snapshot(records: list[StepRecord], step: int) -> str | None:

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -12,6 +12,8 @@ import json
 import os
 import subprocess
 import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from fcntl import LOCK_EX, LOCK_UN, flock
 from pathlib import Path
@@ -24,7 +26,27 @@ class SnapshotError(RuntimeError):
     """Raised when git snapshot/restore plumbing fails."""
 
 
-def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> str:
+@contextmanager
+def global_lock(spotter_home: Path | None = None) -> Iterator[None]:
+    """Serialize snapshot-ref creation+journaling against prune.
+
+    The ref exists before the journal references it; without this lock a
+    concurrent prune --apply sees an unreferenced ref in that window and
+    deletes a snapshot the journal is about to claim (PR #12 review, P0).
+    """
+    home = spotter_home or Path(os.environ.get("SPOTTER_HOME", Path.home() / ".spotter"))
+    home.mkdir(parents=True, exist_ok=True)
+    with (home / "lock").open("w") as handle:
+        flock(handle, LOCK_EX)
+        try:
+            yield
+        finally:
+            flock(handle, LOCK_UN)
+
+
+def _git(
+    repo: Path, *args: str, env: dict[str, str] | None = None, input: str | None = None
+) -> str:
     try:
         result = subprocess.run(
             ["git", *args],
@@ -32,6 +54,7 @@ def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> str:
             env={**os.environ, **(env or {})},
             capture_output=True,
             text=True,
+            input=input,
         )
     except OSError as error:  # missing cwd, missing git binary — same contract
         raise SnapshotError(f"git {' '.join(args)} failed to start: {error}") from error
@@ -119,7 +142,10 @@ class StepJournal:
                 flock(lock, LOCK_UN)
 
     @staticmethod
-    def load(path: Path, *, repair_tail: bool = False) -> list[StepRecord]:
+    def load(path: Path, *, repair_tail: bool = False, strict: bool = False) -> list[StepRecord]:
+        """Load records. strict=True refuses any undecodable content instead of
+        keeping the valid prefix — destructive readers (prune) must not treat a
+        torn tail as proof of absence (PR #12 review, P0)."""
         records: list[StepRecord] = []
         with path.open("r+" if repair_tail else "r", encoding="utf-8") as journal:
             while True:
@@ -132,6 +158,10 @@ class StepJournal:
                 try:
                     raw: dict[str, Any] = json.loads(line)
                 except json.JSONDecodeError:
+                    if strict:
+                        raise SnapshotError(
+                            f"undecodable journal content at byte {line_start} (torn tail?)"
+                        ) from None
                     if line.endswith("\n"):
                         raise SnapshotError(
                             f"invalid journal record at byte {line_start}"
@@ -160,16 +190,23 @@ class StepJournal:
         return [r for r in records if r.step < upto]
 
 
-def referenced_snapshots(sessions_dir: Path) -> set[str]:
-    """Every snapshot sha any journal still points at.
+def referenced_snapshots(sessions_dir: Path, repo: Path | None = None) -> set[str]:
+    """Every snapshot sha the journals still point at, filtered to ``repo``.
 
-    An unreadable journal aborts the scan: pruning with unknown references
-    could delete a snapshot a future fork needs, and that loss is silent.
+    Strict read: an unreadable journal or torn tail aborts the scan — pruning
+    with unknown references could delete a snapshot a future fork needs.
+    A record without a cwd is kept regardless of repo (conservative: unknown
+    provenance must never enable deletion).
     """
+    target = repo.resolve() if repo else None
     shas: set[str] = set()
     for journal in sorted(sessions_dir.glob("*.jsonl")):
-        for record in StepJournal.load(journal):
-            if record.snapshot:
+        for record in StepJournal.load(journal, strict=True):
+            if not record.snapshot:
+                continue
+            cwd = record.event.payload.get("cwd")
+            unknown_provenance = target is None or not isinstance(cwd, str) or not cwd
+            if unknown_provenance or Path(str(cwd)).resolve() == target:
                 shas.add(record.snapshot)
     return shas
 
@@ -181,13 +218,16 @@ def prune_snapshots(repo: Path, referenced: set[str], *, apply: bool = False) ->
     referenced snapshots are structurally out of reach.
     """
     output = _git(repo, "for-each-ref", "--format=%(refname)%00%(objectname)", "refs/spotter/steps")
-    pruned: list[str] = []
+    doomed: list[tuple[str, str]] = []
     for line in output.splitlines():
         refname, _, sha = line.partition("\x00")
         if not refname.startswith("refs/spotter/steps/"):
             continue  # paranoia: never consider anything else deletable
         if sha and sha not in referenced:
-            pruned.append(sha)
-            if apply:
-                _git(repo, "update-ref", "-d", refname)
-    return pruned
+            doomed.append((refname, sha))
+    if apply and doomed:
+        # One update-ref --stdin transaction: all deletions or none — a
+        # mid-loop failure must not leave a half-pruned ref namespace.
+        script = "".join(f"delete {refname} {sha}\n" for refname, sha in doomed)
+        _git(repo, "update-ref", "--stdin", input=script)
+    return [sha for _, sha in doomed]

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -158,3 +158,36 @@ class StepJournal:
     def prefix(records: list[StepRecord], upto: int) -> list[StepRecord]:
         """Events before step ``upto`` — the branch point for a future replay."""
         return [r for r in records if r.step < upto]
+
+
+def referenced_snapshots(sessions_dir: Path) -> set[str]:
+    """Every snapshot sha any journal still points at.
+
+    An unreadable journal aborts the scan: pruning with unknown references
+    could delete a snapshot a future fork needs, and that loss is silent.
+    """
+    shas: set[str] = set()
+    for journal in sorted(sessions_dir.glob("*.jsonl")):
+        for record in StepJournal.load(journal):
+            if record.snapshot:
+                shas.add(record.snapshot)
+    return shas
+
+
+def prune_snapshots(repo: Path, referenced: set[str], *, apply: bool = False) -> list[str]:
+    """List (and with apply=True, delete) refs/spotter/steps/* no journal references.
+
+    Touches nothing outside refs/spotter/steps — user refs, worktrees, and
+    referenced snapshots are structurally out of reach.
+    """
+    output = _git(repo, "for-each-ref", "--format=%(refname)%00%(objectname)", "refs/spotter/steps")
+    pruned: list[str] = []
+    for line in output.splitlines():
+        refname, _, sha = line.partition("\x00")
+        if not refname.startswith("refs/spotter/steps/"):
+            continue  # paranoia: never consider anything else deletable
+        if sha and sha not in referenced:
+            pruned.append(sha)
+            if apply:
+                _git(repo, "update-ref", "-d", refname)
+    return pruned

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -5,7 +5,7 @@ import pytest
 
 from spotter.config import GatesConfig, MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.hook import event_from_hook, journal_path, run_hook
-from spotter.snapshot import StepJournal
+from spotter.snapshot import StepJournal, restore_snapshot
 
 
 @pytest.fixture(autouse=True)
@@ -140,6 +140,16 @@ def test_apply_patch_takes_snapshot_for_fork(tmp_path: Path, spotter_home: Path)
     assert record.snapshot  # repo state pinned at the commit boundary
     assert record.event.payload["tool_use_id"] == "call_1"
     assert record.event.payload["cwd"] == str(repo)
+
+    (repo / "x.txt").write_text("patched")
+    post = {**payload, "hook_event_name": "PostToolUse", "tool_response": {"ok": True}}
+    assert run_hook(post, _config(observation_only=True)) is None
+    post_record = StepJournal.load(journal_path(payload))[1]
+    assert post_record.snapshot and post_record.snapshot != record.snapshot
+
+    restored = tmp_path / "restored"
+    restore_snapshot(repo, post_record.snapshot, restored)
+    assert (restored / "x.txt").read_text() == "patched"
 
 
 def test_snapshot_failure_fails_open(tmp_path: Path, spotter_home: Path) -> None:

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -1,0 +1,117 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from spotter.hook import journal_path
+from spotter.snapshot import (
+    SnapshotError,
+    StepJournal,
+    prune_snapshots,
+    referenced_snapshots,
+    snapshot_worktree,
+)
+from spotter.trace import TraceEvent
+
+
+@pytest.fixture(autouse=True)
+def spotter_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "spotter"
+    monkeypatch.setenv("SPOTTER_HOME", str(home))
+    return home
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    (repo / "a.txt").write_text("v1")
+    return repo
+
+
+def _refs(repo: Path) -> set[str]:
+    out = subprocess.run(
+        ["git", "for-each-ref", "--format=%(refname)", "refs/spotter/steps"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return set(out.split())
+
+
+def test_prune_keeps_referenced_and_drops_orphans(repo: Path) -> None:
+    kept = snapshot_worktree(repo)
+    (repo / "a.txt").write_text("v2")
+    orphan = snapshot_worktree(repo)
+    StepJournal(journal_path({"session_id": "s1"})).record(
+        TraceEvent("tool_proposal"), snapshot=kept
+    )
+
+    referenced = referenced_snapshots(journal_path({"session_id": "s1"}).parent)
+
+    # dry-run reports but deletes nothing
+    assert prune_snapshots(repo, referenced) == [orphan]
+    assert len(_refs(repo)) == 2
+
+    assert prune_snapshots(repo, referenced, apply=True) == [orphan]
+    assert _refs(repo) == {f"refs/spotter/steps/{kept}"}
+
+
+def test_unreadable_journal_aborts_prune(repo: Path, spotter_home: Path) -> None:
+    snapshot_worktree(repo)
+    sessions = spotter_home / "sessions"
+    sessions.mkdir(parents=True)
+    (sessions / "bad.jsonl").write_text('{"step": 7, "kind": "x", "payload": {}}\n')
+    with pytest.raises(SnapshotError):
+        referenced_snapshots(sessions)  # unknown references → refuse to guess
+
+
+def test_prune_never_touches_other_refs(repo: Path, spotter_home: Path) -> None:
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=repo, check=True)
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    subprocess.run(["git", "update-ref", "refs/heads/precious", head], cwd=repo, check=True)
+    (spotter_home / "sessions").mkdir(parents=True)
+
+    prune_snapshots(repo, set(), apply=True)
+
+    branches = subprocess.run(
+        ["git", "for-each-ref", "--format=%(refname)", "refs/heads"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "refs/heads/precious" in branches
+
+
+def test_journal_survives_concurrent_processes(tmp_path: Path) -> None:
+    """flock is a cross-process guarantee; threads cannot exercise it (issue #6)."""
+    journal = tmp_path / "journal.jsonl"
+    script = (
+        "import sys\n"
+        "from pathlib import Path\n"
+        "from spotter.snapshot import StepJournal\n"
+        "from spotter.trace import TraceEvent\n"
+        "j = StepJournal(Path(sys.argv[1]))\n"
+        "for i in range(10):\n"
+        "    j.record(TraceEvent('event'))\n"
+    )
+    workers = [
+        subprocess.Popen(
+            [sys.executable, "-c", script, str(journal)],
+            cwd=Path(__file__).parent.parent,
+            env={"PYTHONPATH": "src", "PATH": "/usr/bin:/bin"},
+        )
+        for _ in range(4)
+    ]
+    assert all(worker.wait() == 0 for worker in workers)
+    records = StepJournal.load(journal)
+    assert [r.step for r in records] == list(range(40))  # unique, monotonic, no gaps

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -115,3 +115,106 @@ def test_journal_survives_concurrent_processes(tmp_path: Path) -> None:
     assert all(worker.wait() == 0 for worker in workers)
     records = StepJournal.load(journal)
     assert [r.step for r in records] == list(range(40))  # unique, monotonic, no gaps
+
+
+# --- Regression tests for the PR #12 review findings: each one hits the exact
+# --- window the review said the previous tests avoided.
+
+
+def test_race_hook_snapshot_vs_prune_is_serialized(repo: Path, spotter_home: Path) -> None:
+    """P0: a ref pinned but not yet journaled must survive a concurrent prune."""
+    (spotter_home / "sessions").mkdir(parents=True, exist_ok=True)
+    ready = spotter_home / "ready"
+    script = (
+        "import sys, time\n"
+        "from pathlib import Path\n"
+        "from spotter.snapshot import StepJournal, global_lock, snapshot_worktree\n"
+        "from spotter.trace import TraceEvent\n"
+        "repo, home = Path(sys.argv[1]), Path(sys.argv[2])\n"
+        "with global_lock(home):\n"
+        "    sha = snapshot_worktree(repo)  # ref exists, journal not yet written\n"
+        "    (home / 'ready').write_text(sha)\n"
+        "    time.sleep(1.0)  # the window prune must NOT be able to enter\n"
+        "    journal = StepJournal(home / 'sessions' / 's-race.jsonl')\n"
+        "    journal.record(TraceEvent('tool_proposal', {'cwd': str(repo)}), snapshot=sha)\n"
+    )
+    worker = subprocess.Popen(
+        [sys.executable, "-c", script, str(repo), str(spotter_home)],
+        cwd=Path(__file__).parent.parent,
+        env={"PYTHONPATH": "src", "PATH": "/usr/bin:/bin"},
+    )
+    try:
+        deadline = 50
+        while not ready.exists() and deadline:
+            deadline -= 1
+            import time
+
+            time.sleep(0.1)
+        assert ready.exists(), "worker never reached the race window"
+        from spotter.snapshot import global_lock
+
+        with global_lock(spotter_home):  # blocks until the worker journals
+            referenced = referenced_snapshots(spotter_home / "sessions", repo)
+            pruned = prune_snapshots(repo, referenced, apply=True)
+    finally:
+        assert worker.wait(timeout=30) == 0
+    assert pruned == []
+    assert _refs(repo) == {f"refs/spotter/steps/{ready.read_text()}"}
+
+
+def test_torn_tail_with_snapshot_aborts_prune(repo: Path, spotter_home: Path) -> None:
+    """P0: a torn tail may hold the newest sha; strict read refuses to guess."""
+    sha = snapshot_worktree(repo)
+    sessions = spotter_home / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    torn = f'{{"step": 0, "kind": "tool_proposal", "payload": {{}}, "snapshot": "{sha}"'
+    (sessions / "s-torn.jsonl").write_text(torn)  # no newline: crash mid-write
+    with pytest.raises(SnapshotError, match="torn tail"):
+        referenced_snapshots(sessions, repo)
+
+
+def test_apply_deletes_all_doomed_refs_in_one_transaction(repo: Path) -> None:
+    """P1: multiple deletions go through one update-ref --stdin transaction."""
+    shas = []
+    for n in range(3):
+        (repo / "a.txt").write_text(f"v{n}")
+        shas.append(snapshot_worktree(repo))
+    assert sorted(prune_snapshots(repo, set(), apply=True)) == sorted(shas)
+    assert _refs(repo) == set()
+
+
+def test_trigger_resolution_survives_interleaved_journals() -> None:
+    """P1: gate events resolve their proposal by tool_use_id, not adjacency."""
+    from spotter.cli import _trigger_for
+    from spotter.snapshot import StepRecord
+
+    records = [
+        StepRecord(
+            0, TraceEvent("tool_proposal", {"tool_use_id": "A", "command": "rm -rf /"}), None
+        ),
+        StepRecord(1, TraceEvent("tool_proposal", {"tool_use_id": "B", "command": "pytest"}), None),
+        StepRecord(
+            2, TraceEvent("gate_shadow_block", {"rule": "rm_root", "tool_use_id": "A"}), None
+        ),
+    ]
+    assert _trigger_for(records, records[2])["command"] == "rm -rf /"
+
+
+def test_referenced_snapshots_filters_by_repo(
+    repo: Path, tmp_path: Path, spotter_home: Path
+) -> None:
+    """P2: a sha referenced only by another repo's journal is prunable here;
+    a record with unknown provenance is conservatively kept everywhere."""
+    sha = snapshot_worktree(repo)
+    sessions = spotter_home / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    other_repo = tmp_path / "elsewhere"
+    other_repo.mkdir()
+    StepJournal(sessions / "s-other.jsonl").record(
+        TraceEvent("tool_proposal", {"cwd": str(other_repo)}), snapshot=sha
+    )
+    assert referenced_snapshots(sessions, repo) == set()  # other repo's claim doesn't count here
+    assert referenced_snapshots(sessions, other_repo) == {sha}
+
+    StepJournal(sessions / "s-nocwd.jsonl").record(TraceEvent("tool_proposal"), snapshot=sha)
+    assert referenced_snapshots(sessions, repo) == {sha}  # unknown provenance → keep

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -6,7 +7,7 @@ import pytest
 
 from spotter.hook import journal_path
 from spotter.replay import ReplayError, fork, fork_rollout
-from spotter.snapshot import StepJournal, snapshot_worktree
+from spotter.snapshot import SnapshotError, StepJournal, snapshot_worktree
 from spotter.trace import TraceEvent
 
 OLD_ID = "aaaa1111-bbbb-2222-cccc-333344445555"
@@ -61,10 +62,33 @@ def test_fork_rollout_truncates_and_renames(codex_home: Path) -> None:
     assert rollout.read_text().count("call_B") == 1  # original untouched
 
 
+def test_fork_rollout_only_rewrites_session_metadata(codex_home: Path) -> None:
+    rollout = next((codex_home / "sessions").rglob("*.jsonl"))
+    lines = rollout.read_text().splitlines()
+    lines.insert(
+        1,
+        json.dumps({"type": "event", "payload": {"message": f"keep literal session {OLD_ID}"}}),
+    )
+    rollout.write_text("\n".join(lines) + "\n")
+    forked = fork_rollout(rollout, "call_B", "new-id")
+    records = [json.loads(line) for line in forked.read_text().splitlines()]
+    assert records[0]["payload"]["session_id"] == "new-id"
+    assert records[1]["payload"]["message"].endswith(OLD_ID)
+
+
 def test_fork_rollout_unknown_call_id_fails_loudly(codex_home: Path) -> None:
     rollout = next((codex_home / "sessions").rglob("*.jsonl"))
     with pytest.raises(ReplayError, match="call_id call_X not found"):
         fork_rollout(rollout, "call_X", "new-id")
+
+
+def test_fork_rollout_invalid_json_fails_cleanly(codex_home: Path) -> None:
+    rollout = next((codex_home / "sessions").rglob("*.jsonl"))
+    lines = rollout.read_text().splitlines()
+    lines.insert(3, "not-json")
+    rollout.write_text("\n".join(lines) + "\n")
+    with pytest.raises(ReplayError, match="invalid rollout JSON on line 4"):
+        fork_rollout(rollout, "call_B", "new-id")
 
 
 def test_fork_end_to_end(repo: Path, codex_home: Path) -> None:
@@ -87,6 +111,56 @@ def test_fork_end_to_end(repo: Path, codex_home: Path) -> None:
     assert plan.session_id in plan.command and str(plan.worktree) in plan.command
     assert "check the stack trace first" in plan.command
     assert Path(plan.rollout).exists()
+    assert shlex.split(plan.command) == [
+        "codex",
+        "exec",
+        "-C",
+        plan.worktree,
+        "resume",
+        "--json",
+        plan.session_id,
+        "check the stack trace first",
+    ]
+
+
+def test_fork_command_shell_quotes_guidance(repo: Path, codex_home: Path) -> None:
+    sha = snapshot_worktree(repo)
+    _journal(
+        OLD_ID,
+        [
+            (
+                TraceEvent("tool_proposal", {"tool_use_id": "call_B", "cwd": str(repo)}),
+                sha,
+            )
+        ],
+    )
+    guidance = "$(touch /tmp/should-not-run)"
+    plan = fork(OLD_ID, 0, codex_home=codex_home, guidance=guidance)
+    assert shlex.split(plan.command)[-1] == guidance
+
+
+def test_fork_removes_rollout_when_restore_fails(
+    repo: Path, codex_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sha = snapshot_worktree(repo)
+    _journal(
+        OLD_ID,
+        [
+            (
+                TraceEvent("tool_proposal", {"tool_use_id": "call_B", "cwd": str(repo)}),
+                sha,
+            )
+        ],
+    )
+    original = set((codex_home / "sessions").rglob("*.jsonl"))
+
+    def fail_restore(*args: object) -> Path:
+        raise SnapshotError("restore failed")
+
+    monkeypatch.setattr("spotter.replay.restore_snapshot", fail_restore)
+    with pytest.raises(SnapshotError, match="restore failed"):
+        fork(OLD_ID, 0, codex_home=codex_home)
+    assert set((codex_home / "sessions").rglob("*.jsonl")) == original
 
 
 def test_fork_without_snapshot_names_the_missing_ingredient(codex_home: Path) -> None:

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -182,3 +182,25 @@ def test_fork_rejects_non_proposal_steps(codex_home: Path) -> None:
     _journal(OLD_ID, [(TraceEvent("tool_result"), None)])
     with pytest.raises(ReplayError, match="fork at a tool_proposal"):
         fork(OLD_ID, 0, codex_home=codex_home)
+
+
+def test_fork_rollout_matches_event_msg_item_ids(codex_home: Path) -> None:
+    """Real hooks journal harness ids (exec-…) that appear as event_msg
+    payload.item.id, not response_item call_id — both must match."""
+    rollout = next((codex_home / "sessions").rglob("*.jsonl"))
+    lines = rollout.read_text().splitlines()
+    lines.append(
+        json.dumps(
+            {
+                "ordinal": 4,
+                "type": "event_msg",
+                "payload": {
+                    "type": "item_completed",
+                    "item": {"id": "exec-1234", "type": "FileChange"},
+                },
+            }
+        )
+    )
+    rollout.write_text("\n".join(lines) + "\n")
+    forked = fork_rollout(rollout, "exec-1234", "new-id")
+    assert len(forked.read_text().splitlines()) == 4  # cut before the event_msg


### PR DESCRIPTION
## Plan progress — where this lands

| Phase | Status after this PR |
|---|---|
| **P0** fork/replay | 🟢 recording+fork complete and hardened; remaining: first real `codex exec resume` run against a truncated rollout (exit-criterion experiment) |
| **P1** passive observer | 🟡 collection + `spotter analyze`; ceiling labeling remains |
| **P2** audit state | 🟡 built, not wired (needs reviewer) |
| **P3** gates | 🟢 shadow-deployed, token-stream judgment (#10) |
| **P4/P5** reviewer / ablations | 🔴 deliberately blocked on P0 exit criterion |

## Per open issue

### #7 — snapshot lifecycle: `spotter prune`
- Drops `refs/spotter/steps/*` that **no journal references**. Dry-run by default; `--apply` is the human trigger — deleting a snapshot is the one spotter operation that can destroy fork-ability.
- An **unreadable journal aborts the scan** instead of guessing: unknown references must not become silent deletions.
- Structurally cannot touch anything outside `refs/spotter/steps` (refname prefix check + only `update-ref -d` on matches). Regression test pins that user branches survive.
- E2E on this live repo: a real Codex session is already writing snapshot refs; prune reports all 4 referenced, deletes 0.
- Remaining from #7 (not in this PR): age/count-based retention policy, redundant-snapshot dedup when state hasn't changed.

### #6 — journal concurrency: the missing evidence
- The flock/fsync/torn-tail-repair core landed in #11. What was missing is proof: the existing concurrency test used **threads**, which cannot exercise flock.
- Added a stress test with 4 separate **processes** appending concurrently: 40 records, unique monotonic steps, no gaps.
- Remaining from #6 (not in this PR): abrupt-termination fault injection; Windows (no fcntl) is out of scope for now.

### #9 — replay: fork hardening
- Restore failure now removes the forked rollout copy — no half-assembled forks left in `~/.codex/sessions`.
- `--guidance` is shell-quoted into the suggested command (an injection-shaped string stays one argv token).
- `PostToolUse` also snapshots `apply_patch`, so later rollout prefixes stay aligned with on-disk state.
- Remaining from #9: replay-mode taxonomy, observable-context reconstruction, and the resume-compat experiment above.

## Verification

82 tests, ruff, mypy --strict clean. E2E: prune dry-run on the live repo (4 referenced / 0 deleted); multi-process journal stress green.