### PR TITLE
Fix remote marketplace plugin installation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,11 @@ newer must still be available as `python3`.
 
 ### Codex
 
-Clone the repository, add its bundled local marketplace, and install Spotter:
+Add the Spotter GitHub repository as a marketplace, then add the qualified plugin:
 
 ```bash
-git clone https://github.com/bogyie/spotter.git
-codex plugin marketplace add "$(pwd)/spotter/.agents/plugins"
-codex plugin install spotter
+codex plugin marketplace add bogyie/spotter
+codex plugin add spotter@spotter
 ```
 
 Restart Codex after installation. Codex discovers `.codex-plugin/plugin.json` and the
@@ -204,11 +203,10 @@ bundled `hooks/hooks.json` configuration.
 
 ### Claude Code
 
-Add the repository as a marketplace and install its plugin:
+Add the Spotter GitHub repository as a marketplace and install its qualified plugin:
 
 ```bash
-git clone https://github.com/bogyie/spotter.git
-claude plugin marketplace add ./spotter
+claude plugin marketplace add bogyie/spotter
 claude plugin install spotter@spotter
 ```
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -15,9 +15,20 @@ def test_plugin_manifests_and_hooks_are_well_formed() -> None:
 
     assert codex["name"] == claude["name"] == "spotter"
     assert codex["version"] == claude["version"]
+    assert claude_marketplace["name"] == codex_marketplace["name"] == "spotter"
     assert claude_marketplace["plugins"][0]["source"] == "./"
     assert codex_marketplace["plugins"][0]["source"]["path"] == "./plugins/spotter"
+    assert Path(".agents/plugins/plugins/spotter").resolve() == Path.cwd().resolve()
     assert set(hooks) == {"SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse"}
+
+
+def test_readme_uses_remote_marketplace_install_commands() -> None:
+    readme = Path("README.md").read_text()
+
+    assert "codex plugin marketplace add bogyie/spotter" in readme
+    assert "codex plugin add spotter@spotter" in readme
+    assert "claude plugin marketplace add bogyie/spotter" in readme
+    assert "claude plugin install spotter@spotter" in readme
 
 
 def test_bundled_hook_runs_without_installing_package(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Update the installation instructions to prefer adding the Spotter GitHub repository as a remote marketplace and installing the qualified `spotter@spotter` plugin for both Codex and Claude Code.
- Add test coverage to prevent regressions in marketplace identity, local-source resolution, and the documented install commands.

### Description

- Replace the local-marketplace install steps in `README.md` with remote GitHub marketplace commands for Codex (`codex plugin marketplace add bogyie/spotter` / `codex plugin add spotter@spotter`) and Claude Code (`claude plugin marketplace add bogyie/spotter` / `claude plugin install spotter@spotter`).
- Extend `tests/test_plugins.py` with assertions that check the marketplace `name` equality, that the `.agents/plugins/plugins/spotter` path resolves to the repo root, and a new test that verifies the `README.md` contains the new remote install commands.
- Minor README formatting adjustments to place the new instructions under the existing "Install the agent plugins" section.

### Testing

- Ran `PYTHONPATH=src python -m pytest` and all tests passed (`156 passed`).
- Ran `python -m ruff check .` and `python -m mypy src tests` with no issues reported.
- Ran the plugin validator `python3 /opt/codex/skills/.system/plugin-creator/scripts/validate_plugin.py .` and it reported success for the repository.
- Note: an initial `python -m pytest` run without `PYTHONPATH=src` failed to import the package, which was resolved by running tests with `PYTHONPATH=src` as listed above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bdb0c6f488329a58a9a88f14bbe6c)