### PR TITLE
feat: add Codex App Server attach PoC

### DIFF
--- a/docs/app-server-poc.md
+++ b/docs/app-server-poc.md
@@ -1,0 +1,31 @@
+# Codex App Server attach PoC
+
+Run the server and the independent Spotter client in separate terminals:
+
+```bash
+codex app-server --listen unix://spotter-poc.sock
+uv run python -m spotter.app_server_poc --socket spotter-poc.sock
+```
+
+The client performs the WebSocket upgrade required by the Unix transport, initializes a second
+JSON-RPC connection, and calls `thread/list`. It never sends input unless `--steer` is explicitly
+provided together with `--thread-id` and `--turn-id`.
+
+```bash
+uv run python -m spotter.app_server_poc \
+  --socket spotter-poc.sock \
+  --thread-id THREAD --turn-id TURN --steer "[Spotter] Verify the failing assumption."
+```
+
+## Result on Codex 0.147.0
+
+- A second client can initialize and list threads over the external Unix-socket App Server.
+- `turn/steer` is present in the generated protocol and requires both thread and active-turn IDs.
+- `codex app-server daemon start` rejected the Homebrew/Cask install because managed daemon mode
+  requires Codex's standalone installer.
+- A TUI started before the external server remained on its embedded server: the same thread was
+  visible from durable history but reported `notLoaded`, so this is not a shared live control plane.
+
+The Tier-0 premise is therefore only partially proven. Do not build `spotterd` or automatic
+intervention on this yet. The remaining E2E check is to start plain `codex` after a supported managed
+daemon is available and confirm that this client sees its thread as loaded before testing steering.

--- a/docs/app-server-poc.md
+++ b/docs/app-server-poc.md
@@ -17,9 +17,12 @@ uv run python -m spotter.app_server_poc \
   --thread-id THREAD --turn-id TURN --steer "[Spotter] Verify the failing assumption."
 ```
 
-## Result on Codex 0.147.0
+## Result on Codex 0.147.0: no shared live control plane
 
-- A second client can initialize and list threads over the external Unix-socket App Server.
+- The required Tier-0 result is negative: the active TUI did not share the external App Server, so
+  Spotter could not observe or steer its live turn.
+- A second client can initialize and read durable thread history over the external Unix socket, but
+  this alone does not prove live attachment.
 - `turn/steer` is present in the generated protocol and requires both thread and active-turn IDs.
 - `codex app-server daemon start` rejected the Homebrew/Cask install because managed daemon mode
   requires Codex's standalone installer.

--- a/src/spotter/app_server_poc.py
+++ b/src/spotter/app_server_poc.py
@@ -1,0 +1,166 @@
+"""Tier-0 probe for attaching to a running Codex App Server."""
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import socket
+import struct
+import sys
+from pathlib import Path
+from typing import Any, Protocol
+
+
+class AppServerError(RuntimeError):
+    pass
+
+
+class _Readable(Protocol):
+    def read(self, size: int = -1, /) -> bytes | None: ...
+
+
+def _read_exact(stream: _Readable, size: int) -> bytes:
+    data = stream.read(size)
+    if data is None or len(data) != size:
+        raise AppServerError("app-server connection closed")
+    return data
+
+
+def _client_frame(payload: bytes, opcode: int = 1) -> bytes:
+    mask = os.urandom(4)
+    size = len(payload)
+    if size < 126:
+        header = bytes((0x80 | opcode, 0x80 | size))
+    elif size < 65536:
+        header = bytes((0x80 | opcode, 0xFE)) + struct.pack("!H", size)
+    else:
+        header = bytes((0x80 | opcode, 0xFF)) + struct.pack("!Q", size)
+    return header + mask + bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+
+
+class AppServerClient:
+    def __init__(self, socket_path: Path) -> None:
+        connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            connection.connect(str(socket_path))
+        except OSError as error:
+            connection.close()
+            raise AppServerError(f"cannot connect to {socket_path}: {error}") from error
+        self._stream = connection.makefile("rwb", buffering=0)
+        self._next_id = 1
+        self.notifications: list[dict[str, Any]] = []
+        self._handshake()
+
+    def _handshake(self) -> None:
+        key = base64.b64encode(os.urandom(16)).decode()
+        request = (
+            "GET / HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\n"
+            f"Connection: Upgrade\r\nSec-WebSocket-Key: {key}\r\n"
+            "Sec-WebSocket-Version: 13\r\n\r\n"
+        )
+        self._stream.write(request.encode())
+        status = self._stream.readline().decode(errors="replace").strip()
+        headers: dict[str, str] = {}
+        while line := self._stream.readline().decode(errors="replace").strip():
+            name, _, value = line.partition(":")
+            headers[name.lower()] = value.strip()
+        expected = base64.b64encode(
+            hashlib.sha1((key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode()).digest()
+        ).decode()
+        if " 101 " not in f" {status} " or headers.get("sec-websocket-accept") != expected:
+            raise AppServerError(f"websocket upgrade failed: {status}")
+
+    def _send(self, message: dict[str, Any]) -> None:
+        self._stream.write(_client_frame(json.dumps(message, separators=(",", ":")).encode()))
+
+    def _receive(self) -> dict[str, Any]:
+        while True:
+            first, second = _read_exact(self._stream, 2)
+            opcode = first & 0x0F
+            size = second & 0x7F
+            if size == 126:
+                size = struct.unpack("!H", _read_exact(self._stream, 2))[0]
+            elif size == 127:
+                size = struct.unpack("!Q", _read_exact(self._stream, 8))[0]
+            mask = _read_exact(self._stream, 4) if second & 0x80 else None
+            payload = _read_exact(self._stream, size)
+            if mask:
+                payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+            if opcode == 8:
+                raise AppServerError("app-server closed the websocket")
+            if opcode == 9:
+                self._stream.write(_client_frame(payload, opcode=10))
+                continue
+            if opcode == 1:
+                value = json.loads(payload)
+                if isinstance(value, dict):
+                    return value
+
+    def request(self, method: str, params: dict[str, Any]) -> Any:
+        request_id = self._next_id
+        self._next_id += 1
+        self._send({"id": request_id, "method": method, "params": params})
+        while True:
+            message = self._receive()
+            if message.get("id") == request_id:
+                if "error" in message:
+                    raise AppServerError(str(message["error"]))
+                return message.get("result")
+            self.notifications.append(message)
+
+    def initialize(self) -> dict[str, Any]:
+        result = self.request(
+            "initialize",
+            {
+                "clientInfo": {
+                    "name": "spotter",
+                    "title": "Spotter Tier-0 PoC",
+                    "version": "0.1.0",
+                },
+                "capabilities": {"experimentalApi": True},
+            },
+        )
+        if not isinstance(result, dict):
+            raise AppServerError("initialize returned a non-object result")
+        self._send({"method": "initialized", "params": {}})
+        return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--socket",
+        type=Path,
+        default=Path.home() / ".codex/app-server-control/app-server-control.sock",
+    )
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--thread-id")
+    parser.add_argument("--turn-id")
+    parser.add_argument("--steer", help="send text to an active turn (never done implicitly)")
+    args = parser.parse_args()
+    if args.steer and not (args.thread_id and args.turn_id):
+        parser.error("--steer requires --thread-id and --turn-id")
+    try:
+        client = AppServerClient(args.socket)
+        server = client.initialize()
+        threads = client.request("thread/list", {"limit": args.limit, "sortKey": "updated_at"})
+        result: dict[str, Any] = {"server": server, "threads": threads.get("data", [])}
+        if args.steer:
+            result["steer"] = client.request(
+                "turn/steer",
+                {
+                    "threadId": args.thread_id,
+                    "expectedTurnId": args.turn_id,
+                    "input": [{"type": "text", "text": args.steer}],
+                },
+            )
+        print(json.dumps(result, indent=2))
+        return 0
+    except (AppServerError, OSError, ValueError) as error:
+        print(f"app-server PoC failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/spotter/app_server_poc.py
+++ b/src/spotter/app_server_poc.py
@@ -21,10 +21,13 @@ class _Readable(Protocol):
 
 
 def _read_exact(stream: _Readable, size: int) -> bytes:
-    data = stream.read(size)
-    if data is None or len(data) != size:
-        raise AppServerError("app-server connection closed")
-    return data
+    chunks = bytearray()
+    while len(chunks) < size:
+        chunk = stream.read(size - len(chunks))
+        if not chunk:
+            raise AppServerError("app-server connection closed")
+        chunks.extend(chunk)
+    return bytes(chunks)
 
 
 def _client_frame(payload: bytes, opcode: int = 1) -> bytes:
@@ -40,8 +43,9 @@ def _client_frame(payload: bytes, opcode: int = 1) -> bytes:
 
 
 class AppServerClient:
-    def __init__(self, socket_path: Path) -> None:
+    def __init__(self, socket_path: Path, timeout: float = 10.0) -> None:
         connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        connection.settimeout(timeout)
         try:
             connection.connect(str(socket_path))
         except OSError as error:
@@ -72,11 +76,14 @@ class AppServerClient:
             raise AppServerError(f"websocket upgrade failed: {status}")
 
     def _send(self, message: dict[str, Any]) -> None:
+        message = {"jsonrpc": "2.0", **message}
         self._stream.write(_client_frame(json.dumps(message, separators=(",", ":")).encode()))
 
     def _receive(self) -> dict[str, Any]:
+        message = bytearray()
         while True:
             first, second = _read_exact(self._stream, 2)
+            final = bool(first & 0x80)
             opcode = first & 0x0F
             size = second & 0x7F
             if size == 126:
@@ -93,9 +100,20 @@ class AppServerClient:
                 self._stream.write(_client_frame(payload, opcode=10))
                 continue
             if opcode == 1:
-                value = json.loads(payload)
+                if message:
+                    raise AppServerError("new text frame before fragmented message completed")
+                message.extend(payload)
+            elif opcode == 0:
+                if not message:
+                    raise AppServerError("continuation frame without an initial text frame")
+                message.extend(payload)
+            else:
+                continue
+            if final:
+                value = json.loads(message)
                 if isinstance(value, dict):
                     return value
+                raise AppServerError("app-server returned a non-object message")
 
     def request(self, method: str, params: dict[str, Any]) -> Any:
         request_id = self._next_id
@@ -129,11 +147,8 @@ class AppServerClient:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--socket",
-        type=Path,
-        default=Path.home() / ".codex/app-server-control/app-server-control.sock",
-    )
+    parser.add_argument("--socket", type=Path, required=True)
+    parser.add_argument("--timeout", type=float, default=10.0)
     parser.add_argument("--limit", type=int, default=20)
     parser.add_argument("--thread-id")
     parser.add_argument("--turn-id")
@@ -142,7 +157,7 @@ def main() -> int:
     if args.steer and not (args.thread_id and args.turn_id):
         parser.error("--steer requires --thread-id and --turn-id")
     try:
-        client = AppServerClient(args.socket)
+        client = AppServerClient(args.socket, args.timeout)
         server = client.initialize()
         threads = client.request("thread/list", {"limit": args.limit, "sortKey": "updated_at"})
         result: dict[str, Any] = {"server": server, "threads": threads.get("data", [])}

--- a/tests/test_app_server_poc.py
+++ b/tests/test_app_server_poc.py
@@ -1,0 +1,13 @@
+import struct
+
+from spotter.app_server_poc import _client_frame
+
+
+def test_client_frame_is_masked_and_round_trips() -> None:
+    payload = b"x" * 130
+    frame = _client_frame(payload)
+    assert frame[0] == 0x81
+    assert frame[1] == 0xFE
+    assert struct.unpack("!H", frame[2:4])[0] == len(payload)
+    mask = frame[4:8]
+    assert bytes(byte ^ mask[index % 4] for index, byte in enumerate(frame[8:])) == payload

--- a/tests/test_app_server_poc.py
+++ b/tests/test_app_server_poc.py
@@ -1,6 +1,21 @@
+import io
+import json
 import struct
 
-from spotter.app_server_poc import _client_frame
+from spotter.app_server_poc import AppServerClient, _client_frame, _read_exact
+
+
+class ChunkedReader:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.chunks = iter(chunks)
+
+    def read(self, size: int = -1) -> bytes:
+        return next(self.chunks, b"")
+
+
+def _server_frame(payload: bytes, *, opcode: int, final: bool) -> bytes:
+    assert len(payload) < 126
+    return bytes(((0x80 if final else 0) | opcode, len(payload))) + payload
 
 
 def test_client_frame_is_masked_and_round_trips() -> None:
@@ -11,3 +26,19 @@ def test_client_frame_is_masked_and_round_trips() -> None:
     assert struct.unpack("!H", frame[2:4])[0] == len(payload)
     mask = frame[4:8]
     assert bytes(byte ^ mask[index % 4] for index, byte in enumerate(frame[8:])) == payload
+
+
+def test_read_exact_collects_short_reads() -> None:
+    assert _read_exact(ChunkedReader([b"ab", b"c", b"de"]), 5) == b"abcde"
+
+
+def test_receive_reassembles_fragmented_text_frames() -> None:
+    payload = json.dumps({"id": 1, "result": {"data": ["x"]}}).encode()
+    stream = io.BytesIO(
+        _server_frame(payload[:8], opcode=1, final=False)
+        + _server_frame(payload[8:], opcode=0, final=True)
+    )
+    client = object.__new__(AppServerClient)
+    client._stream = stream  # type: ignore[assignment]
+
+    assert client._receive() == {"id": 1, "result": {"data": ["x"]}}


### PR DESCRIPTION
## Result

The Tier-0 result is negative: the active Codex TUI did not share the external App Server, so this PoC cannot yet observe or steer its live turn. It only proves that an independent second client can initialize and read durable thread history over the Unix-socket transport. Do not build `spotterd` or automatic intervention on this result yet.

## Changes

- add a dependency-free Unix-socket WebSocket probe
- support `initialize`, `thread/list`, and explicit `turn/steer`
- handle short socket reads and fragmented WebSocket messages
- require an explicit socket and bound connection/response waits with a timeout
- document the managed-daemon limitation and remaining shared-live-session check

## Verification

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src tests`
- `uv run pytest` (`159 passed`)
- live attach against Codex 0.147.0 external Unix-socket App Server

Tracks the Tier-0 App Server lifecycle/attach PoC in #66.