### PR TITLE
fix: the plugin could not start on a default macOS PATH

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${PLUGIN_ROOT}/scripts/spotter-hook\""
+            "command": "\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT}}/scripts/spotter-hook\""
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${PLUGIN_ROOT}/scripts/spotter-hook\""
+            "command": "\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT}}/scripts/spotter-hook\""
           }
         ]
       }
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${PLUGIN_ROOT}/scripts/spotter-hook\""
+            "command": "\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT}}/scripts/spotter-hook\""
           }
         ]
       }
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${PLUGIN_ROOT}/scripts/spotter-hook\""
+            "command": "\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT}}/scripts/spotter-hook\""
           }
         ]
       }

--- a/scripts/spotter-hook
+++ b/scripts/spotter-hook
@@ -1,16 +1,65 @@
 #!/bin/sh
-# Run the bridge directly from an installed plugin checkout; no editable Python
-# installation is required. A project-local config wins unless SPOTTER_CONFIG
-# explicitly selects another file.
-set -eu
+# Run the bridge from an installed plugin checkout; no Python installation is
+# required, because Spotter has no runtime dependencies.
+#
+# Two rules govern this script:
+#
+#   1. It must resolve a Python that can actually run the package. The system
+#      python3 on macOS is 3.9, which cannot import tomllib, so calling `python3`
+#      unqualified fails on every hook invocation — silently, from the user's
+#      point of view, since a hook's stderr is discarded.
+#   2. It must fail open. A supervisor that cannot start has to let the session
+#      continue; the alternative is breaking the work it exists to protect.
+#
+# Note the deliberate absence of `set -e`: a failed probe must not take the
+# whole hook with it.
+set -u
 
-plugin_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# Parameter expansion rather than dirname: an external tool is one more thing
+# that can be missing from a hook's PATH, and this script exists precisely
+# because such assumptions fail quietly.
+case "$0" in
+    */*) script_dir=${0%/*} ;;
+    *) script_dir=. ;;
+esac
+plugin_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
 export PYTHONPATH="$plugin_root/src${PYTHONPATH:+:$PYTHONPATH}"
 
+runs_spotter() {
+    # tomllib is the binding constraint (3.11+), so test for what we need
+    # rather than for a version string we would have to parse.
+    "$1" -c 'import sys, tomllib; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' \
+        >/dev/null 2>&1
+}
+
+interpreter=""
+for candidate in ${SPOTTER_PYTHON:-} python3.14 python3.13 python3.12 python3.11 python3 python; do
+    [ -n "$candidate" ] || continue
+    command -v "$candidate" >/dev/null 2>&1 || continue
+    if runs_spotter "$candidate"; then
+        interpreter="$candidate"
+        break
+    fi
+done
+
+if [ -z "$interpreter" ]; then
+    # Deliberately not falling back to `uv run`: it can download an interpreter,
+    # and a multi-second stall inside PreToolUse is worse than not observing.
+    echo "spotter: no python 3.11+ on PATH; this session is NOT being supervised" >&2
+    echo "spotter: set SPOTTER_PYTHON=/path/to/python3.11+ to fix" >&2
+    exit 0
+fi
+
+# Config discovery, most specific first. ~/.spotter/spotter.toml is included
+# because that is where the tool's own documentation puts it; omitting it made
+# an installed plugin silently ignore the gates the user had configured.
 if [ -n "${SPOTTER_CONFIG:-}" ]; then
-    exec python3 -m spotter hook --config "$SPOTTER_CONFIG"
+    exec "$interpreter" -m spotter hook --config "$SPOTTER_CONFIG"
 fi
 if [ -f "${PWD}/spotter.toml" ]; then
-    exec python3 -m spotter hook --config "${PWD}/spotter.toml"
+    exec "$interpreter" -m spotter hook --config "${PWD}/spotter.toml"
 fi
-exec python3 -m spotter hook
+if [ -f "${SPOTTER_HOME:-$HOME/.spotter}/spotter.toml" ]; then
+    exec "$interpreter" -m spotter hook --config "${SPOTTER_HOME:-$HOME/.spotter}/spotter.toml"
+fi
+exec "$interpreter" -m spotter hook

--- a/scripts/spotter-hook
+++ b/scripts/spotter-hook
@@ -33,7 +33,12 @@ runs_spotter() {
 }
 
 interpreter=""
-for candidate in ${SPOTTER_PYTHON:-} python3.14 python3.13 python3.12 python3.11 python3 python; do
+if [ -n "${SPOTTER_PYTHON:-}" ] && command -v "$SPOTTER_PYTHON" >/dev/null 2>&1 \
+    && runs_spotter "$SPOTTER_PYTHON"; then
+    interpreter=$SPOTTER_PYTHON
+fi
+for candidate in python3.14 python3.13 python3.12 python3.11 python3 python; do
+    [ -z "$interpreter" ] || break
     [ -n "$candidate" ] || continue
     command -v "$candidate" >/dev/null 2>&1 || continue
     if runs_spotter "$candidate"; then
@@ -53,13 +58,15 @@ fi
 # Config discovery, most specific first. ~/.spotter/spotter.toml is included
 # because that is where the tool's own documentation puts it; omitting it made
 # an installed plugin silently ignore the gates the user had configured.
+set --
 if [ -n "${SPOTTER_CONFIG:-}" ]; then
-    exec "$interpreter" -m spotter hook --config "$SPOTTER_CONFIG"
+    set -- --config "$SPOTTER_CONFIG"
+elif [ -f "${PWD}/spotter.toml" ]; then
+    set -- --config "${PWD}/spotter.toml"
+elif [ -f "${SPOTTER_HOME:-$HOME/.spotter}/spotter.toml" ]; then
+    set -- --config "${SPOTTER_HOME:-$HOME/.spotter}/spotter.toml"
 fi
-if [ -f "${PWD}/spotter.toml" ]; then
-    exec "$interpreter" -m spotter hook --config "${PWD}/spotter.toml"
-fi
-if [ -f "${SPOTTER_HOME:-$HOME/.spotter}/spotter.toml" ]; then
-    exec "$interpreter" -m spotter hook --config "${SPOTTER_HOME:-$HOME/.spotter}/spotter.toml"
-fi
-exec "$interpreter" -m spotter hook
+"$interpreter" -m spotter hook "$@" || {
+    echo "spotter: hook failed; this event was allowed unsupervised" >&2
+    exit 0
+}

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -115,14 +115,20 @@ def _load_config(parser: argparse.ArgumentParser, path: Path | None) -> SpotterC
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    if args.command == "hook":
+        # Config is loaded inside the hook's own fail-open boundary rather than
+        # by the shared path below. parser.error() exits 2, and 2 is how a
+        # PreToolUse hook says "deny" — so a malformed config file would not
+        # merely disable supervision, it would block every tool call in the
+        # session. Unsupervised beats blocked.
+        return _hook_main(None, args.config)
+
     config = _load_config(parser, args.config)
     # One boundary check for every command that names a session: sanitizing
     # instead of rejecting maps distinct ids onto one file ("a/b" -> "a_b").
     if args.session is not None and not valid_session(args.session):
         parser.error(f"--session {args.session!r} is not a valid session id")
-
-    if args.command == "hook":
-        return _hook_main(config, args.config)
     if args.command == "analyze":
         return _analyze_main(args.session)
     if args.command == "prune":
@@ -419,6 +425,14 @@ def _hook_main(config: SpotterConfig | None, config_path: Path | None = None) ->
     Always exits 0: any failure here fails open. Breaking the Codex session
     over a supervision bug would be the exact harm Spotter exists to prevent.
     """
+    if config is None and config_path is not None:
+        try:
+            config = SpotterConfig.from_toml(config_path)
+        except (OSError, tomllib.TOMLDecodeError, ConfigurationError) as error:
+            # Unsupervised beats blocked: fall back to defaults and say so.
+            print(
+                f"spotter: unusable config {config_path} ({error}); using defaults", file=sys.stderr
+            )
     if config is None:
         config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig())
     try:

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -428,7 +428,7 @@ def _hook_main(config: SpotterConfig | None, config_path: Path | None = None) ->
     if config is None and config_path is not None:
         try:
             config = SpotterConfig.from_toml(config_path)
-        except (OSError, tomllib.TOMLDecodeError, ConfigurationError) as error:
+        except Exception as error:  # noqa: BLE001 — config is inside the fail-open boundary
             # Unsupervised beats blocked: fall back to defaults and say so.
             print(
                 f"spotter: unusable config {config_path} ({error}); using defaults", file=sys.stderr

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -86,7 +86,7 @@ def test_wrapper_fails_open_when_no_usable_python_exists(tmp_path: Path) -> None
         ),
         text=True,
         capture_output=True,
-        env={"PATH": f"{unusable}:/usr/bin:/bin", "HOME": str(home), "SPOTTER_HOME": str(home)},
+        env={"PATH": str(unusable), "HOME": str(home), "SPOTTER_HOME": str(home)},
         check=False,
     )
 
@@ -113,6 +113,8 @@ def test_wrapper_runs_with_an_empty_path(tmp_path: Path) -> None:
 
 def test_wrapper_finds_a_usable_python_by_explicit_override(tmp_path: Path) -> None:
     unusable = _fake_bin(tmp_path, "python3", "#!/bin/sh\nexit 1\n")
+    override = tmp_path / "python with spaces"
+    override.symlink_to(sys.executable)
     home = tmp_path / "home"
     result = subprocess.run(
         [str(Path("scripts/spotter-hook").resolve())],
@@ -128,15 +130,74 @@ def test_wrapper_finds_a_usable_python_by_explicit_override(tmp_path: Path) -> N
         text=True,
         capture_output=True,
         env={
-            "PATH": f"{unusable}:/usr/bin:/bin",
+            "PATH": str(unusable),
             "HOME": str(home),
             "SPOTTER_HOME": str(home),
-            "SPOTTER_PYTHON": sys.executable,
+            "SPOTTER_PYTHON": str(override),
         },
         check=False,
     )
     assert result.returncode == 0
     assert (home / "sessions" / "override.jsonl").exists()
+
+
+def test_wrapper_keeps_observing_when_the_config_is_invalid(tmp_path: Path) -> None:
+    """The bad config is handled inside the hook rather than by the wrapper's
+    catch-all, so supervision degrades to defaults instead of stopping."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "spotter.toml").write_text("not valid toml")
+
+    result = subprocess.run(
+        [str(Path("scripts/spotter-hook").resolve())],
+        input=json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "session_id": "bad-toml",
+                "cwd": str(tmp_path),
+                "tool_name": "Bash",
+                "tool_input": {"command": "true"},
+            }
+        ),
+        text=True,
+        capture_output=True,
+        env={**os.environ, "HOME": str(home), "SPOTTER_HOME": str(home)},
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "using defaults" in result.stderr
+    assert StepJournal.load(home / "sessions" / "bad-toml.jsonl")
+
+
+def test_wrapper_converts_an_unexpected_crash_into_fail_open(tmp_path: Path) -> None:
+    """Nothing in the hook path should exit non-zero any more, which is exactly
+    why the wrapper's catch-all must stay: it covers the failures nobody
+    predicted, such as an interpreter that dies on import."""
+    crasher = tmp_path / "bin-crash"
+    crasher.mkdir()
+    fake = crasher / "python3"
+    fake.write_text(
+        "#!/bin/sh\n"
+        'for arg in "$@"; do\n'
+        "  [ \"$arg\" = '-m' ] && exit 3\n"
+        "done\n"
+        "exit 0\n"  # the capability probe succeeds
+    )
+    fake.chmod(0o755)
+    home = tmp_path / "home"
+
+    result = subprocess.run(
+        [str(Path("scripts/spotter-hook").resolve())],
+        input="{}",
+        text=True,
+        capture_output=True,
+        env={"PATH": str(crasher), "HOME": str(home), "SPOTTER_HOME": str(home)},
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "allowed unsupervised" in result.stderr
 
 
 def test_wrapper_reads_the_documented_home_config(tmp_path: Path) -> None:
@@ -182,3 +243,65 @@ def test_hook_command_uses_the_runtime_plugin_root_variable() -> None:
     assert commands
     for command in commands:
         assert "${CLAUDE_PLUGIN_ROOT" in command
+
+
+def test_a_malformed_config_never_blocks_the_session(tmp_path: Path) -> None:
+    """A PreToolUse hook exits 2 to mean *deny*, and argparse.error() exits 2.
+    Loading config outside the fail-open boundary therefore turned a typo in
+    spotter.toml into a block on every tool call."""
+    home = tmp_path / "home"
+    home.mkdir()
+    broken = home / "spotter.toml"
+    broken.write_text("this is not = valid = toml\n")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "spotter", "hook", "--config", str(broken)],
+        input=json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "session_id": "broken-config",
+                "cwd": str(tmp_path),
+                "tool_name": "Bash",
+                "tool_input": {"command": "true"},
+            }
+        ),
+        text=True,
+        capture_output=True,
+        env={**os.environ, "SPOTTER_HOME": str(home), "PYTHONPATH": "src"},
+        check=False,
+    )
+
+    assert result.returncode == 0, "a bad config denied the tool call"
+    assert result.stdout == ""  # no deny decision emitted either
+    assert "using defaults" in result.stderr
+    # supervision continues on defaults rather than stopping
+    assert StepJournal.load(home / "sessions" / "broken-config.jsonl")
+
+
+def test_a_missing_config_also_fails_open(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    result = subprocess.run(
+        [sys.executable, "-m", "spotter", "hook", "--config", str(tmp_path / "absent.toml")],
+        input=json.dumps({"hook_event_name": "SessionStart", "session_id": "absent"}),
+        text=True,
+        capture_output=True,
+        env={**os.environ, "SPOTTER_HOME": str(home), "PYTHONPATH": "src"},
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "using defaults" in result.stderr
+
+
+def test_other_commands_still_reject_a_bad_config(tmp_path: Path) -> None:
+    """Only the hook fails open. Everything else should still refuse to run on
+    a config it cannot parse, rather than silently using different settings."""
+    broken = tmp_path / "spotter.toml"
+    broken.write_text("nope = = =\n")
+    result = subprocess.run(
+        [sys.executable, "-m", "spotter", "observe", "--config", str(broken)],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": "src"},
+        check=False,
+    )
+    assert result.returncode == 2

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 from spotter.snapshot import StepJournal
@@ -54,3 +55,130 @@ def test_bundled_hook_runs_without_installing_package(tmp_path: Path) -> None:
     assert result.stdout == ""
     records = StepJournal.load(home / "sessions" / "plugin-test.jsonl")
     assert records[0].event.kind == "tool_proposal"
+
+
+def _fake_bin(tmp_path: Path, name: str, body: str) -> Path:
+    """A directory containing one executable, for building a hermetic PATH."""
+    bin_dir = tmp_path / f"bin-{name}"
+    bin_dir.mkdir(exist_ok=True)
+    script = bin_dir / name
+    script.write_text(body)
+    script.chmod(0o755)
+    return bin_dir
+
+
+def test_wrapper_fails_open_when_no_usable_python_exists(tmp_path: Path) -> None:
+    """The system python3 on macOS is 3.9 and cannot import tomllib, so calling
+    it unqualified failed every hook invocation — with exit 1 and no journal,
+    which is the one outcome a supervisor must never produce silently."""
+    unusable = _fake_bin(tmp_path, "python3", "#!/bin/sh\nexit 1\n")
+    home = tmp_path / "home"
+    result = subprocess.run(
+        [str(Path("scripts/spotter-hook").resolve())],
+        input=json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "session_id": "no-python",
+                "cwd": str(tmp_path),
+                "tool_name": "Bash",
+                "tool_input": {"command": "true"},
+            }
+        ),
+        text=True,
+        capture_output=True,
+        env={"PATH": f"{unusable}:/usr/bin:/bin", "HOME": str(home), "SPOTTER_HOME": str(home)},
+        check=False,
+    )
+
+    assert result.returncode == 0, "a supervisor that cannot start must not fail the session"
+    assert "NOT being supervised" in result.stderr
+    assert "SPOTTER_PYTHON" in result.stderr  # says how to fix it
+    assert not (home / "sessions").exists()
+
+
+def test_wrapper_runs_with_an_empty_path(tmp_path: Path) -> None:
+    """Not even dirname is guaranteed to be present; this script exists because
+    such assumptions fail quietly."""
+    home = tmp_path / "home"
+    result = subprocess.run(
+        [str(Path("scripts/spotter-hook").resolve())],
+        input="{}",
+        text=True,
+        capture_output=True,
+        env={"PATH": str(tmp_path / "empty"), "HOME": str(home), "SPOTTER_HOME": str(home)},
+        check=False,
+    )
+    assert result.returncode == 0
+
+
+def test_wrapper_finds_a_usable_python_by_explicit_override(tmp_path: Path) -> None:
+    unusable = _fake_bin(tmp_path, "python3", "#!/bin/sh\nexit 1\n")
+    home = tmp_path / "home"
+    result = subprocess.run(
+        [str(Path("scripts/spotter-hook").resolve())],
+        input=json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "session_id": "override",
+                "cwd": str(tmp_path),
+                "tool_name": "Bash",
+                "tool_input": {"command": "true"},
+            }
+        ),
+        text=True,
+        capture_output=True,
+        env={
+            "PATH": f"{unusable}:/usr/bin:/bin",
+            "HOME": str(home),
+            "SPOTTER_HOME": str(home),
+            "SPOTTER_PYTHON": sys.executable,
+        },
+        check=False,
+    )
+    assert result.returncode == 0
+    assert (home / "sessions" / "override.jsonl").exists()
+
+
+def test_wrapper_reads_the_documented_home_config(tmp_path: Path) -> None:
+    """An installed plugin used to ignore ~/.spotter/spotter.toml, so the gates
+    a user had configured were silently absent."""
+    home = tmp_path / "home"
+    (home / "sessions").mkdir(parents=True)
+    (home / "spotter.toml").write_text(
+        'observation_only = false\n[main_agent]\nadapter = "codex"\n'
+        '[gates]\nforbidden_paths = ["secrets/*"]\n'
+    )
+    result = subprocess.run(
+        [str(Path("scripts/spotter-hook").resolve())],
+        input=json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "session_id": "cfg",
+                "cwd": str(tmp_path),
+                "tool_name": "apply_patch",
+                "tool_input": {"path": "secrets/key.pem"},
+            }
+        ),
+        text=True,
+        capture_output=True,
+        env={**os.environ, "HOME": str(home), "SPOTTER_HOME": str(home)},
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "forbidden_path" in result.stdout, "the configured gate never reached the hook"
+
+
+def test_hook_command_uses_the_runtime_plugin_root_variable() -> None:
+    """Codex and Claude Code expand CLAUDE_PLUGIN_ROOT; PLUGIN_ROOT is the
+    Copilot spelling, and an unexpanded variable makes the command an absolute
+    path that does not exist."""
+    hooks = json.loads(Path("hooks/hooks.json").read_text())
+    commands = [
+        entry["command"]
+        for event in hooks["hooks"].values()
+        for matcher in event
+        for entry in matcher["hooks"]
+    ]
+    assert commands
+    for command in commands:
+        assert "${CLAUDE_PLUGIN_ROOT" in command

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -252,7 +252,7 @@ def test_a_malformed_config_never_blocks_the_session(tmp_path: Path) -> None:
     home = tmp_path / "home"
     home.mkdir()
     broken = home / "spotter.toml"
-    broken.write_text("this is not = valid = toml\n")
+    broken.write_bytes(b"\xff")
 
     result = subprocess.run(
         [sys.executable, "-m", "spotter", "hook", "--config", str(broken)],


### PR DESCRIPTION
Review of the plugin work merged in #60/#62/#64/#65. Three defects, each reproduced against the merged code before fixing.

## [P0] The wrapper cannot run the package on a default macOS PATH

`scripts/spotter-hook` called an unqualified `python3`. On this machine `/usr/bin/python3` is **3.9.6**, which cannot import `tomllib`. Running the merged wrapper in a hook-like environment:

```
$ env -i PATH=/usr/bin:/bin HOME=$HOME SPOTTER_HOME=/tmp/t ./scripts/spotter-hook < payload.json
ModuleNotFoundError: No module named 'tomllib'
exit=1
journals written: 0
```

So: every hook invocation crashed, **exit 1** rather than the required fail-open 0, and a hook's stderr is discarded — from the user's side supervision was simply **absent while appearing installed**. That is precisely the failure mode `spotter doctor` exists to end.

Now:

```
spotter: no python 3.11+ on PATH; this session is NOT being supervised
spotter: set SPOTTER_PYTHON=/path/to/python3.11+ to fix
exit=0
```

The probe tests for the capability actually needed (`import tomllib`) rather than parsing a version string, honours `SPOTTER_PYTHON`, and tries `python3.14 … 3.11` before falling back to `python3`. It deliberately does **not** fall back to `uv run`: that can download an interpreter, and a multi-second stall inside `PreToolUse` is worse than not observing.

## [P0] `${PLUGIN_ROOT}` is the Copilot spelling

Evidence from the working plugin installed on this machine:

| file | variable |
| --- | --- |
| `ponytail/hooks/claude-codex-hooks.json` — what its Codex **and** Claude manifests point at | `${CLAUDE_PLUGIN_ROOT}` |
| `ponytail/hooks/copilot-hooks.json` | `${PLUGIN_ROOT}` |

An unexpanded variable makes the command `"/scripts/spotter-hook"`, which does not exist. The command now reads `${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT}}`, so one manifest serves all three runtimes.

## [P1] Installing the plugin silently dropped the user's configuration

Discovery was `SPOTTER_CONFIG` → `$PWD/spotter.toml` → none. The location this project's own docs use — `~/.spotter/spotter.toml` — was not in the chain, so an installed plugin ignored the gates and cadence already configured. Added to the chain, with a test that a configured `forbidden_paths` rule actually fires through the wrapper.

## Also

`dirname` replaced with parameter expansion. An external tool is one more thing that can be missing from a hook's PATH, and this script exists because such assumptions fail quietly — it was observed failing with `dirname: command not found` under a minimal PATH.

## Why the existing test did not catch any of this

`test_bundled_hook_runs_without_installing_package` passes `env={**os.environ, …}`, so it inherits the developer's PATH — including whatever modern Python is on it. The new tests build a hermetic PATH containing a `python3` that cannot run the package and assert fail-open, an actionable message, and no journal.

`spotter doctor` should also exercise the wrapper rather than only `sys.executable -m spotter`; that check belongs with #58, which owns `doctor.py`, and will land there.
