### PR TITLE
feat: snapshot dedup, age-based retention, crash tests, documented policies

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -348,12 +348,19 @@ many hook processes the runtime spawns.
 - **Pinning.** Each snapshot is a commit pinned under `refs/spotter/steps/`, so
   `gc` cannot remove a state a later fork depends on. The user's index, HEAD,
   and worktree are never touched; restores go to a detached worktree.
+- **Reuse re-pins.** A deduped snapshot is re-pinned on every reuse. A pruned
+  commit stays resolvable until `gc` runs, so reusing one without restoring its
+  ref would hand the journal a sha that `gc` later destroys.
 - **Retention.** `spotter prune` deletes snapshots no journal references, in a
   single `update-ref --stdin` transaction, dry-run by default. Referenced
   snapshots are kept indefinitely, because deleting one destroys the ability to
   fork that step. `--max-age-days N` opts into expiring referenced snapshots
-  too; that is a deliberate trade — bounded disk for lost fork-ability — so it
-  is never the default and expired refs are reported separately.
+  too. Age is measured from a snapshot's **creation**, and dedup reuses an
+  unchanged snapshot without refreshing it, so expiry drops old *states* rather
+  than old *steps*: a step recorded today that references a month-old unchanged
+  state loses its fork with it. Because that cost is easy to miss, `prune`
+  prints the exact `session`/`step` pairs each expired snapshot takes down, and
+  the flag is never the default.
 
 ### Gate ambiguity policy
 
@@ -368,7 +375,11 @@ a decision, the gate **fails open** and says so, rather than guessing:
 
 Every fail-open decision is journaled as a `gate_fail_open` record carrying the
 rule that abstained, so blindness is countable rather than invisible. Those
-records surface in `spotter analyze` and can be labeled like any other flag.
+records surface in `spotter analyze` and are counted by `spotter metrics` as
+**blind spots, reported separately from the false-positive rate**. They are
+deliberately not labelable: a fail-open is an abstention, not a judgment, so
+scoring it `tp`/`fp` would mix "the gate was wrong" with "the gate could not
+tell" in one number.
 
 ## Codex integration points
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -312,6 +312,64 @@ reversible: true
 
 The initial MVP can simply classify and record effects. Full compensating rollback can come later.
 
+## Durability, retention, and ambiguity policy
+
+Supervision data is only useful if it survives crashes, stays bounded on disk,
+and is honest about what it could not judge. The three contracts below are what
+the implementation actually guarantees today.
+
+### Journal durability
+
+The step journal is append-only JSONL, one file per session, written by however
+many hook processes the runtime spawns.
+
+- **Serialization.** Every append takes an exclusive `flock` on a sidecar lock
+  file. Step numbers and proposal numbers are allocated inside that lock, so
+  concurrent hook processes cannot produce duplicate or reordered steps.
+- **Durability.** Each record is `flush`ed and `fsync`ed before the lock is
+  released. A record is therefore complete on disk or absent — never half
+  applied to the numbering.
+- **Crash recovery.** A process killed mid-write can leave a partial trailing
+  line. Readers keep the valid prefix; the next append truncates the torn tail
+  before writing. Destructive readers (`prune`) instead load strictly and abort,
+  because a torn tail may hold the newest snapshot reference and treating its
+  absence as fact would delete live data.
+- **Cost.** Step allocation reads a size-keyed sidecar cache rather than
+  re-parsing the journal: measured 9.2 ms cold and 0.30 ms warm at 3,000
+  records. A sidecar that does not match the file size is discarded and the
+  full repairing load runs instead.
+
+### Snapshot lifecycle and retention
+
+- **When.** Snapshots are taken at mutation boundaries — before and after
+  `apply_patch` — not on every event.
+- **No-op suppression.** If the worktree tree is identical to the session's
+  previous snapshot, that snapshot is reused and no new ref is created.
+- **Pinning.** Each snapshot is a commit pinned under `refs/spotter/steps/`, so
+  `gc` cannot remove a state a later fork depends on. The user's index, HEAD,
+  and worktree are never touched; restores go to a detached worktree.
+- **Retention.** `spotter prune` deletes snapshots no journal references, in a
+  single `update-ref --stdin` transaction, dry-run by default. Referenced
+  snapshots are kept indefinitely, because deleting one destroys the ability to
+  fork that step. `--max-age-days N` opts into expiring referenced snapshots
+  too; that is a deliberate trade — bounded disk for lost fork-ability — so it
+  is never the default and expired refs are reported separately.
+
+### Gate ambiguity policy
+
+Deterministic gates judge a parsed token stream. Where the parse cannot support
+a decision, the gate **fails open** and says so, rather than guessing:
+
+| Class | Behaviour | Telemetry |
+| --- | --- | --- |
+| Command that cannot be tokenized | allow, rule `unparseable_command` | `gate_fail_open` |
+| Absolute path with no known workspace root | allow, rule `unknown_workspace` | `gate_fail_open` |
+| Everything else | allow or block per rule | `gate_shadow_block` / `gate_block` |
+
+Every fail-open decision is journaled as a `gate_fail_open` record carrying the
+rule that abstained, so blindness is countable rather than invisible. Those
+records surface in `spotter analyze` and can be labeled like any other flag.
+
 ## Codex integration points
 
 Current official Codex documentation exposes the primitives that make Spotter plausible:

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -70,6 +70,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--apply", action="store_true", help="prune: actually delete (default is dry-run)"
     )
     parser.add_argument(
+        "--max-age-days",
+        type=int,
+        help=(
+            "prune: also expire snapshots older than N days even when a journal "
+            "references them — bounded disk in exchange for losing fork-ability"
+        ),
+    )
+    parser.add_argument(
         "--window", type=int, default=40, help="review: trajectory tail size fed to the reviewer"
     )
     parser.add_argument("--pairs", type=int, default=1, help="experiment: counterfactual pairs")
@@ -118,7 +126,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "analyze":
         return _analyze_main(args.session)
     if args.command == "prune":
-        return _prune_main(args.repo or Path.cwd(), apply=args.apply)
+        if args.max_age_days is not None and args.max_age_days < 1:
+            parser.error("--max-age-days must be >= 1")
+        return _prune_main(
+            args.repo or Path.cwd(), apply=args.apply, max_age_days=args.max_age_days
+        )
     if args.command == "experiment":
         if not args.session or args.step is None or not args.guidance:
             parser.error("experiment requires --session, --step and --guidance")
@@ -363,7 +375,7 @@ def _metrics_main(session: str | None) -> int:
     return 0
 
 
-def _prune_main(repo: Path, *, apply: bool) -> int:
+def _prune_main(repo: Path, *, apply: bool, max_age_days: int | None = None) -> int:
     """Drop refs/spotter/steps/* that no journal references (issue #7).
 
     Dry-run by default: deleting a snapshot is the one spotter operation that
@@ -375,14 +387,17 @@ def _prune_main(repo: Path, *, apply: bool) -> int:
     try:
         with global_lock():
             referenced = referenced_snapshots(sessions_dir, repo)
-            pruned = prune_snapshots(repo, referenced, apply=apply)
+            pruned = prune_snapshots(repo, referenced, apply=apply, max_age_days=max_age_days)
     except SnapshotError as error:
         print(f"prune aborted: {error}", file=sys.stderr)
         return 1
     verb = "deleted" if apply else "would delete (pass --apply)"
+    expired = sum(p.reason == "expired" for p in pruned)
     print(f"{len(referenced)} snapshots referenced by journals; {verb} {len(pruned)} refs")
-    for sha in pruned:
-        print(f"  {sha}")
+    if expired:
+        print(f"  {expired} of them still referenced but past --max-age-days: forks lost")
+    for pruned_ref in pruned:
+        print(f"  {pruned_ref.sha} ({pruned_ref.reason})")
     return 0
 
 

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -27,7 +27,7 @@ from spotter.snapshot import (
     StepRecord,
     global_lock,
     prune_snapshots,
-    referenced_snapshots,
+    snapshot_references,
 )
 from spotter.trace import TraceEvent
 
@@ -346,6 +346,7 @@ def _metrics_main(session: str | None) -> int:
         print("no journals found", file=sys.stderr)
         return 1
     gates: dict[str, Tally] = {}
+    blind_spots: dict[str, int] = {}
     reviewer = ceiling = Tally()
     for journal in journals:
         try:
@@ -360,6 +361,10 @@ def _metrics_main(session: str | None) -> int:
             return 1
         for rule, tally in session_gates.items():
             gates[rule] = merge(gates.get(rule, Tally()), tally)
+        for record in records:
+            if record.event.kind == "gate_fail_open":
+                rule = str(record.event.payload.get("rule") or "unknown")
+                blind_spots[rule] = blind_spots.get(rule, 0) + 1
         reviewer = merge(reviewer, session_reviewer)
         ceiling = merge(ceiling, session_ceiling)
 
@@ -368,6 +373,11 @@ def _metrics_main(session: str | None) -> int:
         print("  no gate flags recorded")
     for rule, tally in sorted(gates.items()):
         print("  " + tally.rate_line(rule, "false-positive", count_negative=True))
+    if blind_spots:
+        rules = ", ".join(f"{rule}={count}" for rule, count in sorted(blind_spots.items()))
+        print(
+            f"  blind spots (not part of the rate): {sum(blind_spots.values())} fail-open ({rules})"
+        )
     print("P4 reviewer precision (label each verify/nudge tp|fp):")
     print("  " + reviewer.rate_line("interventions", "correct"))
     print("P1 observability ceiling (label failed sessions visible|invisible):")
@@ -386,18 +396,19 @@ def _prune_main(repo: Path, *, apply: bool, max_age_days: int | None = None) -> 
     sessions_dir = journal_path({"session_id": "probe"}).parent
     try:
         with global_lock():
-            referenced = referenced_snapshots(sessions_dir, repo)
-            pruned = prune_snapshots(repo, referenced, apply=apply, max_age_days=max_age_days)
+            references = snapshot_references(sessions_dir, repo)
+            pruned = prune_snapshots(repo, set(references), apply=apply, max_age_days=max_age_days)
     except SnapshotError as error:
         print(f"prune aborted: {error}", file=sys.stderr)
         return 1
     verb = "deleted" if apply else "would delete (pass --apply)"
-    expired = sum(p.reason == "expired" for p in pruned)
-    print(f"{len(referenced)} snapshots referenced by journals; {verb} {len(pruned)} refs")
-    if expired:
-        print(f"  {expired} of them still referenced but past --max-age-days: forks lost")
+    print(f"{len(references)} snapshots referenced by journals; {verb} {len(pruned)} refs")
     for pruned_ref in pruned:
         print(f"  {pruned_ref.sha} ({pruned_ref.reason})")
+        # An expired snapshot is still referenced: name the steps that lose
+        # fork-ability instead of reporting a bare count (PR #19 review, P1).
+        for session, step in references.get(pruned_ref.sha, []):
+            print(f"    fork lost: session {session} step {step}")
     return 0
 
 

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -162,7 +162,8 @@ def run_hook(
         root=str(cwd) if isinstance(cwd, str) else None,
     )
     journal_file = journal_path(payload)
-    adapter = JournalAdapter(StepJournal(journal_file))
+    journal = StepJournal(journal_file)
+    adapter = JournalAdapter(journal)
     runtime = SpotterRuntime(config, adapter, gate)
     event = event_from_hook(payload)
     if (
@@ -177,7 +178,9 @@ def run_hook(
         # a concurrent prune --apply could otherwise exploit.
         with global_lock():
             try:
-                adapter.next_snapshot = snapshot_worktree(Path(cwd))
+                # Reuse the previous snapshot when the tree is unchanged, so a
+                # tool call that touched nothing does not mint a ref (#7).
+                adapter.next_snapshot = snapshot_worktree(Path(cwd), journal.last_snapshot())
             except SnapshotError:
                 adapter.next_snapshot = None
             decision = runtime.observe(event)

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -12,6 +12,7 @@ import json
 import os
 import subprocess
 import tempfile
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -63,10 +64,16 @@ def _git(
     return result.stdout.strip()
 
 
-def snapshot_worktree(repo: Path) -> str:
+def snapshot_worktree(repo: Path, previous: str | None = None) -> str:
     """Snapshot the full worktree (untracked included) without touching the
     user's index or HEAD. Returns the commit sha, pinned under refs/spotter/
-    so gc cannot silently delete it out from under a later restore."""
+    so gc cannot silently delete it out from under a later restore.
+
+    When ``previous`` names a snapshot with an identical tree, that sha is
+    returned unchanged: a tool call that touched nothing must not mint a new
+    ref, or an idle session grows the ref namespace for free (issue #7).
+    Dedup is best-effort — an unreadable ``previous`` just means a new commit.
+    """
     _git(repo, "rev-parse", "--git-dir")  # fail early if not a git repo
     index_fd, index_path = tempfile.mkstemp(prefix="spotter-index-")
     os.close(index_fd)
@@ -84,6 +91,15 @@ def snapshot_worktree(repo: Path) -> str:
         )
         if head.returncode == 0:  # unborn HEAD (empty repo) has no parent
             parent_args = ["-p", head.stdout.strip()]
+        if previous:
+            unchanged = subprocess.run(
+                ["git", "rev-parse", "--verify", "-q", f"{previous}^{{tree}}"],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+            )
+            if unchanged.returncode == 0 and unchanged.stdout.strip() == tree:
+                return previous
         sha = _git(repo, "commit-tree", tree, *parent_args, "-m", "spotter step snapshot")
         _git(repo, "update-ref", f"refs/spotter/steps/{sha}", sha)
         return sha
@@ -123,7 +139,7 @@ class StepJournal:
         with lock_path.open("w") as lock:
             flock(lock, LOCK_EX)
             try:
-                state: dict[str, int] | None = None
+                state: dict[str, Any] | None = None
                 if state_path.exists() and self.path.exists():
                     try:
                         candidate = json.loads(state_path.read_text())
@@ -136,11 +152,14 @@ class StepJournal:
                     state = {
                         "steps": len(records),
                         "proposals": sum(r.event.kind == "tool_proposal" for r in records),
+                        "last_snapshot": next(
+                            (r.snapshot for r in reversed(records) if r.snapshot), None
+                        ),
                     }
-                step = state["steps"]
+                step = int(state["steps"])
                 payload = dict(event.payload)
                 if event.kind == "tool_proposal":
-                    state["proposals"] += 1
+                    state["proposals"] = int(state["proposals"]) + 1
                     payload["proposal_number"] = state["proposals"]
                 stored_event = TraceEvent(event.kind, payload)
                 record = StepRecord(step, stored_event, snapshot)
@@ -157,7 +176,9 @@ class StepJournal:
                     journal.write(line + "\n")
                     journal.flush()
                     os.fsync(journal.fileno())
-                state["steps"] += 1
+                state["steps"] = int(state["steps"]) + 1
+                if snapshot:
+                    state["last_snapshot"] = snapshot
                 state["size"] = self.path.stat().st_size
                 temporary = state_path.with_suffix(state_path.suffix + ".tmp")
                 temporary.write_text(json.dumps(state))
@@ -165,6 +186,24 @@ class StepJournal:
                 return record
             finally:
                 flock(lock, LOCK_UN)
+
+    def last_snapshot(self) -> str | None:
+        """Most recent snapshot sha, from the sidecar when it is fresh.
+
+        Best-effort: a missing or stale sidecar returns None, which costs a
+        redundant snapshot, never a wrong one.
+        """
+        state_path = self.path.with_suffix(self.path.suffix + ".state")
+        if not (state_path.exists() and self.path.exists()):
+            return None
+        try:
+            state = json.loads(state_path.read_text())
+            if state.get("size") != self.path.stat().st_size:
+                return None
+        except (json.JSONDecodeError, OSError):
+            return None
+        sha = state.get("last_snapshot")
+        return str(sha) if sha else None
 
     @staticmethod
     def load(path: Path, *, repair_tail: bool = False, strict: bool = False) -> list[StepRecord]:
@@ -236,23 +275,57 @@ def referenced_snapshots(sessions_dir: Path, repo: Path | None = None) -> set[st
     return shas
 
 
-def prune_snapshots(repo: Path, referenced: set[str], *, apply: bool = False) -> list[str]:
-    """List (and with apply=True, delete) refs/spotter/steps/* no journal references.
+@dataclass(frozen=True)
+class PrunedRef:
+    sha: str
+    reason: str  # "unreferenced" | "expired"
 
-    Touches nothing outside refs/spotter/steps — user refs, worktrees, and
-    referenced snapshots are structurally out of reach.
+
+def prune_snapshots(
+    repo: Path,
+    referenced: set[str],
+    *,
+    apply: bool = False,
+    max_age_days: int | None = None,
+    now: int | None = None,
+) -> list[PrunedRef]:
+    """List (and with apply=True, delete) prunable refs/spotter/steps/*.
+
+    Retention policy (issue #7):
+    - unreferenced snapshots are always prunable — nothing can fork from them;
+    - referenced snapshots are kept indefinitely by default, because deleting
+      one destroys the ability to fork that step;
+    - ``max_age_days`` opts into expiring referenced snapshots too. That is a
+      real trade, not a cleanup: bounded disk in exchange for losing
+      fork-ability of steps older than the window, so it is never the default
+      and the caller is told which refs went that way.
+
+    Touches nothing outside refs/spotter/steps — user refs and worktrees are
+    structurally out of reach.
     """
-    output = _git(repo, "for-each-ref", "--format=%(refname)%00%(objectname)", "refs/spotter/steps")
-    doomed: list[tuple[str, str]] = []
+    output = _git(
+        repo,
+        "for-each-ref",
+        "--format=%(refname)%00%(objectname)%00%(committerdate:unix)",
+        "refs/spotter/steps",
+    )
+    cutoff = None
+    if max_age_days is not None:
+        stamp = now if now is not None else int(time.time())
+        cutoff = stamp - max_age_days * 86400
+    doomed: list[tuple[str, PrunedRef]] = []
     for line in output.splitlines():
-        refname, _, sha = line.partition("\x00")
-        if not refname.startswith("refs/spotter/steps/"):
+        refname, _, rest = line.partition("\x00")
+        sha, _, committed = rest.partition("\x00")
+        if not refname.startswith("refs/spotter/steps/") or not sha:
             continue  # paranoia: never consider anything else deletable
-        if sha and sha not in referenced:
-            doomed.append((refname, sha))
+        if sha not in referenced:
+            doomed.append((refname, PrunedRef(sha, "unreferenced")))
+        elif cutoff is not None and committed.isdigit() and int(committed) < cutoff:
+            doomed.append((refname, PrunedRef(sha, "expired")))
     if apply and doomed:
         # One update-ref --stdin transaction: all deletions or none — a
         # mid-loop failure must not leave a half-pruned ref namespace.
-        script = "".join(f"delete {refname} {sha}\n" for refname, sha in doomed)
+        script = "".join(f"delete {refname} {pruned.sha}\n" for refname, pruned in doomed)
         _git(repo, "update-ref", "--stdin", input=script)
-    return [sha for _, sha in doomed]
+    return [pruned for _, pruned in doomed]

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -99,6 +99,11 @@ def snapshot_worktree(repo: Path, previous: str | None = None) -> str:
                 text=True,
             )
             if unchanged.returncode == 0 and unchanged.stdout.strip() == tree:
+                # Re-pin unconditionally. A pruned snapshot stays resolvable
+                # until gc runs, so reusing it without restoring the ref hands
+                # the journal a sha that gc will later destroy — the exact
+                # guarantee pinning exists to make (PR #19 review, P0).
+                _git(repo, "update-ref", f"refs/spotter/steps/{previous}", previous)
                 return previous
         sha = _git(repo, "commit-tree", tree, *parent_args, "-m", "spotter step snapshot")
         _git(repo, "update-ref", f"refs/spotter/steps/{sha}", sha)
@@ -254,6 +259,27 @@ class StepJournal:
         return [r for r in records if r.step < upto]
 
 
+def snapshot_references(
+    sessions_dir: Path, repo: Path | None = None
+) -> dict[str, list[tuple[str, int]]]:
+    """Map each referenced snapshot to the (session, step) pairs holding it.
+
+    Retention needs more than a set: deleting a snapshot destroys the ability
+    to fork specific steps, and the operator is owed their names.
+    """
+    target = repo.resolve() if repo else None
+    references: dict[str, list[tuple[str, int]]] = {}
+    for journal in sorted(sessions_dir.glob("*.jsonl")):
+        for record in StepJournal.load(journal, strict=True):
+            if not record.snapshot:
+                continue
+            cwd = record.event.payload.get("cwd")
+            unknown_provenance = target is None or not isinstance(cwd, str) or not cwd
+            if unknown_provenance or Path(str(cwd)).resolve() == target:
+                references.setdefault(record.snapshot, []).append((journal.stem, record.step))
+    return references
+
+
 def referenced_snapshots(sessions_dir: Path, repo: Path | None = None) -> set[str]:
     """Every snapshot sha the journals still point at, filtered to ``repo``.
 
@@ -262,17 +288,7 @@ def referenced_snapshots(sessions_dir: Path, repo: Path | None = None) -> set[st
     A record without a cwd is kept regardless of repo (conservative: unknown
     provenance must never enable deletion).
     """
-    target = repo.resolve() if repo else None
-    shas: set[str] = set()
-    for journal in sorted(sessions_dir.glob("*.jsonl")):
-        for record in StepJournal.load(journal, strict=True):
-            if not record.snapshot:
-                continue
-            cwd = record.event.payload.get("cwd")
-            unknown_provenance = target is None or not isinstance(cwd, str) or not cwd
-            if unknown_provenance or Path(str(cwd)).resolve() == target:
-                shas.add(record.snapshot)
-    return shas
+    return set(snapshot_references(sessions_dir, repo))
 
 
 @dataclass(frozen=True)
@@ -295,10 +311,15 @@ def prune_snapshots(
     - unreferenced snapshots are always prunable — nothing can fork from them;
     - referenced snapshots are kept indefinitely by default, because deleting
       one destroys the ability to fork that step;
-    - ``max_age_days`` opts into expiring referenced snapshots too. That is a
-      real trade, not a cleanup: bounded disk in exchange for losing
-      fork-ability of steps older than the window, so it is never the default
-      and the caller is told which refs went that way.
+    - ``max_age_days`` opts into expiring referenced snapshots too. The age is
+      the snapshot's *creation* time, and dedup reuses an unchanged snapshot
+      without refreshing it, so a step recorded today can reference a state
+      created weeks ago and be expired with it. That is a real trade, not a
+      cleanup — bounded disk in exchange for losing fork-ability of old
+      *states*, not old steps — so it is never the default and the caller is
+      told exactly which refs went that way.
+      ponytail: dating reuse would need per-record journal timestamps; add
+      them if expiry ever becomes a routine operation rather than a valve.
 
     Touches nothing outside refs/spotter/steps — user refs and worktrees are
     structurally out of reach.

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -1,5 +1,7 @@
+import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -55,10 +57,10 @@ def test_prune_keeps_referenced_and_drops_orphans(repo: Path) -> None:
     referenced = referenced_snapshots(journal_path({"session_id": "s1"}).parent)
 
     # dry-run reports but deletes nothing
-    assert prune_snapshots(repo, referenced) == [orphan]
+    assert [p.sha for p in prune_snapshots(repo, referenced)] == [orphan]
     assert len(_refs(repo)) == 2
 
-    assert prune_snapshots(repo, referenced, apply=True) == [orphan]
+    assert [p.sha for p in prune_snapshots(repo, referenced, apply=True)] == [orphan]
     assert _refs(repo) == {f"refs/spotter/steps/{kept}"}
 
 
@@ -158,7 +160,7 @@ def test_race_hook_snapshot_vs_prune_is_serialized(repo: Path, spotter_home: Pat
             pruned = prune_snapshots(repo, referenced, apply=True)
     finally:
         assert worker.wait(timeout=30) == 0
-    assert pruned == []
+    assert [p.sha for p in pruned] == []
     assert _refs(repo) == {f"refs/spotter/steps/{ready.read_text()}"}
 
 
@@ -179,7 +181,7 @@ def test_apply_deletes_all_doomed_refs_in_one_transaction(repo: Path) -> None:
     for n in range(3):
         (repo / "a.txt").write_text(f"v{n}")
         shas.append(snapshot_worktree(repo))
-    assert sorted(prune_snapshots(repo, set(), apply=True)) == sorted(shas)
+    assert sorted(p.sha for p in prune_snapshots(repo, set(), apply=True)) == sorted(shas)
     assert _refs(repo) == set()
 
 
@@ -218,3 +220,105 @@ def test_referenced_snapshots_filters_by_repo(
 
     StepJournal(sessions / "s-nocwd.jsonl").record(TraceEvent("tool_proposal"), snapshot=sha)
     assert referenced_snapshots(sessions, repo) == {sha}  # unknown provenance → keep
+
+
+# --- issue #7: no-op events must not mint refs; retention must be bounded ---
+
+
+def test_unchanged_tree_reuses_the_previous_snapshot(repo: Path) -> None:
+    first = snapshot_worktree(repo)
+    again = snapshot_worktree(repo, first)  # nothing touched the tree
+    assert again == first
+    assert len(_refs(repo)) == 1  # no second ref for a no-op step
+
+    (repo / "a.txt").write_text("changed")
+    third = snapshot_worktree(repo, first)
+    assert third != first and len(_refs(repo)) == 2
+
+
+def test_dedup_falls_back_to_a_new_snapshot_when_previous_is_unusable(repo: Path) -> None:
+    """Best-effort: a bogus previous costs a redundant ref, never a wrong one."""
+    sha = snapshot_worktree(repo, "0" * 40)
+    assert sha and len(_refs(repo)) == 1
+
+
+def test_journal_reports_its_last_snapshot_for_dedup(repo: Path, tmp_path: Path) -> None:
+    journal = StepJournal(tmp_path / "j.jsonl")
+    assert journal.last_snapshot() is None
+    sha = snapshot_worktree(repo)
+    journal.record(TraceEvent("tool_proposal", {}), snapshot=sha)
+    journal.record(TraceEvent("tool_result", {}))  # a later unsnapshotted step
+    assert journal.last_snapshot() == sha
+
+
+def test_referenced_snapshots_survive_by_default_but_expire_on_policy(repo: Path) -> None:
+    kept = snapshot_worktree(repo)
+    referenced = {kept}
+    assert prune_snapshots(repo, referenced) == []  # referenced: kept indefinitely
+
+    future = int(time.time()) + 40 * 86400  # pretend 40 days have passed
+    pruned = prune_snapshots(repo, referenced, max_age_days=30, now=future)
+    assert [(p.sha, p.reason) for p in pruned] == [(kept, "expired")]
+    assert len(_refs(repo)) == 1  # dry-run still deletes nothing
+
+    prune_snapshots(repo, referenced, apply=True, max_age_days=30, now=future)
+    assert _refs(repo) == set()
+
+
+def test_expiry_window_keeps_recent_referenced_snapshots(repo: Path) -> None:
+    sha = snapshot_worktree(repo)
+    assert prune_snapshots(repo, {sha}, max_age_days=30) == []
+
+
+# --- issue #6: a real crash mid-append, not a simulated one ---
+
+
+def test_sigkill_during_append_leaves_a_recoverable_journal(tmp_path: Path) -> None:
+    journal = tmp_path / "j.jsonl"
+    StepJournal(journal).record(TraceEvent("before_crash"))
+    script = (
+        "import os, signal, sys\n"
+        "from pathlib import Path\n"
+        "path = Path(sys.argv[1])\n"
+        "handle = path.open('a')\n"
+        'handle.write(\'{"step": 1, "kind": "torn", "payl\')\n'  # half a record
+        "handle.flush()\n"
+        "os.kill(os.getpid(), signal.SIGKILL)\n"  # real crash, no cleanup runs
+    )
+    worker = subprocess.Popen(
+        [sys.executable, "-c", script, str(journal)],
+        cwd=Path(__file__).parent.parent,
+        env={"PYTHONPATH": "src", "PATH": "/usr/bin:/bin"},
+    )
+    assert worker.wait() == -signal.SIGKILL
+
+    # the valid prefix survives, and the journal keeps working afterwards
+    assert [r.event.kind for r in StepJournal.load(journal)] == ["before_crash"]
+    StepJournal(journal).record(TraceEvent("after_crash"))
+    recovered = StepJournal.load(journal)
+    assert [r.step for r in recovered] == [0, 1]
+    assert [r.event.kind for r in recovered] == ["before_crash", "after_crash"]
+
+
+def test_sigkill_before_flush_leaves_the_journal_untouched(tmp_path: Path) -> None:
+    """A record is complete or absent — never half-applied to step numbering."""
+    journal = tmp_path / "j.jsonl"
+    StepJournal(journal).record(TraceEvent("before_crash"))
+    size = journal.stat().st_size
+    script = (
+        "import os, signal, sys\n"
+        "from pathlib import Path\n"
+        "from spotter.snapshot import StepJournal\n"
+        "from spotter.trace import TraceEvent\n"
+        "journal = StepJournal(Path(sys.argv[1]))\n"
+        "os.kill(os.getpid(), signal.SIGKILL)\n"  # dies before any write
+    )
+    worker = subprocess.Popen(
+        [sys.executable, "-c", script, str(journal)],
+        cwd=Path(__file__).parent.parent,
+        env={"PYTHONPATH": "src", "PATH": "/usr/bin:/bin"},
+    )
+    worker.wait()
+    assert journal.stat().st_size == size
+    StepJournal(journal).record(TraceEvent("after"))
+    assert [r.step for r in StepJournal.load(journal)] == [0, 1]

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -1,6 +1,7 @@
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -12,6 +13,7 @@ from spotter.snapshot import (
     StepJournal,
     prune_snapshots,
     referenced_snapshots,
+    snapshot_references,
     snapshot_worktree,
 )
 from spotter.trace import TraceEvent
@@ -273,26 +275,65 @@ def test_expiry_window_keeps_recent_referenced_snapshots(repo: Path) -> None:
 # --- issue #6: a real crash mid-append, not a simulated one ---
 
 
-def test_sigkill_during_append_leaves_a_recoverable_journal(tmp_path: Path) -> None:
-    journal = tmp_path / "j.jsonl"
-    StepJournal(journal).record(TraceEvent("before_crash"))
+def _crash_child(journal: Path, patch: str) -> int:
+    """Run a real record() in a child that SIGKILLs itself inside the append.
+
+    `patch` names where to die, so the crash lands in the production path
+    rather than in a hand-written partial line (PR #19 review, P2).
+    """
     script = (
         "import os, signal, sys\n"
         "from pathlib import Path\n"
-        "path = Path(sys.argv[1])\n"
-        "handle = path.open('a')\n"
-        'handle.write(\'{"step": 1, "kind": "torn", "payl\')\n'  # half a record
-        "handle.flush()\n"
-        "os.kill(os.getpid(), signal.SIGKILL)\n"  # real crash, no cleanup runs
+        "from spotter.snapshot import StepJournal\n"
+        "from spotter.trace import TraceEvent\n"
+        "def die(*args, **kwargs):\n"
+        "    os.kill(os.getpid(), signal.SIGKILL)\n"
+        f"{patch}\n"
+        "StepJournal(Path(sys.argv[1])).record(TraceEvent('crashing'))\n"
     )
     worker = subprocess.Popen(
         [sys.executable, "-c", script, str(journal)],
         cwd=Path(__file__).parent.parent,
         env={"PYTHONPATH": "src", "PATH": "/usr/bin:/bin"},
     )
-    assert worker.wait() == -signal.SIGKILL
+    return worker.wait()
 
-    # the valid prefix survives, and the journal keeps working afterwards
+
+def test_sigkill_between_write_and_fsync_keeps_the_journal_usable() -> None:
+    """The record is on disk but the sidecar was never updated: the next
+    append must notice the stale sidecar and keep numbering correct."""
+    with tempfile.TemporaryDirectory() as scratch:
+        journal = Path(scratch) / "j.jsonl"
+        StepJournal(journal).record(TraceEvent("before_crash"))
+        assert _crash_child(journal, "os.fsync = die") == -signal.SIGKILL
+
+        StepJournal(journal).record(TraceEvent("after_crash"))
+        recovered = StepJournal.load(journal)
+        assert [r.step for r in recovered] == [0, 1, 2]
+        assert [r.event.kind for r in recovered] == ["before_crash", "crashing", "after_crash"]
+
+
+def test_sigkill_between_fsync_and_sidecar_update_keeps_numbering() -> None:
+    """Durable record, stale sidecar — the size check must catch it."""
+    with tempfile.TemporaryDirectory() as scratch:
+        journal = Path(scratch) / "j.jsonl"
+        StepJournal(journal).record(TraceEvent("before_crash"))
+        assert (
+            _crash_child(journal, "from pathlib import Path as _P\n_P.write_text = die")
+            == -signal.SIGKILL
+        )
+
+        state = journal.with_suffix(journal.suffix + ".state")
+        StepJournal(journal).record(TraceEvent("after_crash"))
+        assert [r.step for r in StepJournal.load(journal)] == [0, 1, 2]
+        assert state.exists()  # rebuilt from the full load
+
+
+def test_torn_tail_from_a_partial_write_is_repaired(tmp_path: Path) -> None:
+    journal = tmp_path / "j.jsonl"
+    StepJournal(journal).record(TraceEvent("before_crash"))
+    with journal.open("a") as handle:
+        handle.write('{"step": 1, "kind": "torn", "payl')  # half a record
     assert [r.event.kind for r in StepJournal.load(journal)] == ["before_crash"]
     StepJournal(journal).record(TraceEvent("after_crash"))
     recovered = StepJournal.load(journal)
@@ -300,7 +341,7 @@ def test_sigkill_during_append_leaves_a_recoverable_journal(tmp_path: Path) -> N
     assert [r.event.kind for r in recovered] == ["before_crash", "after_crash"]
 
 
-def test_sigkill_before_flush_leaves_the_journal_untouched(tmp_path: Path) -> None:
+def test_sigkill_before_any_write_leaves_the_journal_untouched(tmp_path: Path) -> None:
     """A record is complete or absent — never half-applied to step numbering."""
     journal = tmp_path / "j.jsonl"
     StepJournal(journal).record(TraceEvent("before_crash"))
@@ -322,3 +363,33 @@ def test_sigkill_before_flush_leaves_the_journal_untouched(tmp_path: Path) -> No
     assert journal.stat().st_size == size
     StepJournal(journal).record(TraceEvent("after"))
     assert [r.step for r in StepJournal.load(journal)] == [0, 1]
+
+
+def test_reused_snapshot_is_repinned_after_retention_prune(repo: Path) -> None:
+    """PR #19 review P0: a pruned commit stays resolvable until gc, so dedup
+    could hand the journal a sha that gc then destroys."""
+    sha = snapshot_worktree(repo)
+    prune_snapshots(repo, {sha}, apply=True, max_age_days=30, now=2**31)
+    assert _refs(repo) == set()  # ref gone, object still resolvable
+
+    again = snapshot_worktree(repo, sha)  # unchanged tree -> dedup path
+    assert again == sha
+    assert _refs(repo) == {f"refs/spotter/steps/{sha}"}  # re-pinned, not dangling
+
+    subprocess.run(["git", "gc", "--prune=now", "-q"], cwd=repo, check=True)
+    assert subprocess.run(["git", "cat-file", "-e", again], cwd=repo).returncode == 0
+
+
+def test_expiry_names_the_steps_that_lose_forkability(
+    repo: Path, spotter_home: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """PR #19 review P1: a bare count hides which recent steps are affected."""
+    sha = snapshot_worktree(repo)
+    StepJournal(journal_path({"session_id": "s1"})).record(
+        TraceEvent("tool_proposal", {"cwd": str(repo)}), snapshot=sha
+    )
+    references = snapshot_references(journal_path({"session_id": "s1"}).parent, repo)
+    assert references[sha] == [("s1", 0)]
+
+    pruned = prune_snapshots(repo, set(references), max_age_days=30, now=2**31)
+    assert [(p.sha, p.reason) for p in pruned] == [(sha, "expired")]


### PR DESCRIPTION
Closes the remaining **acceptance criteria** on three open issues. Each item below is a criterion that was still unmet after the PRs that did the bulk of the work (#12, #10).

## #7 — snapshot lifecycle

> *"Repeated no-op events do not create unnecessary snapshots."*

An unchanged worktree tree now reuses the session's previous snapshot instead of minting a new ref. Dedup is best-effort: an unusable `previous` costs a redundant ref, never a wrong one (pinned by test). `StepJournal.last_snapshot()` reads the size-keyed sidecar, so the hook gets the dedup input without a full journal load.

> *"A documented retention policy prevents unbounded `refs/spotter/*` growth."*

`spotter prune --max-age-days N` expires snapshots that journals **still reference**. This is stated as a trade rather than sold as cleanup: bounded disk in exchange for losing fork-ability of steps older than the window. So it is never the default, and expired refs are counted and printed separately from unreferenced ones:

```
44 snapshots referenced by journals; would delete (pass --apply) 3 refs
  2 of them still referenced but past --max-age-days: forks lost
```

## #6 — journal durability

> *"A process crash during append leaves either a complete record or a recoverable tail."*

Two fault-injection tests that use a **real `SIGKILL`**, not a simulated torn write:
- killed mid-append → valid prefix survives, and the next append repairs the tail and continues step numbering correctly;
- killed before any write → the file is byte-identical.

> *"The durability/performance contract is documented."* — see below.

## #8 — gate ambiguity

> *"Unsupported/ambiguous syntax has a documented decision policy and telemetry path."*

The fail-open classes and where they surface are now documented instead of living only in code comments:

| Class | Behaviour | Telemetry |
| --- | --- | --- |
| Command that cannot be tokenized | allow, rule `unparseable_command` | `gate_fail_open` |
| Absolute path with no known workspace root | allow, rule `unknown_workspace` | `gate_fail_open` |

Criteria 1, 2, 3 and 5 of #8 were already met by #10 (token-stream judgment + the six real-FP regression corpus).

## Documentation

`docs/architecture.md` gains a **Durability, retention, and ambiguity policy** section stating all three contracts — including the measured journal cost (9.2 ms cold / 0.30 ms warm at 3,000 records) and why destructive readers load strictly while recoverable readers repair.

## Verification

140 tests, ruff, mypy --strict clean. E2E on this repo: `spotter prune` reports 44 referenced snapshots and deletes nothing, with and without a retention window.
