### PR TITLE
feat: shadow-mode reviewer — model-backed trajectory judgment, records only

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,14 @@ observation_only = true
 adapter = "codex"
 
 [reviewer]
-model = "gpt-5.3-spark"
+model = "default"
 ```
 
-`gpt-5.3-spark` is the default Spotter reviewer model, so the `[reviewer]` table may be
-omitted unless a different reviewer model is required.
+`"default"` delegates reviewer model choice to the codex account, so the `[reviewer]`
+table may be omitted. Pin a specific id only if your auth supports it: ChatGPT-account
+auth rejects some ids (observed: `gpt-5.3-spark`) with a slow retry loop rather than a
+fast error. Which reviewer model works best is an open experimental question (see
+docs/research.md RQ3), not a constant.
 
 To record Codex tool calls, add the bridge to `.codex/hooks.json` and review it with
 `/hooks` in Codex:

--- a/spotter.example.toml
+++ b/spotter.example.toml
@@ -4,4 +4,6 @@ observation_only = true
 adapter = "codex"
 
 [reviewer]
-model = "gpt-5.3-spark"
+# "default" uses your codex account's model. Pin an id (e.g. "gpt-5.3-spark")
+# only if your auth supports it — rejected ids fail slowly, not fast.
+model = "default"

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -13,6 +13,7 @@ from spotter.core import SpotterRuntime
 from spotter.gates import Gate
 from spotter.hook import journal_path, run_hook
 from spotter.replay import ReplayError, fork, plan_to_json
+from spotter.reviewer import review
 from spotter.snapshot import (
     SnapshotError,
     StepJournal,
@@ -29,12 +30,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=["observe", "hook", "analyze", "fork", "prune"],
+        choices=["observe", "hook", "analyze", "fork", "prune", "review"],
         default="observe",
         help=(
             "observe: validate config and start; hook: Codex hook bridge (JSON on stdin); "
             "analyze: summarize journaled sessions; fork: branch a session at a step; "
-            "prune: drop unreferenced refs/spotter snapshots (dry-run without --apply)"
+            "prune: drop unreferenced refs/spotter snapshots (dry-run without --apply); "
+            "review: run the shadow reviewer on a session (records only, injects nothing)"
         ),
     )
     parser.add_argument("--config", type=Path, help="path to Spotter TOML config")
@@ -46,6 +48,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--guidance", help="course-correction text for the forked run (fork)")
     parser.add_argument(
         "--apply", action="store_true", help="prune: actually delete (default is dry-run)"
+    )
+    parser.add_argument(
+        "--window", type=int, default=40, help="review: trajectory tail size fed to the reviewer"
     )
     return parser
 
@@ -70,6 +75,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _analyze_main(args.session)
     if args.command == "prune":
         return _prune_main(args.repo or Path.cwd(), apply=args.apply)
+    if args.command == "review":
+        if not args.session:
+            parser.error("review requires --session")
+        if config is None:
+            config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig())
+        return _review_main(args.session, config, window=args.window)
     if args.command == "fork":
         if not args.session or args.step is None:
             parser.error("fork requires --session and --step")
@@ -156,6 +167,44 @@ def _trigger_for(records: list[StepRecord], flagged: StepRecord) -> dict[str, ob
     if flagged.step > 0:
         return records[flagged.step - 1].event.payload
     return {}
+
+
+def _review_main(session: str, config: SpotterConfig, *, window: int) -> int:
+    """Shadow reviewer: judge the trajectory tail, journal the verdict, inject
+    nothing. Injection rights are earned later via labeling + fork pairs."""
+    journal_file = journal_path({"session_id": session})
+    try:
+        records = StepJournal.load(journal_file)
+    except (OSError, SnapshotError) as error:
+        print(f"review failed: {error}", file=sys.stderr)
+        return 1
+    if not records:
+        print("review failed: empty journal", file=sys.stderr)
+        return 1
+    try:
+        decision = review(records, config.reviewer.model, window=window)
+    except Exception as error:  # noqa: BLE001 — reviewer failure must stay observable, not fatal
+        print(f"review failed: {error}", file=sys.stderr)
+        return 1
+    StepJournal(journal_file).record(
+        TraceEvent(
+            "reviewer_decision",
+            {
+                "decision": decision.decision,
+                "failure_class": decision.failure_class,
+                "reason": decision.reason,
+                "confidence": decision.confidence,
+                "model": config.reviewer.model,
+                "reviewed_upto": records[-1].step,
+                "shadow": True,
+            },
+        )
+    )
+    print(
+        f"[shadow] {decision.decision} ({decision.failure_class}, "
+        f"conf={decision.confidence:.2f}): {decision.reason}"
+    )
+    return 0
 
 
 def _prune_main(repo: Path, *, apply: bool) -> int:

--- a/src/spotter/config.py
+++ b/src/spotter/config.py
@@ -10,7 +10,11 @@ class ConfigurationError(ValueError):
     """Raised when a Spotter configuration is malformed."""
 
 
-DEFAULT_REVIEWER_MODEL = "gpt-5.3-spark"
+# "default" delegates to the codex account's own model. A pinned id is an
+# auth-dependent liability: ChatGPT-account auth rejects several ids with a
+# multi-minute retry loop, and the reviewer model is an experimental variable
+# (plan Q6/P5), not a constant. Pin one explicitly only if your auth allows it.
+DEFAULT_REVIEWER_MODEL = "default"
 
 
 @dataclass(frozen=True)

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -74,6 +74,10 @@ def event_from_hook(payload: dict[str, Any]) -> TraceEvent:
                 "tool_response": payload.get("tool_response"),
             },
         )
+    if name == "UserPromptSubmit":
+        # The goal is the reviewer's anchor for spec-drift judgment; without it
+        # the digest has actions but no intent.
+        return TraceEvent("user_prompt", {"prompt": payload.get("prompt")})
     return TraceEvent(str(name or "unknown").lower())
 
 

--- a/src/spotter/reviewer.py
+++ b/src/spotter/reviewer.py
@@ -1,10 +1,149 @@
-"""Reviewer boundary for future model-backed trajectory review."""
+"""Reviewer: model-backed trajectory judgment — SHADOW MODE ONLY (plan P4 step 1).
 
-from typing import Protocol
+Decisions are appended to the journal and injected nowhere. The reviewer must
+earn injection rights the same way the gates did: shadow first, label its
+verdicts against reality, then measure intervention advantage with fork pairs.
 
-from spotter.trace import TraceEvent
+Model access reuses `codex exec` (zero new dependencies, existing auth). The
+digest fed to the reviewer contains observable actions only — commands, files,
+exit codes, gate flags — never Main's own summaries as facts (plan Q2).
+"""
+
+import json
+import subprocess
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from spotter.snapshot import StepRecord
+
+DECISIONS = ("continue", "verify", "nudge")
+FAILURE_CLASSES = ("none", "exploration_loop", "tool_failure_loop", "spec_drift")
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "decision": {"type": "string", "enum": list(DECISIONS)},
+        "failure_class": {"type": "string", "enum": list(FAILURE_CLASSES)},
+        "reason": {"type": "string"},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+    },
+    "required": ["decision", "failure_class", "reason", "confidence"],
+    "additionalProperties": False,
+}
+
+_PROMPT = """You are Spotter, a runtime reviewer watching another coding agent's trajectory.
+You see only observable actions below (commands, files, exit signals, gate flags).
+Judge the PROCESS, not the code: is the agent looping without new information,
+retrying a failing tool strategy, or drifting from the user's request?
+
+Rules:
+- Silence is the default. Neutral exploration is NOT failure. Repeated reads are
+  NOT automatically a loop. If uncertain, answer decision=continue.
+- verify: one consequential assumption deserves cheap evidence before more work
+  depends on it. nudge: the trajectory is clearly wasting effort.
+- Never propose code. One short reason sentence.
+
+Trajectory digest (oldest first):
+{digest}
+
+Respond with the JSON object only."""
 
 
-class Reviewer(Protocol):
-    def review(self, event: TraceEvent) -> str:
-        """Return a structured decision for a normalized event."""
+@dataclass(frozen=True)
+class ReviewerDecision:
+    decision: str
+    failure_class: str
+    reason: str
+    confidence: float
+
+
+def build_digest(records: list[StepRecord], window: int = 40) -> str:
+    """Compact, observation-only view of the trajectory tail."""
+    lines: list[str] = []
+    for record in records[-window:]:
+        kind, payload = record.event.kind, record.event.payload
+        if kind == "user_prompt":
+            text = " ".join(str(payload.get("prompt") or "").split())[:300]
+            lines.append(f"step {record.step} USER GOAL: {text}")
+        elif kind == "tool_proposal":
+            summary = str(payload.get("command") or "")
+            if payload.get("patch"):
+                summary = f"patch files={payload.get('files')}"
+            summary = " ".join(summary.split())[:200]
+            lines.append(f"step {record.step} {payload.get('tool')}: {summary}")
+        elif kind == "tool_result":
+            response = payload.get("tool_response")
+            exit_code = response.get("exit_code") if isinstance(response, dict) else None
+            if exit_code is not None:
+                lines.append(f"step {record.step} result: exit={exit_code}")
+        elif kind in ("gate_shadow_block", "gate_fail_open", "gate_block"):
+            lines.append(f"step {record.step} GATE {kind}: {payload.get('rule')}")
+    return "\n".join(lines) if lines else "(no observable actions recorded)"
+
+
+def parse_decision(raw: str) -> ReviewerDecision:
+    """Validate model output. A reviewer that emits garbage gets CONTINUE —
+    an unparseable judgment must never become an intervention."""
+    try:
+        data = json.loads(raw)
+        decision = ReviewerDecision(
+            decision=str(data["decision"]),
+            failure_class=str(data["failure_class"]),
+            reason=str(data["reason"])[:500],
+            confidence=float(data["confidence"]),
+        )
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return ReviewerDecision("continue", "none", "unparseable reviewer output", 0.0)
+    if decision.decision not in DECISIONS or decision.failure_class not in FAILURE_CLASSES:
+        return ReviewerDecision("continue", "none", "invalid reviewer output", 0.0)
+    if not 0 <= decision.confidence <= 1:
+        return ReviewerDecision("continue", "none", "invalid reviewer confidence", 0.0)
+    return decision
+
+
+def codex_runner(model: str, prompt: str) -> str:
+    """Ask a model via `codex exec` in an empty scratch dir, read-only sandbox."""
+    with tempfile.TemporaryDirectory(prefix="spotter-review-") as scratch:
+        schema = Path(scratch) / "schema.json"
+        schema.write_text(json.dumps(_SCHEMA))
+        answer = Path(scratch) / "answer.txt"
+        # "default" delegates model choice to codex — ChatGPT-account auth
+        # rejects several model ids outright (observed: gpt-5.3-spark → 400),
+        # and a rejected id costs a multi-minute retry loop, not a fast error.
+        model_args = [] if model in ("", "default") else ["-m", model]
+        result = subprocess.run(
+            [
+                "codex",
+                "exec",
+                "-C",
+                scratch,
+                "--skip-git-repo-check",
+                "--sandbox",
+                "read-only",
+                *model_args,
+                "--output-schema",
+                str(schema),
+                "--output-last-message",
+                str(answer),
+                prompt,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"codex exec failed: {result.stderr.strip()[:300]}")
+        return answer.read_text(encoding="utf-8")
+
+
+def review(
+    records: list[StepRecord],
+    model: str,
+    *,
+    window: int = 40,
+    runner: Callable[[str, str], str] = codex_runner,
+) -> ReviewerDecision:
+    prompt = _PROMPT.format(digest=build_digest(records, window))
+    return parse_decision(runner(model, prompt))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,14 +9,14 @@ def test_loads_example_configuration() -> None:
     config = SpotterConfig.from_toml(Path("spotter.example.toml"))
 
     assert config.main_agent.adapter == "codex"
-    assert config.reviewer.model == "gpt-5.3-spark"
+    assert config.reviewer.model == "default"
     assert config.observation_only is True
 
 
 def test_uses_default_reviewer_model_when_reviewer_is_omitted() -> None:
     config = SpotterConfig.from_mapping({"main_agent": {"adapter": "codex"}})
 
-    assert config.reviewer.model == "gpt-5.3-spark"
+    assert config.reviewer.model == "default"
 
 
 def test_rejects_invalid_reviewer_table() -> None:

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -1,0 +1,98 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from spotter.cli import main
+from spotter.hook import journal_path
+from spotter.reviewer import ReviewerDecision, build_digest, parse_decision, review
+from spotter.snapshot import StepJournal, StepRecord
+from spotter.trace import TraceEvent
+
+
+def _records() -> list[StepRecord]:
+    return [
+        StepRecord(0, TraceEvent("user_prompt", {"prompt": "fix the login timeout"}), None),
+        StepRecord(1, TraceEvent("tool_proposal", {"tool": "Bash", "command": "pytest -x"}), None),
+        StepRecord(2, TraceEvent("tool_result", {"tool_response": {"exit_code": 1}}), None),
+        StepRecord(3, TraceEvent("gate_shadow_block", {"rule": "git_reset_hard"}), None),
+        StepRecord(
+            4,
+            TraceEvent(
+                "reasoning_summary", {"text": "I am sure redis is the cause"}
+            ),  # must NOT reach the digest
+            None,
+        ),
+    ]
+
+
+def test_digest_is_observation_only() -> None:
+    digest = build_digest(_records())
+    assert "USER GOAL: fix the login timeout" in digest
+    assert "pytest -x" in digest and "exit=1" in digest and "git_reset_hard" in digest
+    assert "redis" not in digest  # Main's own claims are not observations (plan Q2)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "not json at all",
+        '{"decision": "halt", "failure_class": "none", "reason": "x", "confidence": 0.9}',
+        '{"decision": "nudge", "failure_class": "none", "reason": "x", "confidence": 7}',
+        '{"decision": "nudge"}',
+    ],
+)
+def test_garbage_reviewer_output_becomes_continue(raw: str) -> None:
+    decision = parse_decision(raw)
+    assert decision.decision == "continue"
+    assert decision.confidence == 0.0
+
+
+def test_valid_output_parses() -> None:
+    raw = json.dumps(
+        {
+            "decision": "verify",
+            "failure_class": "tool_failure_loop",
+            "reason": "same failing pytest retried",
+            "confidence": 0.8,
+        }
+    )
+    assert parse_decision(raw) == ReviewerDecision(
+        "verify", "tool_failure_loop", "same failing pytest retried", 0.8
+    )
+
+
+def test_review_uses_injected_runner() -> None:
+    seen: dict[str, str] = {}
+
+    def fake_runner(model: str, prompt: str) -> str:
+        seen["model"], seen["prompt"] = model, prompt
+        return (
+            '{"decision": "continue", "failure_class": "none", "reason": "ok", "confidence": 0.6}'
+        )
+
+    decision = review(_records(), "test-model", runner=fake_runner)
+    assert decision.decision == "continue"
+    assert seen["model"] == "test-model"
+    assert "pytest -x" in seen["prompt"]
+
+
+def test_review_cli_journals_shadow_decision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path))
+    journal = StepJournal(journal_path({"session_id": "rv1"}))
+    journal.record(TraceEvent("tool_proposal", {"tool": "Bash", "command": "pytest"}))
+
+    monkeypatch.setattr(
+        "spotter.cli.review",
+        lambda records, model, window: ReviewerDecision("nudge", "exploration_loop", "loop", 0.9),
+    )
+    assert main(["review", "--session", "rv1"]) == 0
+
+    records = StepJournal.load(journal_path({"session_id": "rv1"}))
+    verdict = records[-1]
+    assert verdict.event.kind == "reviewer_decision"
+    assert verdict.event.payload["shadow"] is True
+    assert verdict.event.payload["decision"] == "nudge"
+    assert verdict.event.payload["reviewed_upto"] == 0


### PR DESCRIPTION
## Plan progress

**P4 step 1 of the earn-trust ladder.** P0's exit criterion passed in #12 (truncated-rollout resume verified live), which unblocks this: a reviewer that judges but cannot touch.

| Phase | Status after this PR |
|---|---|
| P0 fork/replay | ✅ done (resume compat verified live in #12) |
| P1 observer | 🟡 collection + analyze; ceiling labeling next |
| P2 audit state | 🟡 built, wiring becomes relevant once the reviewer grows state |
| P3 gates | 🟢 shadow-deployed |
| **P4 reviewer** | **🟡 this PR: shadow mode — judge, record, inject nothing** |
| P5 ablations | 🔴 |

## What

### `spotter review --session S [--window N]`
- Builds an **observation-only digest** of the trajectory tail: commands, patch file lists, exit codes, gate flags, and the user prompt. Main's own reasoning summaries never enter as facts (plan Q2) — pinned by test.
- Asks a model via `codex exec` — zero new dependencies, existing auth, read-only sandbox, `--output-schema`-constrained JSON.
- Verdict: `continue|verify|nudge` × `none|exploration_loop|tool_failure_loop|spec_drift` + one-sentence reason + confidence.
- **Failure posture**: garbage model output degrades to `continue`/conf=0 — an unparseable judgment must never become an intervention. Reviewer subprocess failure is a printed error, never a session-affecting one.
- The verdict is appended to the journal as `reviewer_decision {shadow: true}` and **injected nowhere**.

### Hook: goal capture
`UserPromptSubmit` now journals the prompt as `user_prompt` — without intent in the digest, spec-drift judgment has nothing to anchor on.

### Model selection reality
`gpt-5.3-spark` (the documented default) is rejected by ChatGPT-account Codex auth with a 400 — and a rejected id costs a **multi-minute retry loop**, not a fast error. `model = "default"` delegates to the account's own model; the constraint and its cost are documented in code.

## First real verdict (shadow)

Ran against a live session that re-ran the same `terraform apply` five times:
```
[shadow] nudge (tool_failure_loop, conf=0.99): The agent is repeatedly rerunning
the same Terraform plan/apply strategy without observable new diagnostics…
```
Plausible — whether it is *correct* is exactly what the labeling stage decides. That is the next step: accumulate shadow verdicts, label them, then measure intervention advantage with #12's fork pairs before any injection is enabled.

## Known limits (stated)

- Reviewer currently shares the main agent's model family (account constraint) with an isolated context only; the diversity question is P5's ablation and shadow labeling does not depend on it.
- Manual/periodic invocation for now — auto-triggering from the hook comes after the reviewer earns trust.

## Verification

96 tests, ruff, mypy --strict clean. E2E: real-session shadow verdict above; digest correctness, garbage-output degradation, and journal recording pinned by tests.