### PR TITLE
feat: wire the audit ledger into review; correct the model-id claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,10 @@ model = "default"
 
 `"default"` delegates reviewer model choice to the codex account, so the `[reviewer]`
 table may be omitted. Pin a specific id only if your auth supports it: ChatGPT-account
-auth rejects some ids (observed: `gpt-5.3-spark`) with a slow retry loop rather than a
-fast error. Which reviewer model works best is an open experimental question (see
+auth rejects unknown or unavailable ids with a slow retry loop rather than a fast error —
+and the message ("not supported when using Codex with a ChatGPT account") does not
+distinguish a wrong slug from a restricted one. Check `codex` for the slugs your account
+actually has. Which reviewer model works best is an open experimental question (see
 docs/research.md RQ3), not a constant.
 
 ## Connect Spotter to Codex

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -362,6 +362,29 @@ many hook processes the runtime spawns.
   prints the exact `session`/`step` pairs each expired snapshot takes down, and
   the flag is never the default.
 
+### Audit ledger (claim/evidence)
+
+The reviewer does not treat the agent's own account as fact. A ledger is
+rebuilt from the journal before every review:
+
+- **Evidence** comes only from observable outcomes of tool calls. A reasoning
+  summary can never become evidence — `EvidenceSource` has no member for it,
+  so mypy rejects the call site.
+- **Hypotheses** come from the reviewer's own flagged assumptions and enter as
+  `unverified`.
+- **Retraction is mechanical**: when the same command later produces a
+  different outcome, the earlier outcome is retracted and every hypothesis
+  resting solely on it goes stale, transitively. Stale premises are listed in
+  the next review prompt so a killed assumption cannot quietly stay in view.
+
+**Measured limit.** Only 33 of 340 real Codex tool results (10%) carry an
+observable outcome at all — Codex reports an exit code for `apply_patch` and
+nothing for shell commands. The ledger records outcomes where they exist and
+stays silent where they do not; inferring pass/fail from output text would
+retract evidence every time `git status` changed. This is an
+observability-ceiling fact (P1), not a parser gap, and it bounds how much
+stale-premise detection can do on Codex today.
+
 ### Gate ambiguity policy
 
 Deterministic gates judge a parsed token stream. Where the parse cannot support

--- a/src/spotter/audit.py
+++ b/src/spotter/audit.py
@@ -5,8 +5,12 @@ The type system is the enforcement mechanism: ``EvidenceSource`` has no
 mypy rejecting the call site. Summaries enter only as unverified hypotheses.
 """
 
+import re
 from dataclasses import dataclass, field
-from typing import Literal, get_args
+from typing import TYPE_CHECKING, Literal, get_args
+
+if TYPE_CHECKING:
+    from spotter.snapshot import StepRecord
 
 EvidenceSource = Literal["tool_result", "diff", "test_output", "repo_state"]
 HypothesisStatus = Literal["unverified", "supported", "stale"]
@@ -86,3 +90,93 @@ class AuditState:
         for hypothesis_id in stale:
             self.hypotheses[hypothesis_id].status = "stale"
         return stale
+
+
+def build_state(records: list["StepRecord"]) -> AuditState:
+    """Reconstruct the ledger from a journal (plan P2, wired).
+
+    Evidence comes only from observable outcomes — a tool result, never a
+    summary the agent wrote about itself. Hypotheses come from the reviewer's
+    own VERIFY/NUDGE claims, which is why they enter as ``unverified``.
+
+    Retraction is mechanical, not a judgment call: when the same command later
+    produces a different exit code, the earlier outcome is no longer true, so
+    it is retracted and anything resting solely on it goes stale.
+    """
+    state = AuditState()
+    outcomes: dict[str, str] = {}  # command -> evidence id of its last result
+    for record in records:
+        payload = record.event.payload
+        if record.event.kind == "tool_result":
+            command = _command_of(payload)
+            exit_code = _exit_code_of(payload)
+            if command is None or exit_code is None:
+                continue
+            evidence_id = f"e{record.step}"
+            state.add_evidence(
+                Evidence(evidence_id, "tool_result", f"{command} -> exit {exit_code}")
+            )
+            previous = outcomes.get(command)
+            if previous is not None and state.evidence[previous].description.rsplit(" ", 1)[
+                -1
+            ] != str(exit_code):
+                state.retract(previous)  # same command, different outcome
+            outcomes[command] = evidence_id
+        elif record.event.kind == "reviewer_decision":
+            claim = payload.get("hypothesis")
+            if isinstance(claim, str) and claim.strip():
+                state.add_hypothesis(
+                    Hypothesis(
+                        f"h{record.step}",
+                        claim.strip(),
+                        supported_by=set(state.evidence) - state.retracted,
+                    )
+                )
+    return state
+
+
+def _command_of(payload: dict[str, object]) -> str | None:
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command")
+        if isinstance(command, str) and command.strip():
+            return " ".join(command.split())
+    return None
+
+
+_EXIT_CODE_TEXT = re.compile(r"(?im)^Exit code: (-?\d+)\s*$")
+
+
+def _exit_code_of(payload: dict[str, object]) -> int | None:
+    """Outcome of a tool call, where one is observable at all.
+
+    Two shapes exist in the wild: a structured ``{"exit_code": n}`` response,
+    and Codex's raw text with an ``Exit code: n`` line. Measured on real
+    journals, only 33 of 301 Codex tool results carry an outcome at all (all
+    of them apply_patch) — shell results carry none. So the ledger records
+    outcomes where they exist and stays silent where they do not, rather than
+    inventing pass/fail from output text that legitimately differs run to run.
+    That gap is an observability-ceiling fact (plan P1), not a parser bug.
+    """
+    response = payload.get("tool_response")
+    if isinstance(response, dict):
+        exit_code = response.get("exit_code")
+        if isinstance(exit_code, int):
+            return exit_code
+    if isinstance(response, str):
+        match = _EXIT_CODE_TEXT.search(response)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def stale_summary(state: AuditState) -> list[str]:
+    """Lines for the reviewer digest: what stopped being true, and what that
+    invalidated. An empty list means nothing was retracted."""
+    lines: list[str] = []
+    for evidence_id in sorted(state.retracted):
+        lines.append(f"RETRACTED {state.evidence[evidence_id].description}")
+    for hypothesis in state.hypotheses.values():
+        if hypothesis.status == "stale":
+            lines.append(f"STALE hypothesis: {hypothesis.claim}")
+    return lines

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -304,6 +304,7 @@ def _review_main(session: str, config: SpotterConfig, *, window: int) -> int:
                 "decision": decision.decision,
                 "failure_class": decision.failure_class,
                 "reason": decision.reason,
+                "hypothesis": decision.hypothesis,
                 "confidence": decision.confidence,
                 "model": config.reviewer.model,
                 "reviewed_upto": records[-1].step,

--- a/src/spotter/reviewer.py
+++ b/src/spotter/reviewer.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from spotter.audit import build_state, stale_summary
 from spotter.snapshot import StepRecord
 
 DECISIONS = ("continue", "verify", "nudge")
@@ -29,8 +30,9 @@ _SCHEMA = {
         "failure_class": {"type": "string", "enum": list(FAILURE_CLASSES)},
         "reason": {"type": "string"},
         "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+        "hypothesis": {"type": "string"},
     },
-    "required": ["decision", "failure_class", "reason", "confidence"],
+    "required": ["decision", "failure_class", "reason", "confidence", "hypothesis"],
     "additionalProperties": False,
 }
 
@@ -45,10 +47,14 @@ Rules:
 - verify: one consequential assumption deserves cheap evidence before more work
   depends on it. nudge: the trajectory is clearly wasting effort.
 - Never propose code. One short reason sentence.
+- hypothesis: when you flag something, state the unverified assumption the
+  agent is relying on, in one clause. Empty string when decision=continue.
+- Anything under STALE/RETRACTED below stopped being true. Do not treat it as
+  current evidence, and say so if the agent is still building on it.
 
 Trajectory digest (oldest first):
 {digest}
-
+{stale}
 Respond with the JSON object only."""
 
 
@@ -58,6 +64,7 @@ class ReviewerDecision:
     failure_class: str
     reason: str
     confidence: float
+    hypothesis: str = ""  # the assumption being flagged; "" when none
 
 
 def build_digest(records: list[StepRecord], window: int = 40) -> str:
@@ -94,6 +101,7 @@ def parse_decision(raw: str) -> ReviewerDecision:
             failure_class=str(data["failure_class"]),
             reason=str(data["reason"])[:500],
             confidence=float(data["confidence"]),
+            hypothesis=str(data.get("hypothesis") or "")[:300],
         )
     except (json.JSONDecodeError, KeyError, TypeError, ValueError):
         return ReviewerDecision("continue", "none", "unparseable reviewer output", 0.0)
@@ -110,9 +118,12 @@ def codex_runner(model: str, prompt: str) -> str:
         schema = Path(scratch) / "schema.json"
         schema.write_text(json.dumps(_SCHEMA))
         answer = Path(scratch) / "answer.txt"
-        # "default" delegates model choice to codex — ChatGPT-account auth
-        # rejects several model ids outright (observed: gpt-5.3-spark → 400),
-        # and a rejected id costs a multi-minute retry loop, not a fast error.
+        # "default" delegates model choice to codex. A wrong slug fails with a
+        # misleading 400 ("not supported when using Codex with a ChatGPT
+        # account") after a multi-minute retry loop, not a fast error — the
+        # earlier default gpt-5.3-spark simply did not exist; the real slug is
+        # gpt-5.3-codex-spark. Delegating avoids pinning an id that is only
+        # valid for some accounts.
         model_args = [] if model in ("", "default") else ["-m", model]
         result = subprocess.run(
             [
@@ -149,5 +160,9 @@ def review(
     window: int = 40,
     runner: Callable[[str, str], str] = codex_runner,
 ) -> ReviewerDecision:
-    prompt = _PROMPT.format(digest=build_digest(records, window))
+    # The ledger is rebuilt from observable outcomes each time, so a premise
+    # that later evidence killed cannot quietly stay in the reviewer's view.
+    stale = stale_summary(build_state(records))
+    stale_block = "\nInvalidated premises:\n" + "\n".join(stale) + "\n" if stale else ""
+    prompt = _PROMPT.format(digest=build_digest(records, window), stale=stale_block)
     return parse_decision(runner(model, prompt))

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,6 +1,9 @@
 import pytest
 
-from spotter.audit import AuditState, Evidence, Hypothesis
+from spotter.audit import AuditState, Evidence, Hypothesis, build_state, stale_summary
+from spotter.reviewer import review
+from spotter.snapshot import StepRecord
+from spotter.trace import TraceEvent
 
 
 def _state() -> AuditState:
@@ -58,3 +61,143 @@ def test_duplicate_ids_are_rejected() -> None:
         state.add_evidence(Evidence("e1", "diff", "again"))
     with pytest.raises(ValueError, match="duplicate"):
         state.add_hypothesis(Hypothesis("h1", "again"))
+
+
+# --- plan P2 wired: the ledger is built from the journal, not from claims ---
+
+
+def _records(events: list[tuple[str, dict[str, object]]]) -> list[StepRecord]:
+    return [
+        StepRecord(i, TraceEvent(kind, payload), None) for i, (kind, payload) in enumerate(events)
+    ]
+
+
+def _result(command: str, exit_code: int) -> tuple[str, dict[str, object]]:
+    return (
+        "tool_result",
+        {"tool_input": {"command": command}, "tool_response": {"exit_code": exit_code}},
+    )
+
+
+def test_evidence_comes_only_from_observable_outcomes() -> None:
+    state = build_state(
+        _records(
+            [
+                ("reasoning_summary", {"text": "redis is definitely the cause"}),
+                _result("pytest -q", 1),
+            ]
+        )
+    )
+    assert [e.description for e in state.evidence.values()] == ["pytest -q -> exit 1"]
+    assert all("redis" not in e.description for e in state.evidence.values())
+
+
+def test_same_command_with_a_new_outcome_retracts_the_old_one() -> None:
+    state = build_state(_records([_result("pytest -q", 0), _result("pytest -q", 1)]))
+    assert len(state.retracted) == 1
+    assert state.evidence[next(iter(state.retracted))].description.endswith("exit 0")
+
+
+def test_repeated_identical_outcomes_retract_nothing() -> None:
+    state = build_state(_records([_result("pytest -q", 0), _result("pytest -q", 0)]))
+    assert state.retracted == set()
+
+
+def test_reviewer_hypothesis_goes_stale_when_its_evidence_dies() -> None:
+    state = build_state(
+        _records(
+            [
+                _result("pytest -q", 0),
+                ("reviewer_decision", {"decision": "verify", "hypothesis": "the suite is green"}),
+                _result("pytest -q", 1),
+            ]
+        )
+    )
+    assert state.hypotheses["h1"].status == "stale"
+    lines = stale_summary(state)
+    assert any("RETRACTED" in line for line in lines)
+    assert any("STALE hypothesis: the suite is green" in line for line in lines)
+
+
+def test_continue_decisions_add_no_hypothesis() -> None:
+    state = build_state(
+        _records([("reviewer_decision", {"decision": "continue", "hypothesis": ""})])
+    )
+    assert state.hypotheses == {}
+
+
+def test_reviewer_prompt_carries_invalidated_premises() -> None:
+    seen: dict[str, str] = {}
+
+    def runner(model: str, prompt: str) -> str:
+        seen["prompt"] = prompt
+        return (
+            '{"decision": "nudge", "failure_class": "spec_drift", "reason": "x",'
+            ' "confidence": 0.7, "hypothesis": "the config is loaded"}'
+        )
+
+    records = _records(
+        [
+            _result("pytest -q", 0),
+            ("reviewer_decision", {"decision": "verify", "hypothesis": "the suite is green"}),
+            _result("pytest -q", 1),
+        ]
+    )
+    decision = review(records, "m", runner=runner)
+    assert "Invalidated premises:" in seen["prompt"]
+    assert "STALE hypothesis: the suite is green" in seen["prompt"]
+    assert decision.hypothesis == "the config is loaded"
+
+
+def test_clean_trajectory_adds_no_premise_block() -> None:
+    seen: dict[str, str] = {}
+
+    def runner(model: str, prompt: str) -> str:
+        seen["prompt"] = prompt
+        return (
+            '{"decision": "continue", "failure_class": "none", "reason": "ok",'
+            ' "confidence": 0.5, "hypothesis": ""}'
+        )
+
+    review(_records([_result("pytest -q", 0)]), "m", runner=runner)
+    assert "Invalidated premises" not in seen["prompt"]
+
+
+def test_codex_text_exit_codes_are_read_too() -> None:
+    """Real Codex responses are raw strings with an 'Exit code: n' line, not
+    the structured dict the first tests assumed."""
+    records = _records(
+        [
+            (
+                "tool_result",
+                {"tool_input": {"command": "apply"}, "tool_response": "ok\nExit code: 0\n"},
+            ),
+            (
+                "tool_result",
+                {"tool_input": {"command": "apply"}, "tool_response": "boom\nExit code: 1\n"},
+            ),
+        ]
+    )
+    state = build_state(records)
+    assert len(state.evidence) == 2
+    assert len(state.retracted) == 1
+
+
+def test_results_without_an_observable_outcome_are_not_invented() -> None:
+    """Codex shell results carry no exit code; guessing pass/fail from output
+    text would retract evidence every time `git status` changed."""
+    state = build_state(
+        _records(
+            [
+                (
+                    "tool_result",
+                    {"tool_input": {"command": "git status"}, "tool_response": "A file"},
+                ),
+                (
+                    "tool_result",
+                    {"tool_input": {"command": "git status"}, "tool_response": "B file"},
+                ),
+            ]
+        )
+    )
+    assert state.evidence == {} and state.retracted == set()


### PR DESCRIPTION
## Plan progress

**P2 was the last piece of the plan that existed as code but was connected to nothing.** It is now in the review path.

| Phase | Status after this PR |
|---|---|
| P0 fork/replay | ✅ |
| P1 observer | 🟡 + **first hard ceiling number: 10%** (below) |
| **P2 audit state** | **🟢 wired — rebuilt from the journal before every review** |
| P3 gates | 🟡 shadow; waiting on labels |
| P4 reviewer | 🟡 shadow; waiting on labels |
| P5 ablations | 🔴 — see note |

## What

Before each review the ledger is rebuilt from the journal:

- **Evidence** only from observable tool outcomes. A reasoning summary still cannot become evidence — `EvidenceSource` has no member for it, so mypy rejects the call site.
- **Hypotheses** from the reviewer's own flagged assumption; the schema now asks for it and the journal records it beside the decision.
- **Retraction is mechanical**: same command, different outcome → the earlier outcome is retracted and hypotheses resting solely on it go stale, transitively. Stale premises are injected into the next review prompt, so an assumption later evidence killed cannot quietly stay in view.

## Real data corrected this twice — both recorded, not smoothed over

1. **Codex `tool_response` is a raw string**, not the structured dict my first tests assumed. Synthetic tests passed while the ledger was completely inert on real journals. The parser now reads both shapes.
2. **Only 33 of 340 real Codex tool results (10%) carry an observable outcome at all** — an exit code for `apply_patch`, nothing for shell commands.

```
019fee58: tool_result=118  observable=16
019fee8e: tool_result= 61  observable=13
019feea7: tool_result=113  observable= 2
019fef84: tool_result= 23  observable= 0
019fefe6: tool_result= 25  observable= 2
                     ---            ---
                     340             33   = 10%
```

The ledger stays silent where no outcome exists rather than inferring pass/fail from output text that legitimately changes between runs (`git status`). **That 10% is an observability-ceiling fact (P1)**, documented in `docs/architecture.md`, and it bounds how much stale-premise detection can do on Codex today.

## Correction to an earlier claim

`gpt-5.3-spark` was rejected because **that slug does not exist** — the real one is `gpt-5.3-codex-spark`, verified working. It was not ChatGPT-account auth blocking a class of models, as an earlier commit and the README asserted. The 400 message conflates the two cases; the comment and README now say so.

## Note on P5

This account exposes 9 models, all one family (`gpt-5.6-sol`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, …). P5's decisive cell is *different family, weaker model*; the performance axis is testable today, the diversity axis is not. P5 is red because its decisive experiment is not runnable here, not because code is missing.

153 tests, ruff, mypy --strict clean.
