### PR TITLE
feat: counterfactual experiment harness and auto shadow-review cadence

### DIFF
--- a/spotter.example.toml
+++ b/spotter.example.toml
@@ -7,3 +7,4 @@ adapter = "codex"
 # "default" uses your codex account's model. Pin an id (e.g. "gpt-5.3-spark")
 # only if your auth supports it — rejected ids fail slowly, not fast.
 model = "default"
+# every_steps = 25  # auto shadow review cadence (0 = off; spends model tokens)

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 import tomllib
 from collections.abc import Sequence
+from contextlib import suppress
+from fcntl import LOCK_EX, LOCK_NB, flock
 from pathlib import Path
 
 from spotter.codex import CodexAdapter
@@ -82,7 +84,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     config = _load_config(parser, args.config)
 
     if args.command == "hook":
-        return _hook_main(config)
+        return _hook_main(config, args.config)
     if args.command == "analyze":
         return _analyze_main(args.session)
     if args.command == "prune":
@@ -90,6 +92,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "experiment":
         if not args.session or args.step is None or not args.guidance:
             parser.error("experiment requires --session, --step and --guidance")
+        if args.pairs < 1:
+            parser.error("--pairs must be >= 1")
         try:
             results = run_experiment(
                 args.session,
@@ -212,6 +216,16 @@ def _review_main(session: str, config: SpotterConfig, *, window: int) -> int:
     """Shadow reviewer: judge the trajectory tail, journal the verdict, inject
     nothing. Injection rights are earned later via labeling + fork pairs."""
     journal_file = journal_path({"session_id": session})
+    # In-flight guard: a slow model call must not stack duplicate paid reviews
+    # of the same session when the next cadence tick arrives.
+    lock_file = journal_file.with_suffix(".review.lock")
+    lock = lock_file.open("w")
+    try:
+        flock(lock, LOCK_EX | LOCK_NB)
+    except OSError:
+        print(f"review already in flight for {session}; skipping", file=sys.stderr)
+        lock.close()
+        return 0
     try:
         records = StepJournal.load(journal_file)
     except (OSError, SnapshotError) as error:
@@ -224,6 +238,12 @@ def _review_main(session: str, config: SpotterConfig, *, window: int) -> int:
         decision = review(records, config.reviewer.model, window=window)
     except Exception as error:  # noqa: BLE001 — reviewer failure must stay observable, not fatal
         print(f"review failed: {error}", file=sys.stderr)
+        # Failure evidence belongs in the journal too — "no verdict" must be
+        # distinguishable from "reviewer silently died".
+        with suppress(SnapshotError):
+            StepJournal(journal_file).record(
+                TraceEvent("reviewer_error", {"error": str(error)[:300]})
+            )
         return 1
     StepJournal(journal_file).record(
         TraceEvent(
@@ -269,7 +289,7 @@ def _prune_main(repo: Path, *, apply: bool) -> int:
     return 0
 
 
-def _hook_main(config: SpotterConfig | None) -> int:
+def _hook_main(config: SpotterConfig | None, config_path: Path | None = None) -> int:
     """Read one hook payload from stdin, print a decision if any.
 
     Always exits 0: any failure here fails open. Breaking the Codex session
@@ -281,7 +301,7 @@ def _hook_main(config: SpotterConfig | None) -> int:
         payload = json.load(sys.stdin)
         if not isinstance(payload, dict):
             raise ValueError("hook payload must be a JSON object")
-        output = run_hook(payload, config)
+        output = run_hook(payload, config, config_path)
     except Exception as error:  # noqa: BLE001 — deliberate fail-open boundary
         print(f"spotter hook error (failing open): {error}", file=sys.stderr)
         return 0

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -7,6 +7,7 @@ import sys
 import tomllib
 from collections.abc import Sequence
 from contextlib import suppress
+from dataclasses import replace
 from fcntl import LOCK_EX, LOCK_NB, flock
 from pathlib import Path
 
@@ -58,6 +59,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--window", type=int, default=40, help="review: trajectory tail size fed to the reviewer"
     )
     parser.add_argument("--pairs", type=int, default=1, help="experiment: counterfactual pairs")
+    parser.add_argument("--model", help="review/experiment: pin the Codex model")
     parser.add_argument(
         "--check", help="experiment: success command run in each fork worktree (exit 0 = pass)"
     )
@@ -65,6 +67,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--run",
         action="store_true",
         help="experiment: actually execute the 2*pairs agent runs (costs real tokens)",
+    )
+    parser.add_argument(
+        "--keep-artifacts",
+        action="store_true",
+        help="experiment: keep forked worktrees (rollouts are always retained)",
     )
     return parser
 
@@ -102,6 +109,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 pairs=args.pairs,
                 check=args.check,
                 run=args.run,
+                model=args.model,
+                keep_artifacts=args.keep_artifacts,
             )
         except (ReplayError, SnapshotError, OSError, subprocess.SubprocessError) as error:
             print(f"experiment failed: {error}", file=sys.stderr)
@@ -114,6 +123,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             parser.error("review requires --session")
         if config is None:
             config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig())
+        if args.model:
+            config = replace(config, reviewer=replace(config.reviewer, model=args.model))
         return _review_main(args.session, config, window=args.window)
     if args.command == "fork":
         if not args.session or args.step is None:

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import subprocess
 import sys
 import tomllib
 from collections.abc import Sequence
@@ -10,6 +11,7 @@ from pathlib import Path
 from spotter.codex import CodexAdapter
 from spotter.config import ConfigurationError, MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.core import SpotterRuntime
+from spotter.experiment import results_path, run_experiment, summarize
 from spotter.gates import Gate
 from spotter.hook import journal_path, run_hook
 from spotter.replay import ReplayError, fork, plan_to_json
@@ -30,13 +32,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=["observe", "hook", "analyze", "fork", "prune", "review"],
+        choices=["observe", "hook", "analyze", "fork", "prune", "review", "experiment"],
         default="observe",
         help=(
             "observe: validate config and start; hook: Codex hook bridge (JSON on stdin); "
             "analyze: summarize journaled sessions; fork: branch a session at a step; "
             "prune: drop unreferenced refs/spotter snapshots (dry-run without --apply); "
-            "review: run the shadow reviewer on a session (records only, injects nothing)"
+            "review: run the shadow reviewer on a session (records only, injects nothing); "
+            "experiment: counterfactual fork pairs — nudge vs control (needs --run to execute)"
         ),
     )
     parser.add_argument("--config", type=Path, help="path to Spotter TOML config")
@@ -51,6 +54,15 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--window", type=int, default=40, help="review: trajectory tail size fed to the reviewer"
+    )
+    parser.add_argument("--pairs", type=int, default=1, help="experiment: counterfactual pairs")
+    parser.add_argument(
+        "--check", help="experiment: success command run in each fork worktree (exit 0 = pass)"
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="experiment: actually execute the 2*pairs agent runs (costs real tokens)",
     )
     return parser
 
@@ -75,6 +87,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _analyze_main(args.session)
     if args.command == "prune":
         return _prune_main(args.repo or Path.cwd(), apply=args.apply)
+    if args.command == "experiment":
+        if not args.session or args.step is None or not args.guidance:
+            parser.error("experiment requires --session, --step and --guidance")
+        try:
+            results = run_experiment(
+                args.session,
+                args.step,
+                args.guidance,
+                pairs=args.pairs,
+                check=args.check,
+                run=args.run,
+            )
+        except (ReplayError, SnapshotError, OSError, subprocess.SubprocessError) as error:
+            print(f"experiment failed: {error}", file=sys.stderr)
+            return 1
+        print(summarize(results))
+        print(f"rows appended to {results_path(args.session, args.step)}")
+        return 0
     if args.command == "review":
         if not args.session:
             parser.error("review requires --session")
@@ -134,10 +164,19 @@ def _analyze_main(session: str | None) -> int:
         proposals = [r for r in records if r.event.kind == "tool_proposal"]
         snapshots = sum(1 for r in records if r.snapshot)
         flagged = [r for r in records if r.event.kind in ("gate_shadow_block", "gate_fail_open")]
+        verdicts = [r for r in records if r.event.kind == "reviewer_decision"]
         print(
             f"{journal.stem}: steps={len(records)} proposals={len(proposals)} "
-            f"snapshots={snapshots} flagged={len(flagged)}"
+            f"snapshots={snapshots} flagged={len(flagged)} reviews={len(verdicts)}"
         )
+        for record in verdicts:
+            payload = record.event.payload
+            print(
+                f"  step {record.step:4d} reviewer         "
+                f"{payload.get('decision')}/{payload.get('failure_class')} "
+                f"conf={payload.get('confidence')}: "
+                f"{str(payload.get('reason'))[:100]}"
+            )
         for record in flagged:
             trigger = _trigger_for(records, record)
             summary = str(trigger.get("command") or trigger.get("patch") or trigger)

--- a/src/spotter/config.py
+++ b/src/spotter/config.py
@@ -25,6 +25,10 @@ class MainAgentConfig:
 @dataclass(frozen=True)
 class ReviewerConfig:
     model: str = DEFAULT_REVIEWER_MODEL
+    # Auto-run the SHADOW reviewer every N tool proposals (0 = off). Off by
+    # default: even shadow judgments spend the user's model tokens, and silent
+    # spending is not "safe" just because nothing is injected.
+    every_steps: int = 0
 
 
 @dataclass(frozen=True)
@@ -58,7 +62,8 @@ class SpotterConfig:
         return cls(
             main_agent=MainAgentConfig(adapter=_string(main_agent, "adapter")),
             reviewer=ReviewerConfig(
-                model=_optional_string(reviewer, "model", DEFAULT_REVIEWER_MODEL)
+                model=_optional_string(reviewer, "model", DEFAULT_REVIEWER_MODEL),
+                every_steps=_int(reviewer, "every_steps", 0),
             ),
             gates=GatesConfig(
                 forbidden_paths=_string_tuple(gates, "forbidden_paths"),
@@ -101,6 +106,13 @@ def _string_tuple(raw: dict[str, Any], key: str) -> tuple[str, ...]:
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         raise ConfigurationError(f"{key} must be a list of strings")
     return tuple(value)
+
+
+def _int(raw: dict[str, Any], key: str, default: int) -> int:
+    value = raw.get(key, default)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ConfigurationError(f"{key} must be a non-negative integer")
+    return value
 
 
 def _bool(raw: dict[str, Any], key: str, default: bool) -> bool:

--- a/src/spotter/experiment.py
+++ b/src/spotter/experiment.py
@@ -18,9 +18,12 @@ a crash loses at most one run.
 import json
 import os
 import subprocess
+import uuid
 from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 
+from spotter.hook import sanitize_session, spotter_home
 from spotter.replay import fork
 
 CONTROL_PROMPT = "Continue the task."
@@ -28,6 +31,7 @@ CONTROL_PROMPT = "Continue the task."
 
 @dataclass(frozen=True)
 class ArmResult:
+    experiment_id: str
     pair: int
     arm: str  # "control" | "guidance"
     session_id: str
@@ -37,9 +41,9 @@ class ArmResult:
 
 
 def results_path(session_id: str, step: int) -> Path:
-    base = Path(os.environ.get("SPOTTER_HOME", Path.home() / ".spotter")) / "experiments"
+    base = spotter_home() / "experiments"
     base.mkdir(parents=True, exist_ok=True)
-    return base / f"{session_id}-step{step}.jsonl"
+    return base / f"{sanitize_session(session_id)}-step{step}.jsonl"
 
 
 def _run_arm(
@@ -84,13 +88,36 @@ def run_experiment(
     codex_home: Path | None = None,
 ) -> list[ArmResult]:
     """Build (and with run=True, execute) n counterfactual pairs."""
+    if pairs < 1:
+        raise ValueError("pairs must be >= 1 — an empty experiment is not a successful one")
     out = results_path(session_id, step)
+    experiment_id = str(uuid.uuid4())
+    # Provenance header: rows are meaningless as measurements unless the exact
+    # conditions that produced them can be recovered and compared.
+    meta = {
+        "meta": True,
+        "experiment_id": experiment_id,
+        "source_session": session_id,
+        "step": step,
+        "guidance": guidance,
+        "control_prompt": CONTROL_PROMPT,
+        "check": check,
+        "sandbox": sandbox,
+        "timeout": timeout,
+        "run": run,
+        "started_at": datetime.now(UTC).isoformat(),
+    }
+    with out.open("a", encoding="utf-8") as sink:
+        sink.write(json.dumps(meta) + "\n")
     results: list[ArmResult] = []
     for pair in range(pairs):
-        for arm, prompt in (
+        arms = [
             ("control", CONTROL_PROMPT),
             ("guidance", f"{CONTROL_PROMPT} {guidance}"),
-        ):
+        ]
+        if pair % 2:  # counterbalance: time-varying backend state must not
+            arms.reverse()  # always land on the same arm (order effect)
+        for arm, prompt in arms:
             plan = fork(session_id, step, codex_home=codex_home)
             agent_exit: int | None = None
             check_exit: int | None = None
@@ -102,7 +129,9 @@ def run_experiment(
                     check_exit = subprocess.run(
                         check, shell=True, cwd=plan.worktree, capture_output=True, timeout=timeout
                     ).returncode
-            result = ArmResult(pair, arm, plan.session_id, plan.worktree, agent_exit, check_exit)
+            result = ArmResult(
+                experiment_id, pair, arm, plan.session_id, plan.worktree, agent_exit, check_exit
+            )
             results.append(result)
             with out.open("a", encoding="utf-8") as sink:  # one row per run, crash-safe
                 sink.write(json.dumps(asdict(result)) + "\n")

--- a/src/spotter/experiment.py
+++ b/src/spotter/experiment.py
@@ -1,0 +1,125 @@
+"""Same-prefix counterfactual experiment: does the nudge actually help? (plan Q3)
+
+For one branch point, build n pairs of forks and run both arms:
+- control:  resumed with a neutral "Continue the task."
+- guidance: resumed with "Continue the task." + the nudge text
+
+Both arms receive a user message, so the only difference is the guidance
+content — prompt *presence* is not a confound. Success is judged by an
+explicit --check command run in each fork's worktree afterward; without a
+check the experiment records completion only and says so, because "the agent
+finished" is not "the agent succeeded".
+
+This is the expensive machine (2n real agent runs). It never starts without
+--run, runs arms sequentially, and journals every result row immediately so
+a crash loses at most one run.
+"""
+
+import json
+import os
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from spotter.replay import fork
+
+CONTROL_PROMPT = "Continue the task."
+
+
+@dataclass(frozen=True)
+class ArmResult:
+    pair: int
+    arm: str  # "control" | "guidance"
+    session_id: str
+    worktree: str
+    agent_exit: int | None  # None = not run
+    check_exit: int | None  # None = no check command
+
+
+def results_path(session_id: str, step: int) -> Path:
+    base = Path(os.environ.get("SPOTTER_HOME", Path.home() / ".spotter")) / "experiments"
+    base.mkdir(parents=True, exist_ok=True)
+    return base / f"{session_id}-step{step}.jsonl"
+
+
+def _run_arm(
+    plan_session: str,
+    worktree: str,
+    prompt: str,
+    *,
+    sandbox: str,
+    timeout: int,
+) -> int:
+    result = subprocess.run(
+        [
+            "codex",
+            "exec",
+            "-C",
+            worktree,
+            "--skip-git-repo-check",
+            "--sandbox",
+            sandbox,
+            "resume",
+            plan_session,
+            prompt,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={**os.environ, "SPOTTER_DISABLE": "1"},
+    )
+    return result.returncode
+
+
+def run_experiment(
+    session_id: str,
+    step: int,
+    guidance: str,
+    *,
+    pairs: int = 1,
+    check: str | None = None,
+    run: bool = False,
+    sandbox: str = "workspace-write",
+    timeout: int = 1800,
+    codex_home: Path | None = None,
+) -> list[ArmResult]:
+    """Build (and with run=True, execute) n counterfactual pairs."""
+    out = results_path(session_id, step)
+    results: list[ArmResult] = []
+    for pair in range(pairs):
+        for arm, prompt in (
+            ("control", CONTROL_PROMPT),
+            ("guidance", f"{CONTROL_PROMPT} {guidance}"),
+        ):
+            plan = fork(session_id, step, codex_home=codex_home)
+            agent_exit: int | None = None
+            check_exit: int | None = None
+            if run:
+                agent_exit = _run_arm(
+                    plan.session_id, plan.worktree, prompt, sandbox=sandbox, timeout=timeout
+                )
+                if check:
+                    check_exit = subprocess.run(
+                        check, shell=True, cwd=plan.worktree, capture_output=True, timeout=timeout
+                    ).returncode
+            result = ArmResult(pair, arm, plan.session_id, plan.worktree, agent_exit, check_exit)
+            results.append(result)
+            with out.open("a", encoding="utf-8") as sink:  # one row per run, crash-safe
+                sink.write(json.dumps(asdict(result)) + "\n")
+    return results
+
+
+def summarize(results: list[ArmResult]) -> str:
+    lines = []
+    for arm in ("control", "guidance"):
+        rows = [r for r in results if r.arm == arm]
+        ran = [r for r in rows if r.agent_exit is not None]
+        passed = [r for r in ran if r.check_exit == 0]
+        checked = [r for r in ran if r.check_exit is not None]
+        if not ran:
+            lines.append(f"{arm}: {len(rows)} fork(s) prepared, not run")
+        elif not checked:
+            lines.append(f"{arm}: {len(ran)} run(s), no --check given — completion is not success")
+        else:
+            lines.append(f"{arm}: {len(passed)}/{len(checked)} passed check")
+    return "\n".join(lines)

--- a/src/spotter/experiment.py
+++ b/src/spotter/experiment.py
@@ -19,12 +19,14 @@ import json
 import os
 import subprocess
 import uuid
+from contextlib import suppress
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-from spotter.hook import sanitize_session, spotter_home
+from spotter.hook import journal_path, sanitize_session, spotter_home
 from spotter.replay import fork
+from spotter.snapshot import StepJournal
 
 CONTROL_PROMPT = "Continue the task."
 
@@ -53,24 +55,29 @@ def _run_arm(
     *,
     sandbox: str,
     timeout: int,
+    model: str | None = None,
+    codex_home: Path | None = None,
 ) -> int:
+    args = ["codex", "exec", "-C", worktree]
+    if model:
+        args += ["--model", model]
+    args += [
+        "--skip-git-repo-check",
+        "--sandbox",
+        sandbox,
+        "resume",
+        plan_session,
+        prompt,
+    ]
+    env = {**os.environ, "SPOTTER_DISABLE": "1"}
+    if codex_home:
+        env["CODEX_HOME"] = str(codex_home)
     result = subprocess.run(
-        [
-            "codex",
-            "exec",
-            "-C",
-            worktree,
-            "--skip-git-repo-check",
-            "--sandbox",
-            sandbox,
-            "resume",
-            plan_session,
-            prompt,
-        ],
+        args,
         capture_output=True,
         text=True,
         timeout=timeout,
-        env={**os.environ, "SPOTTER_DISABLE": "1"},
+        env=env,
     )
     return result.returncode
 
@@ -86,12 +93,15 @@ def run_experiment(
     sandbox: str = "workspace-write",
     timeout: int = 1800,
     codex_home: Path | None = None,
+    model: str | None = None,
+    keep_artifacts: bool = False,
 ) -> list[ArmResult]:
     """Build (and with run=True, execute) n counterfactual pairs."""
     if pairs < 1:
         raise ValueError("pairs must be >= 1 — an empty experiment is not a successful one")
     out = results_path(session_id, step)
     experiment_id = str(uuid.uuid4())
+    source_snapshot = _source_snapshot(session_id, step)
     # Provenance header: rows are meaningless as measurements unless the exact
     # conditions that produced them can be recovered and compared.
     meta = {
@@ -105,6 +115,11 @@ def run_experiment(
         "sandbox": sandbox,
         "timeout": timeout,
         "run": run,
+        "pairs": pairs,
+        "model": model or "codex-config-default",
+        "codex_version": _codex_version(),
+        "codex_home": str(codex_home or os.environ.get("CODEX_HOME") or Path.home() / ".codex"),
+        "source_snapshot": source_snapshot,
         "started_at": datetime.now(UTC).isoformat(),
     }
     with out.open("a", encoding="utf-8") as sink:
@@ -115,27 +130,83 @@ def run_experiment(
             ("control", CONTROL_PROMPT),
             ("guidance", f"{CONTROL_PROMPT} {guidance}"),
         ]
-        if pair % 2:  # counterbalance: time-varying backend state must not
-            arms.reverse()  # always land on the same arm (order effect)
+        if (pair + uuid.UUID(experiment_id).int) % 2:  # randomize pair 0, then alternate
+            arms.reverse()
         for arm, prompt in arms:
             plan = fork(session_id, step, codex_home=codex_home)
             agent_exit: int | None = None
             check_exit: int | None = None
             if run:
-                agent_exit = _run_arm(
-                    plan.session_id, plan.worktree, prompt, sandbox=sandbox, timeout=timeout
-                )
-                if check:
-                    check_exit = subprocess.run(
-                        check, shell=True, cwd=plan.worktree, capture_output=True, timeout=timeout
-                    ).returncode
+                try:
+                    agent_exit = _run_arm(
+                        plan.session_id,
+                        plan.worktree,
+                        prompt,
+                        sandbox=sandbox,
+                        timeout=timeout,
+                        model=model,
+                        codex_home=codex_home,
+                    )
+                except subprocess.TimeoutExpired:
+                    agent_exit = 124
+                if check and agent_exit == 0:
+                    try:
+                        check_exit = subprocess.run(
+                            check,
+                            shell=True,
+                            cwd=plan.worktree,
+                            capture_output=True,
+                            timeout=timeout,
+                        ).returncode
+                    except subprocess.TimeoutExpired:
+                        check_exit = 124
             result = ArmResult(
                 experiment_id, pair, arm, plan.session_id, plan.worktree, agent_exit, check_exit
             )
             results.append(result)
             with out.open("a", encoding="utf-8") as sink:  # one row per run, crash-safe
                 sink.write(json.dumps(asdict(result)) + "\n")
+            if run and not keep_artifacts:
+                _cleanup(plan.worktree)
+    with out.open("a", encoding="utf-8") as sink:
+        sink.write(
+            json.dumps(
+                {
+                    "complete": True,
+                    "experiment_id": experiment_id,
+                    "results": len(results),
+                    "finished_at": datetime.now(UTC).isoformat(),
+                }
+            )
+            + "\n"
+        )
     return results
+
+
+def _codex_version() -> str | None:
+    try:
+        result = subprocess.run(["codex", "--version"], capture_output=True, text=True, timeout=10)
+        return str(getattr(result, "stdout", "")).strip() or None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _cleanup(worktree: str) -> None:
+    if Path(worktree).exists():
+        with suppress(OSError):
+            subprocess.run(
+                ["git", "-C", worktree, "worktree", "remove", "--force", worktree],
+                capture_output=True,
+                check=False,
+            )
+
+
+def _source_snapshot(session_id: str, step: int) -> str | None:
+    try:
+        records = StepJournal.load(journal_path({"session_id": session_id}))
+    except FileNotFoundError:
+        return None
+    return next((r.snapshot for r in reversed(records[: step + 1]) if r.snapshot), None)
 
 
 def summarize(results: list[ArmResult]) -> str:
@@ -143,12 +214,37 @@ def summarize(results: list[ArmResult]) -> str:
     for arm in ("control", "guidance"):
         rows = [r for r in results if r.arm == arm]
         ran = [r for r in rows if r.agent_exit is not None]
-        passed = [r for r in ran if r.check_exit == 0]
-        checked = [r for r in ran if r.check_exit is not None]
+        valid = [r for r in ran if r.agent_exit == 0]
+        invalid = len(ran) - len(valid)
+        passed = [r for r in valid if r.check_exit == 0]
+        checked = [r for r in valid if r.check_exit is not None]
         if not ran:
             lines.append(f"{arm}: {len(rows)} fork(s) prepared, not run")
+        elif not valid:
+            lines.append(f"{arm}: {invalid} invalid agent run(s), no result")
         elif not checked:
-            lines.append(f"{arm}: {len(ran)} run(s), no --check given — completion is not success")
+            lines.append(
+                f"{arm}: {len(valid)} run(s), no --check given — completion is not success"
+            )
         else:
-            lines.append(f"{arm}: {len(passed)}/{len(checked)} passed check")
+            suffix = f", {invalid} invalid agent run(s)" if invalid else ""
+            lines.append(f"{arm}: {len(passed)}/{len(checked)} passed check{suffix}")
+    pairs = {result.pair for result in results}
+    guidance_better = control_better = tied = complete = 0
+    for pair in pairs:
+        pair_rows = {result.arm: result for result in results if result.pair == pair}
+        if set(pair_rows) != {"control", "guidance"} or any(
+            row.agent_exit != 0 or row.check_exit is None for row in pair_rows.values()
+        ):
+            continue
+        complete += 1
+        control_passed = pair_rows["control"].check_exit == 0
+        guidance_passed = pair_rows["guidance"].check_exit == 0
+        guidance_better += guidance_passed and not control_passed
+        control_better += control_passed and not guidance_passed
+        tied += control_passed == guidance_passed
+    lines.append(
+        f"pairs: n={complete}/{len(pairs)} complete; guidance better={guidance_better}, "
+        f"control better={control_better}, tied={tied}"
+    )
     return "\n".join(lines)

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -26,9 +26,12 @@ class JournalAdapter:
     def __init__(self, journal: StepJournal) -> None:
         self.journal = journal
         self.next_snapshot: str | None = None
+        self.last_proposal_number = 0
 
     def record(self, event: TraceEvent) -> None:
-        self.journal.record(event, snapshot=self.next_snapshot)
+        record = self.journal.record(event, snapshot=self.next_snapshot)
+        if event.kind == "tool_proposal":
+            self.last_proposal_number = int(record.event.payload["proposal_number"])
         self.next_snapshot = None  # attaches to the first (proposal) event only
 
 
@@ -102,7 +105,7 @@ def _maybe_spawn_shadow_review(
     config: SpotterConfig,
     payload: dict[str, Any],
     journal_file: Path,
-    config_path: Path | None,
+    proposal_number: int,
 ) -> None:
     """Fire-and-forget shadow review every N *proposals* (Wink-style cadence).
 
@@ -116,25 +119,36 @@ def _maybe_spawn_shadow_review(
     every = config.reviewer.every_steps
     if not every or os.environ.get("SPOTTER_DISABLE"):
         return
-    proposals = sum(1 for r in StepJournal.load(journal_file) if r.event.kind == "tool_proposal")
-    if proposals == 0 or proposals % every:
+    if proposal_number == 0 or proposal_number % every:
         return
     session = str(payload.get("session_id") or "")
     if not session:
         return
-    args = [sys.executable, "-m", "spotter", "review", "--session", session]
-    if config_path is not None:
-        args += ["--config", str(config_path)]  # child must judge with the user's config
+    args = [
+        sys.executable,
+        "-m",
+        "spotter",
+        "review",
+        "--session",
+        session,
+        "--model",
+        config.reviewer.model,
+    ]
     logs = spotter_home() / "logs"
     logs.mkdir(parents=True, exist_ok=True)
     with (logs / f"review-{sanitize_session(session)}.log").open("ab") as log:
-        subprocess.Popen(
-            args,
-            env={**os.environ, "SPOTTER_DISABLE": "1"},
-            stdout=log,
-            stderr=log,
-            start_new_session=True,
-        )
+        try:
+            subprocess.Popen(
+                args,
+                env={**os.environ, "SPOTTER_DISABLE": "1"},
+                stdout=log,
+                stderr=log,
+                start_new_session=True,
+            )
+        except OSError as error:
+            StepJournal(journal_file).record(
+                TraceEvent("reviewer_error", {"error": f"review process failed: {error}"[:300]})
+            )
 
 
 def run_hook(
@@ -170,7 +184,7 @@ def run_hook(
     else:
         decision = runtime.observe(event)
     if event.kind == "tool_proposal":
-        _maybe_spawn_shadow_review(config, payload, journal_file, config_path)
+        _maybe_spawn_shadow_review(config, payload, journal_file, adapter.last_proposal_number)
     if decision.allowed:
         return None  # implicit allow; stay silent on the happy path
     return json.dumps(

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -26,10 +26,9 @@ class JournalAdapter:
     def __init__(self, journal: StepJournal) -> None:
         self.journal = journal
         self.next_snapshot: str | None = None
-        self.last_step: int = -1
 
     def record(self, event: TraceEvent) -> None:
-        self.last_step = self.journal.record(event, snapshot=self.next_snapshot).step
+        self.journal.record(event, snapshot=self.next_snapshot)
         self.next_snapshot = None  # attaches to the first (proposal) event only
 
 
@@ -84,39 +83,63 @@ def event_from_hook(payload: dict[str, Any]) -> TraceEvent:
     return TraceEvent(str(name or "unknown").lower())
 
 
+def sanitize_session(session_id: object) -> str:
+    """External input headed into a filename — never let it carry a path."""
+    return re.sub(r"[^A-Za-z0-9_-]", "_", str(session_id or "unknown"))
+
+
+def spotter_home() -> Path:
+    return Path(os.environ.get("SPOTTER_HOME", Path.home() / ".spotter"))
+
+
 def journal_path(payload: dict[str, Any]) -> Path:
-    base = Path(os.environ.get("SPOTTER_HOME", Path.home() / ".spotter")) / "sessions"
+    base = spotter_home() / "sessions"
     base.mkdir(parents=True, exist_ok=True)
-    # session_id is external input headed into a filename — sanitize it.
-    session = re.sub(r"[^A-Za-z0-9_-]", "_", str(payload.get("session_id") or "unknown"))
-    return base / f"{session}.jsonl"
+    return base / f"{sanitize_session(payload.get('session_id'))}.jsonl"
 
 
-def _maybe_spawn_shadow_review(config: SpotterConfig, payload: dict[str, Any], step: int) -> None:
-    """Fire-and-forget shadow review every N proposals (Wink-style cadence).
+def _maybe_spawn_shadow_review(
+    config: SpotterConfig,
+    payload: dict[str, Any],
+    journal_file: Path,
+    config_path: Path | None,
+) -> None:
+    """Fire-and-forget shadow review every N *proposals* (Wink-style cadence).
 
-    Detached: the hook must never wait on a model call. SPOTTER_DISABLE guards
-    recursion — the review itself runs `codex exec`, whose session would
-    otherwise trigger hooks that could spawn reviews of the review.
+    The cadence counts tool proposals, not journal steps — results, prompts,
+    gate flags and the reviewer's own verdicts also consume step numbers, and
+    a cadence keyed on those drifts (and is even perturbed by the verdicts it
+    writes). Detached: the hook must never wait on a model call.
+    SPOTTER_DISABLE guards recursion. Child output goes to a per-session log —
+    a silently vanishing reviewer is not "accumulating samples".
     """
     every = config.reviewer.every_steps
     if not every or os.environ.get("SPOTTER_DISABLE"):
         return
-    if step == 0 or step % every:
+    proposals = sum(1 for r in StepJournal.load(journal_file) if r.event.kind == "tool_proposal")
+    if proposals == 0 or proposals % every:
         return
     session = str(payload.get("session_id") or "")
     if not session:
         return
-    subprocess.Popen(
-        [sys.executable, "-m", "spotter", "review", "--session", session],
-        env={**os.environ, "SPOTTER_DISABLE": "1"},
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-    )
+    args = [sys.executable, "-m", "spotter", "review", "--session", session]
+    if config_path is not None:
+        args += ["--config", str(config_path)]  # child must judge with the user's config
+    logs = spotter_home() / "logs"
+    logs.mkdir(parents=True, exist_ok=True)
+    with (logs / f"review-{sanitize_session(session)}.log").open("ab") as log:
+        subprocess.Popen(
+            args,
+            env={**os.environ, "SPOTTER_DISABLE": "1"},
+            stdout=log,
+            stderr=log,
+            start_new_session=True,
+        )
 
 
-def run_hook(payload: dict[str, Any], config: SpotterConfig) -> str | None:
+def run_hook(
+    payload: dict[str, Any], config: SpotterConfig, config_path: Path | None = None
+) -> str | None:
     """Process one hook invocation. Returns stdout JSON, or None to allow."""
     cwd = payload.get("cwd")
     gate = Gate(
@@ -124,7 +147,8 @@ def run_hook(payload: dict[str, Any], config: SpotterConfig) -> str | None:
         block_dependency_changes=config.gates.block_dependency_changes,
         root=str(cwd) if isinstance(cwd, str) else None,
     )
-    adapter = JournalAdapter(StepJournal(journal_path(payload)))
+    journal_file = journal_path(payload)
+    adapter = JournalAdapter(StepJournal(journal_file))
     runtime = SpotterRuntime(config, adapter, gate)
     event = event_from_hook(payload)
     if (
@@ -146,7 +170,7 @@ def run_hook(payload: dict[str, Any], config: SpotterConfig) -> str | None:
     else:
         decision = runtime.observe(event)
     if event.kind == "tool_proposal":
-        _maybe_spawn_shadow_review(config, payload, adapter.last_step)
+        _maybe_spawn_shadow_review(config, payload, journal_file, config_path)
     if decision.allowed:
         return None  # implicit allow; stay silent on the happy path
     return json.dumps(

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -8,6 +8,8 @@ losing an observation is recoverable, Codex dying mid-turn is not.
 import json
 import os
 import re
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -24,9 +26,10 @@ class JournalAdapter:
     def __init__(self, journal: StepJournal) -> None:
         self.journal = journal
         self.next_snapshot: str | None = None
+        self.last_step: int = -1
 
     def record(self, event: TraceEvent) -> None:
-        self.journal.record(event, snapshot=self.next_snapshot)
+        self.last_step = self.journal.record(event, snapshot=self.next_snapshot).step
         self.next_snapshot = None  # attaches to the first (proposal) event only
 
 
@@ -89,6 +92,30 @@ def journal_path(payload: dict[str, Any]) -> Path:
     return base / f"{session}.jsonl"
 
 
+def _maybe_spawn_shadow_review(config: SpotterConfig, payload: dict[str, Any], step: int) -> None:
+    """Fire-and-forget shadow review every N proposals (Wink-style cadence).
+
+    Detached: the hook must never wait on a model call. SPOTTER_DISABLE guards
+    recursion — the review itself runs `codex exec`, whose session would
+    otherwise trigger hooks that could spawn reviews of the review.
+    """
+    every = config.reviewer.every_steps
+    if not every or os.environ.get("SPOTTER_DISABLE"):
+        return
+    if step == 0 or step % every:
+        return
+    session = str(payload.get("session_id") or "")
+    if not session:
+        return
+    subprocess.Popen(
+        [sys.executable, "-m", "spotter", "review", "--session", session],
+        env={**os.environ, "SPOTTER_DISABLE": "1"},
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
 def run_hook(payload: dict[str, Any], config: SpotterConfig) -> str | None:
     """Process one hook invocation. Returns stdout JSON, or None to allow."""
     cwd = payload.get("cwd")
@@ -118,6 +145,8 @@ def run_hook(payload: dict[str, Any], config: SpotterConfig) -> str | None:
             decision = runtime.observe(event)
     else:
         decision = runtime.observe(event)
+    if event.kind == "tool_proposal":
+        _maybe_spawn_shadow_review(config, payload, adapter.last_step)
     if decision.allowed:
         return None  # implicit allow; stay silent on the happy path
     return json.dumps(

--- a/src/spotter/reviewer.py
+++ b/src/spotter/reviewer.py
@@ -10,6 +10,7 @@ exit codes, gate flags — never Main's own summaries as facts (plan Q2).
 """
 
 import json
+import os
 import subprocess
 import tempfile
 from collections.abc import Callable
@@ -132,6 +133,9 @@ def codex_runner(model: str, prompt: str) -> str:
             capture_output=True,
             text=True,
             timeout=300,
+            # The reviewer's own codex session must not journal-trigger more
+            # reviews of itself.
+            env={**os.environ, "SPOTTER_DISABLE": "1"},
         )
         if result.returncode != 0:
             raise RuntimeError(f"codex exec failed: {result.stderr.strip()[:300]}")

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -119,16 +119,36 @@ class StepJournal:
 
     def record(self, event: TraceEvent, snapshot: str | None = None) -> StepRecord:
         lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+        state_path = self.path.with_suffix(self.path.suffix + ".state")
         with lock_path.open("w") as lock:
             flock(lock, LOCK_EX)
             try:
-                step = len(self.load(self.path, repair_tail=True)) if self.path.exists() else 0
-                record = StepRecord(step, event, snapshot)
+                state: dict[str, int] | None = None
+                if state_path.exists() and self.path.exists():
+                    try:
+                        candidate = json.loads(state_path.read_text())
+                        if candidate.get("size") == self.path.stat().st_size:
+                            state = candidate
+                    except (json.JSONDecodeError, OSError):
+                        pass
+                if state is None:
+                    records = self.load(self.path, repair_tail=True) if self.path.exists() else []
+                    state = {
+                        "steps": len(records),
+                        "proposals": sum(r.event.kind == "tool_proposal" for r in records),
+                    }
+                step = state["steps"]
+                payload = dict(event.payload)
+                if event.kind == "tool_proposal":
+                    state["proposals"] += 1
+                    payload["proposal_number"] = state["proposals"]
+                stored_event = TraceEvent(event.kind, payload)
+                record = StepRecord(step, stored_event, snapshot)
                 line = json.dumps(
                     {
                         "step": record.step,
-                        "kind": event.kind,
-                        "payload": event.payload,
+                        "kind": stored_event.kind,
+                        "payload": stored_event.payload,
                         "snapshot": snapshot,
                     },
                     ensure_ascii=False,
@@ -137,6 +157,11 @@ class StepJournal:
                     journal.write(line + "\n")
                     journal.flush()
                     os.fsync(journal.fileno())
+                state["steps"] += 1
+                state["size"] = self.path.stat().st_size
+                temporary = state_path.with_suffix(state_path.suffix + ".tmp")
+                temporary.write_text(json.dumps(state))
+                os.replace(temporary, state_path)
                 return record
             finally:
                 flock(lock, LOCK_UN)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,4 +1,7 @@
 import json
+import subprocess
+import uuid
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -43,6 +46,8 @@ def test_results_carry_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
     assert meta["guidance"] == "look at the trace"
     assert meta["check"] == "pytest -q"
     assert meta["sandbox"] and meta["timeout"] and meta["started_at"]
+    assert meta["pairs"] == 1
+    assert rows[-1]["complete"] is True and rows[-1]["finished_at"]
     # every row is linked to its conditions via the experiment id
     assert all(row["experiment_id"] == meta["experiment_id"] for row in rows[1:])
     assert all(r.experiment_id == meta["experiment_id"] for r in results)
@@ -64,9 +69,12 @@ def test_results_path_is_traversal_safe() -> None:
 def test_arm_order_is_counterbalanced(monkeypatch: pytest.MonkeyPatch) -> None:
     """PR #15 review P1: control-always-first bakes order effects into results."""
     monkeypatch.setattr(experiment, "fork", _fake_fork({}))
+    monkeypatch.setattr("spotter.experiment.uuid.uuid4", lambda: uuid.UUID(int=0))
     prompts: list[str] = []
 
-    def record_prompt(s: str, w: str, prompt: str, *, sandbox: str, timeout: int) -> int:
+    def record_prompt(
+        s: str, w: str, prompt: str, *, sandbox: str, timeout: int, **kwargs: object
+    ) -> int:
         prompts.append(prompt)
         return 0
 
@@ -85,14 +93,15 @@ def test_empty_experiment_is_an_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_check_runs_in_each_fork_worktree(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(experiment, "fork", _fake_fork({}))
-    monkeypatch.setattr(experiment, "_run_arm", lambda s, w, p, *, sandbox, timeout: 0)
+    monkeypatch.setattr(experiment, "_run_arm", lambda *args, **kwargs: 0)
     checks: list[str] = []
 
     class FakeCompleted:
         returncode = 0
 
     def fake_subprocess_run(cmd: object, **kwargs: object) -> FakeCompleted:
-        checks.append(str(kwargs.get("cwd")))
+        if kwargs.get("cwd"):
+            checks.append(str(kwargs["cwd"]))
         return FakeCompleted()
 
     monkeypatch.setattr("spotter.experiment.subprocess.run", fake_subprocess_run)
@@ -135,17 +144,116 @@ def test_cadence_counts_proposals_not_journal_steps(monkeypatch: pytest.MonkeyPa
     assert all("review" in cmd for cmd in spawned)
 
 
+def test_cadence_is_atomic_under_concurrent_proposals(monkeypatch: pytest.MonkeyPatch) -> None:
+    spawned: list[list[str]] = []
+    monkeypatch.setattr(
+        "spotter.hook.subprocess.Popen", lambda cmd, **kw: spawned.append(list(cmd))
+    )
+    config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig(every_steps=2), GatesConfig())
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        list(pool.map(lambda n: run_hook(_cadence_payload("PreToolUse", n), config), range(2)))
+    assert len(spawned) == 1
+
+
 def test_cadence_forwards_user_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """PR #15 review P0: the child must judge with the user's reviewer config."""
     spawned: list[list[str]] = []
     monkeypatch.setattr(
         "spotter.hook.subprocess.Popen", lambda cmd, **kw: spawned.append(list(cmd))
     )
-    config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig(every_steps=1), GatesConfig())
+    config = SpotterConfig(
+        MainAgentConfig("codex"), ReviewerConfig("custom-model", every_steps=1), GatesConfig()
+    )
     config_path = tmp_path / "spotter.toml"
     run_hook(_cadence_payload("PreToolUse", 0), config, config_path)
-    assert spawned and "--config" in spawned[0]
-    assert str(config_path) in spawned[0]
+    assert spawned and spawned[0][-2:] == ["--model", "custom-model"]
+
+
+def test_failed_agent_is_not_checked_or_counted_as_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(experiment, "fork", _fake_fork({}))
+    monkeypatch.setattr(experiment, "_run_arm", lambda *args, **kwargs: 1)
+    checks: list[tuple[object, ...]] = []
+
+    def record_check(*args: object, **kwargs: object) -> object:
+        checks.append(args)
+        return type("Completed", (), {"returncode": 0})()
+
+    monkeypatch.setattr("spotter.experiment.subprocess.run", record_check)
+    results = run_experiment("s1", 5, "hint", run=True, check="pytest -q")
+    assert all(result.check_exit is None for result in results)
+    assert "invalid agent run" in summarize(results)
+    assert not any(args and args[0] == "pytest -q" for args in checks)
+
+
+def test_timeout_does_not_abort_experiment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(experiment, "fork", _fake_fork({}))
+    calls = 0
+
+    def run(*args: object, **kwargs: object) -> int:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise subprocess.TimeoutExpired("codex", 1)
+        return 0
+
+    monkeypatch.setattr(experiment, "_run_arm", run)
+    monkeypatch.setattr(experiment, "_cleanup", lambda worktree: None)
+    results = run_experiment("s1", 5, "hint", pairs=3, run=True)
+    assert len(results) == 6
+    assert [result.agent_exit for result in results].count(124) == 1
+
+
+def test_cleanup_is_best_effort_and_preserves_rollout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    rollout = tmp_path / "rollout.jsonl"
+    rollout.write_text("transcript")
+    monkeypatch.setattr(
+        "spotter.experiment.subprocess.run",
+        lambda *args, **kwargs: type("Completed", (), {"returncode": 1})(),
+    )
+    experiment._cleanup(str(worktree))
+    assert rollout.read_text() == "transcript"
+
+
+def test_summary_compares_complete_pairs() -> None:
+    rows = [
+        ArmResult("e", 0, "control", "s", "/wt", 0, 1),
+        ArmResult("e", 0, "guidance", "s", "/wt", 0, 0),
+        ArmResult("e", 1, "control", "s", "/wt", 124, None),
+        ArmResult("e", 1, "guidance", "s", "/wt", 0, 0),
+    ]
+    assert "n=1/2 complete; guidance better=1" in summarize(rows)
+
+
+def test_run_arm_forwards_model_and_codex_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    class Completed:
+        returncode = 0
+
+    def record_call(args: list[str], **kwargs: object) -> Completed:
+        calls.append((args, kwargs))
+        return Completed()
+
+    monkeypatch.setattr("spotter.experiment.subprocess.run", record_call)
+    experiment._run_arm(
+        "fork",
+        "/wt",
+        "go",
+        sandbox="workspace-write",
+        timeout=1,
+        model="gpt-test",
+        codex_home=tmp_path,
+    )
+    assert calls[0][0][4:6] == ["--model", "gpt-test"]
+    assert calls[0][1]["env"]["CODEX_HOME"] == str(tmp_path)  # type: ignore[index]
 
 
 def test_cadence_recursion_guard(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -4,13 +4,14 @@ from pathlib import Path
 import pytest
 
 import spotter.experiment as experiment
+from spotter.config import GatesConfig, MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.experiment import ArmResult, results_path, run_experiment, summarize
-from spotter.hook import run_hook
+from spotter.hook import run_hook, spotter_home
 from spotter.replay import ForkPlan
 
 
 @pytest.fixture(autouse=True)
-def spotter_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("SPOTTER_HOME", str(tmp_path))
     return tmp_path
 
@@ -30,22 +31,61 @@ def test_experiment_without_run_only_prepares(monkeypatch: pytest.MonkeyPatch) -
     assert len(results) == 4  # 2 pairs x 2 arms
     assert {r.arm for r in results} == {"control", "guidance"}
     assert all(r.agent_exit is None for r in results)  # nothing executed
+
+
+def test_results_carry_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PR #15 review P1: rows without conditions are not measurements."""
+    monkeypatch.setattr(experiment, "fork", _fake_fork({}))
+    results = run_experiment("s1", 5, "look at the trace", check="pytest -q")
     rows = [json.loads(line) for line in results_path("s1", 5).read_text().splitlines()]
-    assert len(rows) == 4  # every fork journaled immediately
+    meta = rows[0]
+    assert meta["meta"] is True
+    assert meta["guidance"] == "look at the trace"
+    assert meta["check"] == "pytest -q"
+    assert meta["sandbox"] and meta["timeout"] and meta["started_at"]
+    # every row is linked to its conditions via the experiment id
+    assert all(row["experiment_id"] == meta["experiment_id"] for row in rows[1:])
+    assert all(r.experiment_id == meta["experiment_id"] for r in results)
+    # a rerun with different conditions is distinguishable
+    monkeypatch.setattr(experiment, "fork", _fake_fork({}))
+    run_experiment("s1", 5, "different guidance")
+    rows2 = [json.loads(line) for line in results_path("s1", 5).read_text().splitlines()]
+    metas = [r for r in rows2 if r.get("meta")]
+    assert len(metas) == 2 and metas[0]["experiment_id"] != metas[1]["experiment_id"]
 
 
-def test_experiment_run_executes_both_arms_and_checks(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_results_path_is_traversal_safe() -> None:
+    """PR #15 review P1: session_id is external input."""
+    path = results_path("../../outside", 1)
+    assert path.parent == spotter_home() / "experiments"
+    assert ".." not in path.name
+
+
+def test_arm_order_is_counterbalanced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PR #15 review P1: control-always-first bakes order effects into results."""
     monkeypatch.setattr(experiment, "fork", _fake_fork({}))
     prompts: list[str] = []
 
-    def fake_run_arm(
-        session: str, worktree: str, prompt: str, *, sandbox: str, timeout: int
-    ) -> int:
+    def record_prompt(s: str, w: str, prompt: str, *, sandbox: str, timeout: int) -> int:
         prompts.append(prompt)
         return 0
 
+    monkeypatch.setattr(experiment, "_run_arm", record_prompt)
+    results = run_experiment("s1", 5, "hint", pairs=2, run=True)
+    assert [r.arm for r in results] == ["control", "guidance", "guidance", "control"]
+    assert prompts[0] == "Continue the task." and "hint" in prompts[1]
+    assert "hint" in prompts[2] and prompts[3] == "Continue the task."
+
+
+def test_empty_experiment_is_an_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PR #15 review P2: --pairs 0 must not succeed with zero data."""
+    with pytest.raises(ValueError, match="pairs must be >= 1"):
+        run_experiment("s1", 5, "hint", pairs=0)
+
+
+def test_check_runs_in_each_fork_worktree(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(experiment, "fork", _fake_fork({}))
+    monkeypatch.setattr(experiment, "_run_arm", lambda s, w, p, *, sandbox, timeout: 0)
     checks: list[str] = []
 
     class FakeCompleted:
@@ -55,47 +95,65 @@ def test_experiment_run_executes_both_arms_and_checks(
         checks.append(str(kwargs.get("cwd")))
         return FakeCompleted()
 
-    monkeypatch.setattr(experiment, "_run_arm", fake_run_arm)
     monkeypatch.setattr("spotter.experiment.subprocess.run", fake_subprocess_run)
-
-    results = run_experiment("s1", 5, "look at the trace", run=True, check="pytest -q")
-    assert prompts == ["Continue the task.", "Continue the task. look at the trace"]
-    assert checks == ["/wt/1", "/wt/2"]  # check ran in each fork worktree
+    results = run_experiment("s1", 5, "hint", run=True, check="pytest -q")
+    assert checks == ["/wt/1", "/wt/2"]
     assert all(r.check_exit == 0 for r in results)
 
 
 def test_summarize_refuses_to_call_completion_success() -> None:
-    ran_no_check = [ArmResult(0, "control", "s", "/wt", 0, None)]
+    ran_no_check = [ArmResult("e", 0, "control", "s", "/wt", 0, None)]
     assert "completion is not success" in summarize(ran_no_check)
-    prepared = [ArmResult(0, "guidance", "s", "/wt", None, None)]
+    prepared = [ArmResult("e", 0, "guidance", "s", "/wt", None, None)]
     assert "not run" in summarize(prepared)
 
 
-def test_hook_spawns_shadow_review_on_cadence(monkeypatch: pytest.MonkeyPatch) -> None:
-    from spotter.config import GatesConfig, MainAgentConfig, ReviewerConfig, SpotterConfig
+def _cadence_payload(kind: str, n: int) -> dict[str, object]:
+    return {
+        "hook_event_name": kind,
+        "session_id": "cadence",
+        "cwd": "/nonexistent",
+        "tool_name": "Bash",
+        "tool_use_id": f"c{n}",
+        "tool_input": {"command": "true"},
+    }
 
+
+def test_cadence_counts_proposals_not_journal_steps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PR #15 review P0: results/prompts/verdicts consume steps; the cadence
+    must key on proposals only. Realistic flow: proposal+result pairs."""
     spawned: list[list[str]] = []
     monkeypatch.setattr(
         "spotter.hook.subprocess.Popen", lambda cmd, **kw: spawned.append(list(cmd))
     )
     config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig(every_steps=2), GatesConfig())
+    for n in range(4):
+        run_hook(_cadence_payload("PreToolUse", n), config)  # proposals 1..4
+        run_hook(_cadence_payload("PostToolUse", n), config)  # results consume steps too
+    # proposals 2 and 4 hit the cadence; journal steps alone would drift
+    assert len(spawned) == 2
+    assert all("review" in cmd for cmd in spawned)
 
-    def payload(n: int) -> dict[str, object]:
-        return {
-            "hook_event_name": "PreToolUse",
-            "session_id": "cadence",
-            "cwd": "/nonexistent",
-            "tool_name": "Bash",
-            "tool_use_id": f"c{n}",
-            "tool_input": {"command": "true"},
-        }
 
-    for n in range(4):  # steps 0..3
-        run_hook(payload(n), config)
-    assert len(spawned) == 1  # step 2 only (0 excluded, cadence 2)
-    assert "review" in spawned[0]
+def test_cadence_forwards_user_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """PR #15 review P0: the child must judge with the user's reviewer config."""
+    spawned: list[list[str]] = []
+    monkeypatch.setattr(
+        "spotter.hook.subprocess.Popen", lambda cmd, **kw: spawned.append(list(cmd))
+    )
+    config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig(every_steps=1), GatesConfig())
+    config_path = tmp_path / "spotter.toml"
+    run_hook(_cadence_payload("PreToolUse", 0), config, config_path)
+    assert spawned and "--config" in spawned[0]
+    assert str(config_path) in spawned[0]
 
-    # recursion guard: a review's own codex session must not spawn reviews
+
+def test_cadence_recursion_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    spawned: list[list[str]] = []
+    monkeypatch.setattr(
+        "spotter.hook.subprocess.Popen", lambda cmd, **kw: spawned.append(list(cmd))
+    )
     monkeypatch.setenv("SPOTTER_DISABLE", "1")
-    run_hook(payload(4), config)
-    assert len(spawned) == 1
+    config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig(every_steps=1), GatesConfig())
+    run_hook(_cadence_payload("PreToolUse", 0), config)
+    assert spawned == []

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,0 +1,101 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import spotter.experiment as experiment
+from spotter.experiment import ArmResult, results_path, run_experiment, summarize
+from spotter.hook import run_hook
+from spotter.replay import ForkPlan
+
+
+@pytest.fixture(autouse=True)
+def spotter_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _fake_fork(counter: dict[str, int]) -> object:
+    def fake(session_id: str, step: int, *, codex_home: object = None) -> ForkPlan:
+        counter["n"] = counter.get("n", 0) + 1
+        n = counter["n"]
+        return ForkPlan(f"fork-{n}", step, f"/wt/{n}", f"/ro/{n}", "codex ...")
+
+    return fake
+
+
+def test_experiment_without_run_only_prepares(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(experiment, "fork", _fake_fork({}))
+    results = run_experiment("s1", 5, "check the stack trace", pairs=2)
+    assert len(results) == 4  # 2 pairs x 2 arms
+    assert {r.arm for r in results} == {"control", "guidance"}
+    assert all(r.agent_exit is None for r in results)  # nothing executed
+    rows = [json.loads(line) for line in results_path("s1", 5).read_text().splitlines()]
+    assert len(rows) == 4  # every fork journaled immediately
+
+
+def test_experiment_run_executes_both_arms_and_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(experiment, "fork", _fake_fork({}))
+    prompts: list[str] = []
+
+    def fake_run_arm(
+        session: str, worktree: str, prompt: str, *, sandbox: str, timeout: int
+    ) -> int:
+        prompts.append(prompt)
+        return 0
+
+    checks: list[str] = []
+
+    class FakeCompleted:
+        returncode = 0
+
+    def fake_subprocess_run(cmd: object, **kwargs: object) -> FakeCompleted:
+        checks.append(str(kwargs.get("cwd")))
+        return FakeCompleted()
+
+    monkeypatch.setattr(experiment, "_run_arm", fake_run_arm)
+    monkeypatch.setattr("spotter.experiment.subprocess.run", fake_subprocess_run)
+
+    results = run_experiment("s1", 5, "look at the trace", run=True, check="pytest -q")
+    assert prompts == ["Continue the task.", "Continue the task. look at the trace"]
+    assert checks == ["/wt/1", "/wt/2"]  # check ran in each fork worktree
+    assert all(r.check_exit == 0 for r in results)
+
+
+def test_summarize_refuses_to_call_completion_success() -> None:
+    ran_no_check = [ArmResult(0, "control", "s", "/wt", 0, None)]
+    assert "completion is not success" in summarize(ran_no_check)
+    prepared = [ArmResult(0, "guidance", "s", "/wt", None, None)]
+    assert "not run" in summarize(prepared)
+
+
+def test_hook_spawns_shadow_review_on_cadence(monkeypatch: pytest.MonkeyPatch) -> None:
+    from spotter.config import GatesConfig, MainAgentConfig, ReviewerConfig, SpotterConfig
+
+    spawned: list[list[str]] = []
+    monkeypatch.setattr(
+        "spotter.hook.subprocess.Popen", lambda cmd, **kw: spawned.append(list(cmd))
+    )
+    config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig(every_steps=2), GatesConfig())
+
+    def payload(n: int) -> dict[str, object]:
+        return {
+            "hook_event_name": "PreToolUse",
+            "session_id": "cadence",
+            "cwd": "/nonexistent",
+            "tool_name": "Bash",
+            "tool_use_id": f"c{n}",
+            "tool_input": {"command": "true"},
+        }
+
+    for n in range(4):  # steps 0..3
+        run_hook(payload(n), config)
+    assert len(spawned) == 1  # step 2 only (0 excluded, cadence 2)
+    assert "review" in spawned[0]
+
+    # recursion guard: a review's own codex session must not spawn reviews
+    monkeypatch.setenv("SPOTTER_DISABLE", "1")
+    run_hook(payload(4), config)
+    assert len(spawned) == 1

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -96,3 +96,24 @@ def test_review_cli_journals_shadow_decision(
     assert verdict.event.payload["shadow"] is True
     assert verdict.event.payload["decision"] == "nudge"
     assert verdict.event.payload["reviewed_upto"] == 0
+
+
+def test_inflight_lock_skips_duplicate_review(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """PR #15 review P1: a slow review must not stack paid duplicates."""
+    from fcntl import LOCK_EX, flock
+
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path))
+    journal = StepJournal(journal_path({"session_id": "busy"}))
+    journal.record(TraceEvent("tool_proposal", {"command": "pytest"}))
+
+    called: list[bool] = []
+    monkeypatch.setattr("spotter.cli.review", lambda *a, **k: called.append(True))
+
+    lock_file = journal_path({"session_id": "busy"}).with_suffix(".review.lock")
+    with lock_file.open("w") as held:
+        flock(held, LOCK_EX)  # simulate an in-flight review
+        assert main(["review", "--session", "busy"]) == 0
+    assert called == []  # no duplicate model call
+    assert "already in flight" in capsys.readouterr().err

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -84,6 +84,14 @@ def test_journal_roundtrip_prefix_and_resume(tmp_path: Path) -> None:
     assert [r.step for r in StepJournal.load(path)] == [0, 1, 2]
 
 
+def test_proposal_number_does_not_mutate_input_event(tmp_path: Path) -> None:
+    journal = StepJournal(tmp_path / "journal.jsonl")
+    event = TraceEvent("tool_proposal", {"tool": "Bash"})
+    record = journal.record(event)
+    assert "proposal_number" not in event.payload
+    assert record.event.payload["proposal_number"] == 1
+
+
 def test_journal_tolerates_torn_tail_but_rejects_reordering(tmp_path: Path) -> None:
     path = tmp_path / "journal.jsonl"
     journal = StepJournal(path)


### PR DESCRIPTION
## Plan progress

**P4 step 2: the measurement machine.** #13 gave the reviewer judgment (shadow); this PR builds the apparatus that decides whether those judgments deserve injection rights — same-prefix counterfactual pairs (plan Q3) — plus the cadence that accumulates shadow samples.

| Phase | Status after this PR |
|---|---|
| P0 fork/replay | ✅ |
| P1 observer | 🟡 + analyze now surfaces reviewer verdicts (labeling surface) |
| P3 gates | 🟢 shadow |
| **P4 reviewer** | **🟡 shadow judgment (#13) + auto-cadence + counterfactual harness (this PR). Injection still off — it turns on only if these experiments show positive intervention advantage** |
| P5 ablations | 🔴 |

## What

### `spotter experiment --session S --step K --guidance TEXT [--pairs N] [--check CMD] [--run]`
- Builds N **same-prefix fork pairs** on #11/#12's fork machinery.
- **Confound control**: both arms receive a user message — control gets `Continue the task.`, guidance gets the same sentence plus the nudge. Prompt *presence* is identical; only guidance *content* differs.
- **Success is only `--check`** (exit 0 in the fork worktree). `summarize()` explicitly refuses to call completion success: "the agent finished" ≠ "the agent succeeded".
- **Cost posture**: nothing executes without `--run` (2N real agent runs). Every result row is appended to `~/.spotter/experiments/<session>-step<K>.jsonl` immediately — a crash loses at most one run.

### Auto shadow-review cadence
- Hook spawns the shadow reviewer every `reviewer.every_steps` proposals, **detached** — the hook never waits on a model call.
- **Default 0 (off)**: even shadow judgments spend the user's tokens; silent spending is not "safe" just because nothing is injected.
- `SPOTTER_DISABLE` breaks recursion: the review runs `codex exec`, whose own session's hooks must not spawn reviews of the review. Pinned by test.

### `spotter analyze`
Now lists reviewer verdicts per session alongside gate flags — the surface where shadow judgments get labeled true/false.

## Verification

100 tests, ruff, mypy --strict clean. E2E: prepare-only experiment against the real forked session produced a control/guidance pair with journaled rows and zero agent runs; cadence spawn + recursion guard pinned by tests.

## What this unlocks

The full P4 loop is now mechanical:
1. sessions run → shadow verdicts accumulate on cadence
2. `spotter analyze` → label verdicts
3. for labeled nudge-worthy branch points: `spotter experiment --run --check` → intervention advantage, measured
4. only a positive result turns injection on