### PR TITLE
feat: label store and metrics — the evidence every plan gate waits on

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,18 @@ To record Codex tool calls, add the bridge to `.codex/hooks.json` and review it 
 Without `--config`, the hook only records observations. Set `observation_only = false`
 explicitly to enforce configured gates.
 
-Recorded sessions can then be summarized with `spotter analyze`. Run `spotter --help`
-for the complete command and option list.
+Recorded sessions can then be summarized with `spotter analyze`, judged one flag at a
+time with `spotter label`, and scored with `spotter metrics`:
+
+```bash
+spotter analyze                                              # what was flagged, with context
+spotter label --session <id> --step 7 --verdict fp --note "quoted, not executed"
+spotter metrics                                              # gate FP rate, reviewer precision
+```
+
+Labels are stored outside the session journal, so a reviewer never reads its own report
+card. `spotter metrics` reports every rate with its coverage and withholds rates that
+rest on too few labels. Run `spotter --help` for the complete command and option list.
 
 ## Documentation
 

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -17,7 +17,7 @@ from spotter.core import SpotterRuntime
 from spotter.experiment import results_path, run_experiment, summarize
 from spotter.gates import Gate
 from spotter.hook import journal_path, run_hook
-from spotter.labels import LabelError, add_label
+from spotter.labels import LabelError, add_label, valid_session
 from spotter.metrics import Tally, merge, tally_session
 from spotter.replay import ReplayError, fork, plan_to_json
 from spotter.reviewer import review
@@ -108,6 +108,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     config = _load_config(parser, args.config)
+    # One boundary check for every command that names a session: sanitizing
+    # instead of rejecting maps distinct ids onto one file ("a/b" -> "a_b").
+    if args.session is not None and not valid_session(args.session):
+        parser.error(f"--session {args.session!r} is not a valid session id")
 
     if args.command == "hook":
         return _hook_main(config, args.config)
@@ -337,7 +341,11 @@ def _metrics_main(session: str | None) -> int:
         except SnapshotError as error:
             print(f"{journal.stem}: unreadable journal ({error})", file=sys.stderr)
             continue
-        session_gates, session_reviewer, session_ceiling = tally_session(journal.stem, records)
+        try:
+            session_gates, session_reviewer, session_ceiling = tally_session(journal.stem, records)
+        except LabelError as error:
+            print(f"metrics aborted: {error}", file=sys.stderr)
+            return 1
         for rule, tally in session_gates.items():
             gates[rule] = merge(gates.get(rule, Tally()), tally)
         reviewer = merge(reviewer, session_reviewer)
@@ -347,7 +355,7 @@ def _metrics_main(session: str | None) -> int:
     if not gates:
         print("  no gate flags recorded")
     for rule, tally in sorted(gates.items()):
-        print("  " + tally.rate_line(rule, "true-positive"))
+        print("  " + tally.rate_line(rule, "false-positive", count_negative=True))
     print("P4 reviewer precision (label each verify/nudge tp|fp):")
     print("  " + reviewer.rate_line("interventions", "correct"))
     print("P1 observability ceiling (label failed sessions visible|invisible):")

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -17,6 +17,8 @@ from spotter.core import SpotterRuntime
 from spotter.experiment import results_path, run_experiment, summarize
 from spotter.gates import Gate
 from spotter.hook import journal_path, run_hook
+from spotter.labels import LabelError, add_label
+from spotter.metrics import Tally, merge, tally_session
 from spotter.replay import ReplayError, fork, plan_to_json
 from spotter.reviewer import review
 from spotter.snapshot import (
@@ -35,14 +37,26 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=["observe", "hook", "analyze", "fork", "prune", "review", "experiment"],
+        choices=[
+            "observe",
+            "hook",
+            "analyze",
+            "fork",
+            "prune",
+            "review",
+            "experiment",
+            "label",
+            "metrics",
+        ],
         default="observe",
         help=(
             "observe: validate config and start; hook: Codex hook bridge (JSON on stdin); "
             "analyze: summarize journaled sessions; fork: branch a session at a step; "
             "prune: drop unreferenced refs/spotter snapshots (dry-run without --apply); "
             "review: run the shadow reviewer on a session (records only, injects nothing); "
-            "experiment: counterfactual fork pairs — nudge vs control (needs --run to execute)"
+            "experiment: counterfactual fork pairs — nudge vs control (needs --run to execute); "
+            "label: record a human verdict on a gate flag, reviewer decision, or session; "
+            "metrics: gate FP rate, reviewer precision and observability ceiling from labels"
         ),
     )
     parser.add_argument("--config", type=Path, help="path to Spotter TOML config")
@@ -68,6 +82,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="experiment: actually execute the 2*pairs agent runs (costs real tokens)",
     )
+    parser.add_argument(
+        "--verdict",
+        help="label: tp|fp|unclear for a step, visible|invisible|unclear for a session",
+    )
+    parser.add_argument("--note", default="", help="label: why (free text, stored verbatim)")
     parser.add_argument(
         "--keep-artifacts",
         action="store_true",
@@ -118,6 +137,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(summarize(results))
         print(f"rows appended to {results_path(args.session, args.step)}")
         return 0
+    if args.command == "label":
+        if not args.session or not args.verdict:
+            parser.error("label requires --session and --verdict")
+        return _label_main(args.session, args.step, args.verdict, args.note)
+    if args.command == "metrics":
+        return _metrics_main(args.session)
     if args.command == "review":
         if not args.session:
             parser.error("review requires --session")
@@ -274,6 +299,59 @@ def _review_main(session: str, config: SpotterConfig, *, window: int) -> int:
         f"[shadow] {decision.decision} ({decision.failure_class}, "
         f"conf={decision.confidence:.2f}): {decision.reason}"
     )
+    return 0
+
+
+def _label_main(session: str, step: int | None, verdict: str, note: str) -> int:
+    """Record a human verdict. Labels live outside the journal so the reviewer
+    never reads its own report card."""
+    try:
+        records = StepJournal.load(journal_path({"session_id": session}))
+    except (OSError, SnapshotError) as error:
+        print(f"label failed: {error}", file=sys.stderr)
+        return 1
+    try:
+        label = add_label(session, step, verdict, note, records)
+    except LabelError as error:
+        print(f"label failed: {error}", file=sys.stderr)
+        return 1
+    target = "session" if step is None else f"step {step}"
+    print(f"labeled {session} {target}: {label.verdict}")
+    return 0
+
+
+def _metrics_main(session: str | None) -> int:
+    """Report the three numbers the plan gates on, each with its coverage."""
+    sessions_dir = journal_path({"session_id": "probe"}).parent
+    journals = sorted(sessions_dir.glob("*.jsonl"))
+    if session:
+        journals = [j for j in journals if j == journal_path({"session_id": session})]
+    if not journals:
+        print("no journals found", file=sys.stderr)
+        return 1
+    gates: dict[str, Tally] = {}
+    reviewer = ceiling = Tally()
+    for journal in journals:
+        try:
+            records = StepJournal.load(journal)
+        except SnapshotError as error:
+            print(f"{journal.stem}: unreadable journal ({error})", file=sys.stderr)
+            continue
+        session_gates, session_reviewer, session_ceiling = tally_session(journal.stem, records)
+        for rule, tally in session_gates.items():
+            gates[rule] = merge(gates.get(rule, Tally()), tally)
+        reviewer = merge(reviewer, session_reviewer)
+        ceiling = merge(ceiling, session_ceiling)
+
+    print("P3 gate false positives (label each flag tp|fp):")
+    if not gates:
+        print("  no gate flags recorded")
+    for rule, tally in sorted(gates.items()):
+        print("  " + tally.rate_line(rule, "true-positive"))
+    print("P4 reviewer precision (label each verify/nudge tp|fp):")
+    print("  " + reviewer.rate_line("interventions", "correct"))
+    print("P1 observability ceiling (label failed sessions visible|invisible):")
+    print("  " + ceiling.rate_line("sessions", "visible"))
     return 0
 
 

--- a/src/spotter/labels.py
+++ b/src/spotter/labels.py
@@ -17,7 +17,6 @@ later differs, the label is reported as stale rather than silently counted
 
 import hashlib
 import json
-import os
 import re
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
@@ -149,8 +148,11 @@ def matches(label: Label, records: list[StepRecord]) -> bool:
     return fingerprint(records[label.step]) == label.fingerprint
 
 
-_SESSION_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_SESSION_RE = re.compile(r"[A-Za-z0-9_-]+")
 
 
 def valid_session(session: str) -> bool:
-    return bool(_SESSION_RE.match(session)) and os.sep not in session
+    """fullmatch, not match: Python's ``$`` also matches before a trailing
+    newline, so "a\n" passed as valid and then sanitized to "a_" — sharing a
+    journal and label file with the distinct session "a_"."""
+    return bool(_SESSION_RE.fullmatch(session))

--- a/src/spotter/labels.py
+++ b/src/spotter/labels.py
@@ -1,0 +1,124 @@
+"""Human labels over recorded trajectories — the input to every plan decision.
+
+Three gates in the plan wait on the same thing: was a judgment right?
+- P1 observability ceiling: was a failure visible in the observable stream?
+- P3 active gates: what fraction of shadow blocks were false positives?
+- P4 injection: what fraction of reviewer nudges were correct?
+
+Labels live in their own store, NOT in the session journal. Two reasons:
+the journal is what the reviewer reads, so labels inside it would feed the
+judge its own report card; and appending to the journal would shift step
+numbering that forks and prior labels point at.
+
+Each label pins a fingerprint of what was labeled. If the journal record
+later differs, the label is reported as stale rather than silently counted
+— a label that has drifted off its target is not evidence.
+"""
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from spotter.hook import sanitize_session, spotter_home
+from spotter.snapshot import StepRecord
+
+STEP_VERDICTS = ("tp", "fp", "unclear")
+SESSION_VERDICTS = ("visible", "invisible", "unclear")
+
+
+class LabelError(ValueError):
+    """Raised when a label cannot be applied to the thing it names."""
+
+
+@dataclass(frozen=True)
+class Label:
+    session: str
+    step: int | None  # None = session-level (observability ceiling)
+    verdict: str
+    fingerprint: str
+    note: str
+    labeled_at: str
+
+
+def labels_path(session: str) -> Path:
+    base = spotter_home() / "labels"
+    base.mkdir(parents=True, exist_ok=True)
+    return base / f"{sanitize_session(session)}.jsonl"
+
+
+def fingerprint(record: StepRecord) -> str:
+    """Identity of the labeled thing, insensitive to unrelated journal growth."""
+    payload = {k: v for k, v in record.event.payload.items() if k != "proposal_number"}
+    blob = json.dumps([record.event.kind, payload], sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+
+
+def add_label(
+    session: str, step: int | None, verdict: str, note: str, records: list[StepRecord]
+) -> Label:
+    allowed = SESSION_VERDICTS if step is None else STEP_VERDICTS
+    if verdict not in allowed:
+        raise LabelError(f"verdict must be one of {allowed} for this target")
+    if step is None:
+        mark = "session"
+    else:
+        if not 0 <= step < len(records):
+            raise LabelError(f"step {step} out of range (journal has {len(records)} steps)")
+        mark = fingerprint(records[step])
+    label = Label(session, step, verdict, mark, note, datetime.now(UTC).isoformat())
+    with labels_path(session).open("a", encoding="utf-8") as sink:
+        sink.write(json.dumps(asdict(label), ensure_ascii=False) + "\n")
+    return label
+
+
+def load_labels(session: str) -> dict[int | None, Label]:
+    """Latest label wins per target; corrupt lines are skipped loudly enough
+    to be visible in coverage counts rather than silently dropped."""
+    path = labels_path(session)
+    labels: dict[int | None, Label] = {}
+    if not path.exists():
+        return labels
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            raw = json.loads(line)
+            label = Label(
+                session=str(raw["session"]),
+                step=raw["step"],
+                verdict=str(raw["verdict"]),
+                fingerprint=str(raw["fingerprint"]),
+                note=str(raw.get("note") or ""),
+                labeled_at=str(raw.get("labeled_at") or ""),
+            )
+        except (json.JSONDecodeError, KeyError, TypeError):
+            continue
+        labels[label.step] = label
+    return labels
+
+
+def sessions_with_labels() -> list[str]:
+    base = spotter_home() / "labels"
+    if not base.exists():
+        return []
+    return sorted(p.stem for p in base.glob("*.jsonl"))
+
+
+def matches(label: Label, records: list[StepRecord]) -> bool:
+    """False when the label has drifted off the record it was applied to."""
+    if label.step is None:
+        return True
+    if not 0 <= label.step < len(records):
+        return False
+    return fingerprint(records[label.step]) == label.fingerprint
+
+
+_SESSION_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def valid_session(session: str) -> bool:
+    return bool(_SESSION_RE.match(session)) and os.sep not in session

--- a/src/spotter/labels.py
+++ b/src/spotter/labels.py
@@ -27,7 +27,14 @@ from spotter.hook import sanitize_session, spotter_home
 from spotter.snapshot import StepRecord
 
 STEP_VERDICTS = ("tp", "fp", "unclear")
-SESSION_VERDICTS = ("visible", "invisible", "unclear")
+# "na" disposes of a session that had no failure to see — without it the
+# ceiling denominator can never reach full coverage, and a metric whose
+# coverage cannot be completed is a metric nobody will ever trust.
+SESSION_VERDICTS = ("visible", "invisible", "unclear", "na")
+
+# Only records metrics actually scores may be labeled. Accepting a label on
+# anything else prints success and then silently discards the judgment.
+LABELABLE_KINDS = ("gate_shadow_block", "gate_block", "reviewer_decision")
 
 
 class LabelError(ValueError):
@@ -57,6 +64,17 @@ def fingerprint(record: StepRecord) -> str:
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
 
 
+def session_fingerprint(records: list[StepRecord]) -> str:
+    """Identity of a whole trajectory.
+
+    A ceiling verdict is a judgment about the trajectory as a whole, so it
+    must go stale when the trajectory grows — label sessions once they are
+    finished, not while they are still running.
+    """
+    tail = fingerprint(records[-1]) if records else "empty"
+    return f"session:{len(records)}:{tail}"
+
+
 def add_label(
     session: str, step: int | None, verdict: str, note: str, records: list[StepRecord]
 ) -> Label:
@@ -64,11 +82,18 @@ def add_label(
     if verdict not in allowed:
         raise LabelError(f"verdict must be one of {allowed} for this target")
     if step is None:
-        mark = "session"
+        mark = session_fingerprint(records)
     else:
         if not 0 <= step < len(records):
             raise LabelError(f"step {step} out of range (journal has {len(records)} steps)")
-        mark = fingerprint(records[step])
+        target = records[step]
+        if target.event.kind not in LABELABLE_KINDS:
+            raise LabelError(
+                f"step {step} is {target.event.kind}; only {LABELABLE_KINDS} are scored"
+            )
+        if target.event.payload.get("decision") == "continue":
+            raise LabelError(f"step {step} is a CONTINUE verdict; silence is not scored")
+        mark = fingerprint(target)
     label = Label(session, step, verdict, mark, note, datetime.now(UTC).isoformat())
     with labels_path(session).open("a", encoding="utf-8") as sink:
         sink.write(json.dumps(asdict(label), ensure_ascii=False) + "\n")
@@ -76,13 +101,17 @@ def add_label(
 
 
 def load_labels(session: str) -> dict[int | None, Label]:
-    """Latest label wins per target; corrupt lines are skipped loudly enough
-    to be visible in coverage counts rather than silently dropped."""
+    """Latest label wins per target.
+
+    A corrupt line raises. Skipping it would resurrect the verdict it was
+    meant to overwrite: a torn write on a correction silently reinstates the
+    judgment the labeler had just rejected, which is worse than no data.
+    """
     path = labels_path(session)
     labels: dict[int | None, Label] = {}
     if not path.exists():
         return labels
-    for line in path.read_text(encoding="utf-8").splitlines():
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
         if not line.strip():
             continue
         try:
@@ -95,8 +124,11 @@ def load_labels(session: str) -> dict[int | None, Label]:
                 note=str(raw.get("note") or ""),
                 labeled_at=str(raw.get("labeled_at") or ""),
             )
-        except (json.JSONDecodeError, KeyError, TypeError):
-            continue
+        except (json.JSONDecodeError, KeyError, TypeError) as error:
+            raise LabelError(
+                f"{path.name} line {number} is unreadable ({error}); "
+                "a dropped correction would revive the verdict it replaced"
+            ) from error
         labels[label.step] = label
     return labels
 
@@ -109,9 +141,9 @@ def sessions_with_labels() -> list[str]:
 
 
 def matches(label: Label, records: list[StepRecord]) -> bool:
-    """False when the label has drifted off the record it was applied to."""
+    """False when the label has drifted off what it was applied to."""
     if label.step is None:
-        return True
+        return session_fingerprint(records) == label.fingerprint
     if not 0 <= label.step < len(records):
         return False
     return fingerprint(records[label.step]) == label.fingerprint

--- a/src/spotter/metrics.py
+++ b/src/spotter/metrics.py
@@ -1,0 +1,93 @@
+"""Turn labels into the three numbers the plan gates on.
+
+Every rate is reported with its coverage (labeled / total). A rate computed
+from a handful of labels is not a measurement, and this module refuses to
+present one as if it were: rates below FULL coverage are marked provisional,
+and rates with fewer than MIN_SAMPLES labels are withheld entirely.
+"""
+
+from dataclasses import dataclass
+
+from spotter.labels import Label, load_labels, matches
+from spotter.snapshot import StepRecord
+
+MIN_SAMPLES = 5
+GATE_KINDS = ("gate_shadow_block", "gate_block")
+
+
+@dataclass(frozen=True)
+class Tally:
+    labeled: int = 0
+    total: int = 0
+    positive: int = 0  # tp for gates/reviewer, "visible" for ceiling
+    negative: int = 0
+    unclear: int = 0
+    stale: int = 0
+
+    def plus(self, verdict: str | None, *, stale: bool = False) -> "Tally":
+        return Tally(
+            labeled=self.labeled + (verdict is not None and not stale),
+            total=self.total + 1,
+            positive=self.positive + (verdict in ("tp", "visible") and not stale),
+            negative=self.negative + (verdict in ("fp", "invisible") and not stale),
+            unclear=self.unclear + (verdict == "unclear" and not stale),
+            stale=self.stale + stale,
+        )
+
+    def rate_line(self, name: str, positive_name: str) -> str:
+        decided = self.positive + self.negative
+        coverage = f"{self.labeled}/{self.total} labeled"
+        if self.stale:
+            coverage += f", {self.stale} stale"
+        if decided < MIN_SAMPLES:
+            return f"{name}: {coverage} — too few decided labels ({decided}) to state a rate"
+        rate = self.positive / decided
+        qualifier = "" if self.labeled == self.total else " (provisional: coverage incomplete)"
+        return f"{name}: {positive_name} {rate:.0%} of {decided} decided; {coverage}{qualifier}"
+
+
+def _verdict(
+    labels: dict[int | None, Label], records: list[StepRecord], step: int | None
+) -> tuple[str | None, bool]:
+    label = labels.get(step)
+    if label is None:
+        return None, False
+    if not matches(label, records):
+        return label.verdict, True
+    return label.verdict, False
+
+
+def tally_session(session: str, records: list[StepRecord]) -> tuple[dict[str, Tally], Tally, Tally]:
+    """Return (gate tallies by rule, reviewer tally, ceiling tally)."""
+    labels = load_labels(session)
+    gates: dict[str, Tally] = {}
+    reviewer = Tally()
+    ceiling = Tally()
+    for record in records:
+        kind = record.event.kind
+        if kind in GATE_KINDS:
+            rule = str(record.event.payload.get("rule") or "unknown")
+            verdict, stale = _verdict(labels, records, record.step)
+            gates[rule] = gates.get(rule, Tally()).plus(verdict, stale=stale)
+        elif kind == "reviewer_decision":
+            # Only interventions are judgeable: a CONTINUE is silence, and
+            # scoring silence as correct would inflate precision for free.
+            if record.event.payload.get("decision") == "continue":
+                continue
+            verdict, stale = _verdict(labels, records, record.step)
+            reviewer = reviewer.plus(verdict, stale=stale)
+    if None in labels:
+        verdict, _ = _verdict(labels, records, None)
+        ceiling = ceiling.plus(verdict)
+    return gates, reviewer, ceiling
+
+
+def merge(left: Tally, right: Tally) -> Tally:
+    return Tally(
+        labeled=left.labeled + right.labeled,
+        total=left.total + right.total,
+        positive=left.positive + right.positive,
+        negative=left.negative + right.negative,
+        unclear=left.unclear + right.unclear,
+        stale=left.stale + right.stale,
+    )

--- a/src/spotter/metrics.py
+++ b/src/spotter/metrics.py
@@ -22,28 +22,36 @@ class Tally:
     positive: int = 0  # tp for gates/reviewer, "visible" for ceiling
     negative: int = 0
     unclear: int = 0
+    not_applicable: int = 0  # session had no failure to see
     stale: int = 0
 
     def plus(self, verdict: str | None, *, stale: bool = False) -> "Tally":
+        counted = verdict is not None and not stale
         return Tally(
-            labeled=self.labeled + (verdict is not None and not stale),
+            labeled=self.labeled + counted,
             total=self.total + 1,
-            positive=self.positive + (verdict in ("tp", "visible") and not stale),
-            negative=self.negative + (verdict in ("fp", "invisible") and not stale),
-            unclear=self.unclear + (verdict == "unclear" and not stale),
+            positive=self.positive + (counted and verdict in ("tp", "visible")),
+            negative=self.negative + (counted and verdict in ("fp", "invisible")),
+            unclear=self.unclear + (counted and verdict == "unclear"),
+            not_applicable=self.not_applicable + (counted and verdict == "na"),
             stale=self.stale + stale,
         )
 
-    def rate_line(self, name: str, positive_name: str) -> str:
+    def rate_line(self, name: str, measure: str, *, count_negative: bool = False) -> str:
+        """One reported rate. `measure` must name what is counted — a header
+        that says false positives while printing the true-positive share
+        points the reader's decision the wrong way."""
         decided = self.positive + self.negative
         coverage = f"{self.labeled}/{self.total} labeled"
+        if self.not_applicable:
+            coverage += f", {self.not_applicable} n/a"
         if self.stale:
             coverage += f", {self.stale} stale"
         if decided < MIN_SAMPLES:
             return f"{name}: {coverage} — too few decided labels ({decided}) to state a rate"
-        rate = self.positive / decided
+        rate = (self.negative if count_negative else self.positive) / decided
         qualifier = "" if self.labeled == self.total else " (provisional: coverage incomplete)"
-        return f"{name}: {positive_name} {rate:.0%} of {decided} decided; {coverage}{qualifier}"
+        return f"{name}: {measure} {rate:.0%} of {decided} decided; {coverage}{qualifier}"
 
 
 def _verdict(
@@ -76,9 +84,11 @@ def tally_session(session: str, records: list[StepRecord]) -> tuple[dict[str, Ta
                 continue
             verdict, stale = _verdict(labels, records, record.step)
             reviewer = reviewer.plus(verdict, stale=stale)
-    if None in labels:
-        verdict, _ = _verdict(labels, records, None)
-        ceiling = ceiling.plus(verdict)
+    # Every examined session is in the ceiling denominator, labeled or not.
+    # Counting only labeled sessions would report 1/1 coverage after judging
+    # one session out of a hundred.
+    verdict, stale = _verdict(labels, records, None)
+    ceiling = ceiling.plus(verdict, stale=stale)
     return gates, reviewer, ceiling
 
 
@@ -89,5 +99,6 @@ def merge(left: Tally, right: Tally) -> Tally:
         positive=left.positive + right.positive,
         negative=left.negative + right.negative,
         unclear=left.unclear + right.unclear,
+        not_applicable=left.not_applicable + right.not_applicable,
         stale=left.stale + right.stale,
     )

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -5,7 +5,7 @@ import pytest
 from spotter.cli import main
 from spotter.hook import journal_path
 from spotter.labels import LabelError, add_label, labels_path, load_labels, matches
-from spotter.metrics import MIN_SAMPLES, Tally, tally_session
+from spotter.metrics import MIN_SAMPLES, Tally, merge, tally_session
 from spotter.snapshot import StepJournal, StepRecord
 from spotter.trace import TraceEvent
 
@@ -34,37 +34,97 @@ def _flagged(n: int) -> list[TraceEvent]:
 def test_labels_never_enter_the_journal() -> None:
     """The reviewer reads the journal; labels there would feed it its own
     report card, and would shift step numbers forks point at."""
-    records = _journal("s1", [TraceEvent("tool_proposal", {"command": "x"})])
-    add_label("s1", 0, "fp", "quoted text", records)
+    records = _journal("s1", _flagged(1))
+    add_label("s1", 1, "fp", "quoted text", records)
     after = StepJournal.load(journal_path({"session_id": "s1"}))
-    assert [r.event.kind for r in after] == ["tool_proposal"]
+    assert [r.event.kind for r in after] == ["tool_proposal", "gate_shadow_block"]
     assert labels_path("s1").exists()
 
 
 def test_latest_label_wins() -> None:
-    records = _journal("s1", [TraceEvent("tool_proposal", {"command": "x"})])
-    add_label("s1", 0, "tp", "first call", records)
-    add_label("s1", 0, "fp", "on reflection", records)
-    assert load_labels("s1")[0].verdict == "fp"
+    records = _journal("s1", _flagged(1))
+    add_label("s1", 1, "tp", "first call", records)
+    add_label("s1", 1, "fp", "on reflection", records)
+    assert load_labels("s1")[1].verdict == "fp"
 
 
 def test_verdict_vocabulary_is_enforced_per_target() -> None:
-    records = _journal("s1", [TraceEvent("tool_proposal", {})])
+    records = _journal("s1", _flagged(1))
     with pytest.raises(LabelError, match="verdict must be one of"):
-        add_label("s1", 0, "visible", "", records)  # session verdict on a step
+        add_label("s1", 1, "visible", "", records)  # session verdict on a step
     with pytest.raises(LabelError, match="verdict must be one of"):
         add_label("s1", None, "tp", "", records)  # step verdict on a session
     with pytest.raises(LabelError, match="out of range"):
         add_label("s1", 99, "tp", "", records)
 
 
+def test_only_scored_records_accept_labels() -> None:
+    """PR #17 review P1: a label metrics will never read must not report success."""
+    records = _journal(
+        "s1",
+        [
+            TraceEvent("tool_proposal", {"command": "x"}),
+            TraceEvent("gate_shadow_block", {"rule": "r"}),
+            TraceEvent("reviewer_decision", {"decision": "continue"}),
+        ],
+    )
+    with pytest.raises(LabelError, match="only .* are scored"):
+        add_label("s1", 0, "fp", "", records)  # tool_proposal is not scored
+    with pytest.raises(LabelError, match="silence is not scored"):
+        add_label("s1", 2, "tp", "", records)  # CONTINUE is never counted
+    add_label("s1", 1, "fp", "", records)  # the gate flag is fine
+
+
 def test_label_goes_stale_when_its_target_changes() -> None:
-    records = _journal("s1", [TraceEvent("tool_proposal", {"command": "original"})])
-    add_label("s1", 0, "fp", "", records)
-    label = load_labels("s1")[0]
+    records = _journal("s1", _flagged(1))
+    add_label("s1", 1, "fp", "", records)
+    label = load_labels("s1")[1]
     assert matches(label, records)
-    drifted = _journal("s2", [TraceEvent("tool_proposal", {"command": "different"})])
+    drifted = _journal("s2", [TraceEvent("tool_proposal", {}), TraceEvent("gate_shadow_block", {})])
     assert not matches(label, drifted)
+
+
+def test_session_label_goes_stale_when_the_trajectory_grows() -> None:
+    """PR #17 review P1: a ceiling verdict judges the whole trajectory, so it
+    cannot stay current while that trajectory keeps growing."""
+    records = _journal("s1", _flagged(1))
+    add_label("s1", None, "visible", "", records)
+    label = load_labels("s1")[None]
+    assert matches(label, records)
+    grown = _journal("s1", [TraceEvent("tool_proposal", {"command": "later"})])
+    assert not matches(label, grown)
+
+
+def test_corrupt_label_line_raises_instead_of_reviving_the_old_verdict() -> None:
+    """PR #17 review P1: silently skipping a torn correction reinstates the
+    verdict the labeler had just rejected."""
+    records = _journal("s1", _flagged(1))
+    add_label("s1", 1, "tp", "first", records)
+    with labels_path("s1").open("a", encoding="utf-8") as sink:
+        sink.write('{"session": "s1", "step": 1, "verdict": "fp"')  # torn correction
+    with pytest.raises(LabelError, match="unreadable"):
+        load_labels("s1")
+
+
+def test_ceiling_denominator_counts_every_examined_session() -> None:
+    """PR #17 review P0: counting only labeled sessions reports 1/1 coverage
+    after judging one session out of many."""
+    labeled = _journal("s1", _flagged(1))
+    add_label("s1", None, "visible", "", labeled)
+    unlabeled = _journal("s2", _flagged(1))
+    _, _, judged = tally_session("s1", labeled)
+    _, _, unjudged = tally_session("s2", unlabeled)
+    combined = merge(judged, unjudged)
+    assert combined.total == 2 and combined.labeled == 1
+
+
+def test_na_disposes_of_sessions_without_a_failure() -> None:
+    records = _journal("s1", _flagged(1))
+    add_label("s1", None, "na", "no failure in this session", records)
+    _, _, ceiling = tally_session("s1", records)
+    assert ceiling.labeled == 1 and ceiling.not_applicable == 1
+    assert ceiling.positive == 0 and ceiling.negative == 0
+    assert "n/a" in ceiling.rate_line("sessions", "visible")
 
 
 def test_stale_labels_are_not_counted_as_evidence() -> None:
@@ -94,7 +154,9 @@ def test_rate_is_withheld_below_minimum_samples() -> None:
     for step in (1, 3):
         add_label("s1", step, "fp", "", records)
     gates, _, _ = tally_session("s1", records)
-    line = gates["git_reset_hard"].rate_line("git_reset_hard", "true-positive")
+    line = gates["git_reset_hard"].rate_line(
+        "git_reset_hard", "false-positive", count_negative=True
+    )
     assert "too few decided labels" in line
     assert "%" not in line  # no headline number from two samples
 
@@ -105,14 +167,20 @@ def test_rate_is_marked_provisional_until_coverage_is_complete() -> None:
     for step in flag_steps[:MIN_SAMPLES]:
         add_label("s1", step, "fp", "", records)
     gates, _, _ = tally_session("s1", records)
-    line = gates["git_reset_hard"].rate_line("git_reset_hard", "true-positive")
+    line = gates["git_reset_hard"].rate_line(
+        "git_reset_hard", "false-positive", count_negative=True
+    )
     assert "provisional" in line and f"{MIN_SAMPLES}/{MIN_SAMPLES + 2} labeled" in line
 
     for step in flag_steps[MIN_SAMPLES:]:
         add_label("s1", step, "fp", "", records)
     gates, _, _ = tally_session("s1", records)
-    complete = gates["git_reset_hard"].rate_line("git_reset_hard", "true-positive")
-    assert "provisional" not in complete and "true-positive 0%" in complete
+    complete = gates["git_reset_hard"].rate_line(
+        "git_reset_hard", "false-positive", count_negative=True
+    )
+    # all seven labels were fp: the gate report must show 100% false positives,
+    # not the 0% true-positive share the old wording printed (PR #17 review P2)
+    assert "provisional" not in complete and "false-positive 100%" in complete
 
 
 def test_unclear_labels_count_as_coverage_but_not_as_a_verdict() -> None:
@@ -134,6 +202,22 @@ def test_cli_label_and_metrics_roundtrip(capsys: pytest.CaptureFixture[str]) -> 
 
 
 def test_cli_label_rejects_bad_verdict(capsys: pytest.CaptureFixture[str]) -> None:
-    _journal("s1", [TraceEvent("tool_proposal", {})])
-    assert main(["label", "--session", "s1", "--step", "0", "--verdict", "nope"]) == 1
+    _journal("s1", _flagged(1))
+    assert main(["label", "--session", "s1", "--step", "1", "--verdict", "nope"]) == 1
     assert "verdict must be one of" in capsys.readouterr().err
+
+
+def test_cli_rejects_session_ids_that_collide_after_sanitizing() -> None:
+    """PR #17 review P1: 'a/b' and 'a_b' must not share one label file."""
+    for bad in ("a/b", "../../outside", "with space"):
+        with pytest.raises(SystemExit):
+            main(["label", "--session", bad, "--step", "1", "--verdict", "fp"])
+
+
+def test_cli_metrics_aborts_on_unreadable_labels(capsys: pytest.CaptureFixture[str]) -> None:
+    records = _journal("s1", _flagged(1))
+    add_label("s1", 1, "fp", "", records)
+    with labels_path("s1").open("a", encoding="utf-8") as sink:
+        sink.write("{torn")
+    assert main(["metrics", "--session", "s1"]) == 1
+    assert "metrics aborted" in capsys.readouterr().err

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,139 @@
+from pathlib import Path
+
+import pytest
+
+from spotter.cli import main
+from spotter.hook import journal_path
+from spotter.labels import LabelError, add_label, labels_path, load_labels, matches
+from spotter.metrics import MIN_SAMPLES, Tally, tally_session
+from spotter.snapshot import StepJournal, StepRecord
+from spotter.trace import TraceEvent
+
+
+@pytest.fixture(autouse=True)
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _journal(session: str, events: list[TraceEvent]) -> list[StepRecord]:
+    journal = StepJournal(journal_path({"session_id": session}))
+    for event in events:
+        journal.record(event)
+    return StepJournal.load(journal_path({"session_id": session}))
+
+
+def _flagged(n: int) -> list[TraceEvent]:
+    events: list[TraceEvent] = []
+    for i in range(n):
+        events.append(TraceEvent("tool_proposal", {"command": f"cmd{i}"}))
+        events.append(TraceEvent("gate_shadow_block", {"rule": "git_reset_hard"}))
+    return events
+
+
+def test_labels_never_enter_the_journal() -> None:
+    """The reviewer reads the journal; labels there would feed it its own
+    report card, and would shift step numbers forks point at."""
+    records = _journal("s1", [TraceEvent("tool_proposal", {"command": "x"})])
+    add_label("s1", 0, "fp", "quoted text", records)
+    after = StepJournal.load(journal_path({"session_id": "s1"}))
+    assert [r.event.kind for r in after] == ["tool_proposal"]
+    assert labels_path("s1").exists()
+
+
+def test_latest_label_wins() -> None:
+    records = _journal("s1", [TraceEvent("tool_proposal", {"command": "x"})])
+    add_label("s1", 0, "tp", "first call", records)
+    add_label("s1", 0, "fp", "on reflection", records)
+    assert load_labels("s1")[0].verdict == "fp"
+
+
+def test_verdict_vocabulary_is_enforced_per_target() -> None:
+    records = _journal("s1", [TraceEvent("tool_proposal", {})])
+    with pytest.raises(LabelError, match="verdict must be one of"):
+        add_label("s1", 0, "visible", "", records)  # session verdict on a step
+    with pytest.raises(LabelError, match="verdict must be one of"):
+        add_label("s1", None, "tp", "", records)  # step verdict on a session
+    with pytest.raises(LabelError, match="out of range"):
+        add_label("s1", 99, "tp", "", records)
+
+
+def test_label_goes_stale_when_its_target_changes() -> None:
+    records = _journal("s1", [TraceEvent("tool_proposal", {"command": "original"})])
+    add_label("s1", 0, "fp", "", records)
+    label = load_labels("s1")[0]
+    assert matches(label, records)
+    drifted = _journal("s2", [TraceEvent("tool_proposal", {"command": "different"})])
+    assert not matches(label, drifted)
+
+
+def test_stale_labels_are_not_counted_as_evidence() -> None:
+    records = _journal("s1", _flagged(1))
+    add_label("s1", 1, "fp", "", records)
+    drifted = _journal("s2", [TraceEvent("tool_proposal", {}), TraceEvent("gate_shadow_block", {})])
+    gates, _, _ = tally_session("s1", drifted)
+    tally = gates["unknown"]
+    assert tally.stale == 1 and tally.labeled == 0
+
+
+def test_continue_verdicts_are_not_scored() -> None:
+    """Scoring silence as correct would inflate reviewer precision for free."""
+    records = _journal(
+        "s1",
+        [
+            TraceEvent("reviewer_decision", {"decision": "continue"}),
+            TraceEvent("reviewer_decision", {"decision": "nudge"}),
+        ],
+    )
+    _, reviewer, _ = tally_session("s1", records)
+    assert reviewer.total == 1
+
+
+def test_rate_is_withheld_below_minimum_samples() -> None:
+    records = _journal("s1", _flagged(2))
+    for step in (1, 3):
+        add_label("s1", step, "fp", "", records)
+    gates, _, _ = tally_session("s1", records)
+    line = gates["git_reset_hard"].rate_line("git_reset_hard", "true-positive")
+    assert "too few decided labels" in line
+    assert "%" not in line  # no headline number from two samples
+
+
+def test_rate_is_marked_provisional_until_coverage_is_complete() -> None:
+    records = _journal("s1", _flagged(MIN_SAMPLES + 2))
+    flag_steps = [r.step for r in records if r.event.kind == "gate_shadow_block"]
+    for step in flag_steps[:MIN_SAMPLES]:
+        add_label("s1", step, "fp", "", records)
+    gates, _, _ = tally_session("s1", records)
+    line = gates["git_reset_hard"].rate_line("git_reset_hard", "true-positive")
+    assert "provisional" in line and f"{MIN_SAMPLES}/{MIN_SAMPLES + 2} labeled" in line
+
+    for step in flag_steps[MIN_SAMPLES:]:
+        add_label("s1", step, "fp", "", records)
+    gates, _, _ = tally_session("s1", records)
+    complete = gates["git_reset_hard"].rate_line("git_reset_hard", "true-positive")
+    assert "provisional" not in complete and "true-positive 0%" in complete
+
+
+def test_unclear_labels_count_as_coverage_but_not_as_a_verdict() -> None:
+    tally = Tally().plus("unclear").plus("tp").plus(None)
+    assert tally.total == 3 and tally.labeled == 2 and tally.unclear == 1
+    assert tally.positive + tally.negative == 1
+
+
+def test_cli_label_and_metrics_roundtrip(capsys: pytest.CaptureFixture[str]) -> None:
+    _journal("s1", _flagged(1))
+    assert main(["label", "--session", "s1", "--step", "1", "--verdict", "fp"]) == 0
+    assert main(["label", "--session", "s1", "--verdict", "invisible"]) == 0
+    assert main(["metrics", "--session", "s1"]) == 0
+    out = capsys.readouterr().out
+    assert "P3 gate false positives" in out
+    assert "P4 reviewer precision" in out
+    assert "P1 observability ceiling" in out
+    assert "too few decided labels" in out  # honest about n=1
+
+
+def test_cli_label_rejects_bad_verdict(capsys: pytest.CaptureFixture[str]) -> None:
+    _journal("s1", [TraceEvent("tool_proposal", {})])
+    assert main(["label", "--session", "s1", "--step", "0", "--verdict", "nope"]) == 1
+    assert "verdict must be one of" in capsys.readouterr().err

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -3,8 +3,15 @@ from pathlib import Path
 import pytest
 
 from spotter.cli import main
-from spotter.hook import journal_path
-from spotter.labels import LabelError, add_label, labels_path, load_labels, matches
+from spotter.hook import journal_path, sanitize_session
+from spotter.labels import (
+    LabelError,
+    add_label,
+    labels_path,
+    load_labels,
+    matches,
+    valid_session,
+)
 from spotter.metrics import MIN_SAMPLES, Tally, merge, tally_session
 from spotter.snapshot import StepJournal, StepRecord
 from spotter.trace import TraceEvent
@@ -221,3 +228,13 @@ def test_cli_metrics_aborts_on_unreadable_labels(capsys: pytest.CaptureFixture[s
         sink.write("{torn")
     assert main(["metrics", "--session", "s1"]) == 1
     assert "metrics aborted" in capsys.readouterr().err
+
+
+def test_session_validation_rejects_trailing_newline() -> None:
+    """PR #17 review P1: `$` matches before a trailing newline, so "a\\n"
+    passed validation and then sanitized to "a_" — the same file as the
+    distinct session "a_"."""
+    assert not valid_session("a\n")
+    assert not valid_session("a\nb")
+    assert valid_session("a_") and valid_session("019fee58-ab26-72f2")
+    assert sanitize_session("a\n") == "a_"  # why the bypass mattered


### PR DESCRIPTION
## Plan progress

Three separate decisions were blocked on the same missing thing — somewhere to put a human verdict.

| Phase | Gate it waits on | Status after this PR |
|---|---|---|
| **P1** observability ceiling | "was this failure visible in the observable stream?" | 🟢 measurable — `--verdict visible\|invisible` per session |
| **P3** gates → active | gate false-positive rate | 🟢 measurable — `--verdict tp\|fp` per flag |
| **P4** reviewer → injection | reviewer precision on verify/nudge | 🟢 measurable — `--verdict tp\|fp` per decision |
| P5 ablations | — | 🔴 |

Until now those judgments were made by hand in a chat window and thrown away. The gate FP analysis was done twice, from scratch, both times.

## What

### `spotter label --session S [--step K] --verdict V [--note ...]`
`tp|fp|unclear` for a gate flag or reviewer decision; `visible|invisible|unclear` for a whole session (the ceiling question). Vocabulary is enforced per target type.

### Labels live outside the journal
`~/.spotter/labels/<session>.jsonl`, not the session journal. Two reasons, both structural:
- the journal is what the reviewer reads — labels inside it would feed the judge **its own report card**;
- appending would shift the step numbers that forks and earlier labels point at.

### Stale labels are not evidence
Every label pins a fingerprint of the record it was applied to. If that record later differs, `metrics` counts it as **stale** rather than silently folding it into a rate.

### `spotter metrics`
Reports the three numbers with coverage attached:
- withholds any rate resting on fewer than 5 decided labels,
- marks a rate **provisional** until coverage is complete,
- excludes `CONTINUE` verdicts from reviewer precision — scoring silence as correct would inflate the number for free.

## Verification on real data

Labeled the six known gate false positives from the real 104-step session `019fee58`:

```
P3 gate false positives (label each flag tp|fp):
  git_clean_force: 3/3 labeled — too few decided labels (3) to state a rate
  git_reset_hard: 3/3 labeled — too few decided labels (3) to state a rate
```

Note what this says: the tool **refuses to publish the "6/6 FP" headline** that was previously asserted in a PR description from exactly this evidence. Three samples per rule is not a rate. That refusal is the feature.

125 tests, ruff, mypy --strict clean.

## What this unlocks

The P3 and P4 decisions become arithmetic instead of argument: run sessions, label the flags and verdicts, read `spotter metrics`, and flip `observation_only`/injection only when the coverage and rate justify it.
