### PR TITLE
fix: scope the snapshot lock to a repository, and record slow hooks

### DIFF
--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -31,8 +31,8 @@ from spotter.experiment import list_forks, results_path, run_experiment, summari
 from spotter.gates import Gate
 from spotter.hook import journal_path, run_hook
 from spotter.labels import LabelError, add_label, valid_session
-from spotter.metrics import Tally, merge, tally_session
-from spotter.paths import secure_dir, spotter_home
+from spotter.metrics import Tally, merge, tally_harm, tally_session
+from spotter.paths import sanitize_session, secure_dir, spotter_home
 from spotter.redact import scan_text
 from spotter.replay import ReplayError, fork, plan_to_json
 from spotter.reviewer import last_usage, review
@@ -42,6 +42,7 @@ from spotter.snapshot import (
     StepRecord,
     global_lock,
     prune_snapshots,
+    repo_lock,
     snapshot_references,
     stale_journals,
 )
@@ -258,6 +259,18 @@ def _span_of(records: list[StepRecord]) -> str:
     return f" span={span / 60:.1f}m{suffix}"
 
 
+def _slow_of(slow: list[StepRecord]) -> str:
+    """Hooks that ran long enough to risk the runtime's timeout.
+
+    A hook killed at the limit fails open, so supervision stops precisely for
+    the tool calls that mutate files; the count belongs next to the others.
+    """
+    if not slow:
+        return ""
+    worst = max(float(r.event.payload.get("elapsed_ms") or 0) for r in slow)
+    return f" slow_hooks={len(slow)} (worst {worst:.0f}ms)"
+
+
 def _analyze_main(session: str | None) -> int:
     """Summarize journaled sessions: the aggregation step of the FP-review loop.
 
@@ -283,10 +296,11 @@ def _analyze_main(session: str | None) -> int:
         snapshots = sum(1 for r in records if r.snapshot)
         flagged = [r for r in records if r.event.kind in ("gate_shadow_block", "gate_fail_open")]
         verdicts = [r for r in records if r.event.kind == "reviewer_decision"]
+        slow = [r for r in records if r.event.kind == "hook_slow"]
         print(
             f"{journal.stem}: steps={len(records)} proposals={len(proposals)} "
             f"snapshots={snapshots} flagged={len(flagged)} reviews={len(verdicts)}"
-            f"{_span_of(records)}"
+            f"{_span_of(records)}{_slow_of(slow)}"
         )
         for record in verdicts:
             payload = record.event.payload
@@ -652,6 +666,20 @@ def _metrics_main(session: str | None) -> int:
     print("  " + reviewer.rate_line("interventions", "correct"))
     print("P1 observability ceiling (label failed sessions visible|invisible):")
     print("  " + ceiling.rate_line("sessions", "visible"))
+    experiment_dir = spotter_home() / "experiments"
+    experiment_paths = sorted(experiment_dir.glob("*.jsonl")) if experiment_dir.exists() else []
+    if session:
+        prefix = sanitize_session(session) + "-step"
+        experiment_paths = [path for path in experiment_paths if path.name.startswith(prefix)]
+    try:
+        harm = tally_harm(experiment_paths)
+    except (OSError, ValueError) as error:
+        print(f"metrics aborted: {error}", file=sys.stderr)
+        return 1
+    print("Tier 2 intervention safety:")
+    print("  " + harm.line())
+    print("  recovery: not measurable — no explicit intervention outcome events recorded")
+    print("  ignored intervention: not measurable — delivery journaling is not implemented")
     return 0
 
 
@@ -681,7 +709,11 @@ def _prune_main(
         # still referenced, and pruning. Releasing between those steps lets a
         # hook append to a journal being deleted, or pin a ref this pass has
         # already decided is unreferenced (PR #58 review, P0).
-        with global_lock():
+        # Global for the journal phase (journals are not per repository, so two
+        # prunes must not select the same stale file), repo-scoped for the ref
+        # phase. Always in this order; the hook only ever takes the repo lock,
+        # so no caller can acquire them the other way round.
+        with global_lock(), repo_lock(repo):
             cutoff = time.time() - (max_age_days or 0) * 86400
             doomed = (
                 stale_journals(sessions_dir, max_age_days)

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -31,7 +31,15 @@ from spotter.experiment import list_forks, results_path, run_experiment, summari
 from spotter.gates import Gate
 from spotter.hook import journal_path, run_hook
 from spotter.labels import LabelError, add_label, valid_session
-from spotter.metrics import Tally, merge, tally_harm, tally_session
+from spotter.metrics import (
+    InterventionTally,
+    Tally,
+    merge,
+    merge_interventions,
+    tally_harm,
+    tally_interventions,
+    tally_session,
+)
 from spotter.paths import sanitize_session, secure_dir, spotter_home
 from spotter.redact import scan_text
 from spotter.replay import ReplayError, fork, plan_to_json
@@ -46,6 +54,7 @@ from spotter.snapshot import (
     snapshot_references,
     stale_journals,
 )
+from spotter.sycophancy import OUTCOMES, assess, load_case, tally_compliance
 from spotter.trace import TraceEvent
 
 
@@ -62,6 +71,7 @@ def build_parser() -> argparse.ArgumentParser:
             "prune",
             "review",
             "experiment",
+            "assess-sycophancy",
             "label",
             "metrics",
             "status",
@@ -87,6 +97,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--repo", type=Path, help="repo path (prune; fork override when the journal lacks cwd)"
     )
     parser.add_argument("--guidance", help="course-correction text for the forked run (fork)")
+    parser.add_argument("--wrong-nudge", help="experiment: case id from --corpus")
+    parser.add_argument("--corpus", type=Path, help="experiment: wrong-nudge corpus JSON")
+    parser.add_argument("--experiment-id", help="assess-sycophancy: experiment UUID")
+    parser.add_argument("--outcome", choices=OUTCOMES, help="assess-sycophancy: behavior outcome")
     parser.add_argument(
         "--apply", action="store_true", help="prune: actually delete (default is dry-run)"
     )
@@ -179,26 +193,53 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "doctor":
         return _doctor_main(args.config)
     if args.command == "experiment":
-        if not args.session or args.step is None or not args.guidance:
-            parser.error("experiment requires --session, --step and --guidance")
+        if not args.session or args.step is None:
+            parser.error("experiment requires --session and --step")
+        if bool(args.wrong_nudge) != bool(args.corpus):
+            parser.error("--wrong-nudge and --corpus must be used together")
+        if args.guidance and args.wrong_nudge:
+            parser.error("use either --guidance or --wrong-nudge, not both")
+        kind, guidance_class = "nudge", None
+        guidance = args.guidance
+        if args.wrong_nudge:
+            try:
+                case = load_case(args.corpus, args.wrong_nudge)
+            except ValueError as error:
+                parser.error(str(error))
+            guidance, kind, guidance_class = case.guidance, "wrong_nudge", case.kind
+        if not guidance:
+            parser.error("experiment requires --guidance or --wrong-nudge")
         if args.pairs < 1:
             parser.error("--pairs must be >= 1")
         try:
             results = run_experiment(
                 args.session,
                 args.step,
-                args.guidance,
+                guidance,
                 pairs=args.pairs,
                 check=args.check,
                 run=args.run,
                 model=args.model,
                 keep_artifacts=args.keep_artifacts,
+                kind=kind,
+                guidance_class=guidance_class,
             )
         except (ReplayError, SnapshotError, OSError, subprocess.SubprocessError) as error:
             print(f"experiment failed: {error}", file=sys.stderr)
             return 1
         print(summarize(results))
+        print(f"experiment id: {results[0].experiment_id}")
         print(f"rows appended to {results_path(args.session, args.step)}")
+        return 0
+    if args.command == "assess-sycophancy":
+        if not args.experiment_id or args.step is None or not args.outcome:
+            parser.error("assess-sycophancy requires --experiment-id, --step (pair), and --outcome")
+        try:
+            path = assess(args.experiment_id, args.step, args.outcome, args.note)
+        except (OSError, ValueError) as error:
+            print(f"assessment failed: {error}", file=sys.stderr)
+            return 1
+        print(f"assessed {args.experiment_id} pair {args.step}: {args.outcome} ({path})")
         return 0
     if args.command == "label":
         if not args.session or not args.verdict:
@@ -262,13 +303,15 @@ def _span_of(records: list[StepRecord]) -> str:
 def _slow_of(slow: list[StepRecord]) -> str:
     """Hooks that ran long enough to risk the runtime's timeout.
 
-    A hook killed at the limit fails open, so supervision stops precisely for
-    the tool calls that mutate files; the count belongs next to the others.
+    Says "completed" because it means it: a hook killed at the timeout never
+    writes its record, so this counts survivors and cannot see the censored
+    tail. Reporting it without that word would invite reading a p99 off a
+    distribution the worst cases are missing from (PR #73 review, P1).
     """
     if not slow:
         return ""
     worst = max(float(r.event.payload.get("elapsed_ms") or 0) for r in slow)
-    return f" slow_hooks={len(slow)} (worst {worst:.0f}ms)"
+    return f" slow_hooks={len(slow)} (completed only, worst {worst:.0f}ms)"
 
 
 def _analyze_main(session: str | None) -> int:
@@ -632,6 +675,7 @@ def _metrics_main(session: str | None) -> int:
     gates: dict[str, Tally] = {}
     blind_spots: dict[str, int] = {}
     reviewer = ceiling = Tally()
+    interventions: dict[str, InterventionTally] = {}
     for journal in journals:
         try:
             records = StepJournal.load(journal)
@@ -651,6 +695,7 @@ def _metrics_main(session: str | None) -> int:
                 blind_spots[rule] = blind_spots.get(rule, 0) + 1
         reviewer = merge(reviewer, session_reviewer)
         ceiling = merge(ceiling, session_ceiling)
+        interventions = merge_interventions(interventions, tally_interventions(records))
 
     print("P3 gate false positives (label each flag tp|fp):")
     if not gates:
@@ -678,8 +723,16 @@ def _metrics_main(session: str | None) -> int:
         return 1
     print("Tier 2 intervention safety:")
     print("  " + harm.line())
-    print("  recovery: not measurable — no explicit intervention outcome events recorded")
-    print("  ignored intervention: not measurable — delivery journaling is not implemented")
+    try:
+        print("  " + tally_compliance().line())
+    except (OSError, ValueError) as error:
+        print(f"metrics aborted: {error}", file=sys.stderr)
+        return 1
+    if not interventions:
+        print("  recovery/ignored: 0/0 delivered — no intervention outcome data")
+    for kind, intervention_tally in sorted(interventions.items()):
+        for line in intervention_tally.lines(kind):
+            print("  " + line)
     return 0
 
 

--- a/src/spotter/experiment.py
+++ b/src/spotter/experiment.py
@@ -96,6 +96,8 @@ def run_experiment(
     codex_home: Path | None = None,
     model: str | None = None,
     keep_artifacts: bool = False,
+    kind: str = "nudge",
+    guidance_class: str | None = None,
 ) -> list[ArmResult]:
     """Build (and with run=True, execute) n counterfactual pairs."""
     if pairs < 1:
@@ -111,6 +113,8 @@ def run_experiment(
         "source_session": session_id,
         "step": step,
         "guidance": guidance,
+        "kind": kind,
+        "guidance_class": guidance_class,
         "control_prompt": CONTROL_PROMPT,
         "check": check,
         "sandbox": sandbox,

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -171,10 +171,15 @@ def _maybe_spawn_shadow_review(
             )
 
 
-# Hooks are registered with a 10s timeout that nobody measured. A hook killed
-# at that limit fails open, so supervision stops silently for exactly the tool
-# calls that mutate files — the one case where it matters most. Recording the
+# Hooks are registered with a 10s timeout that nobody measured. Recording the
 # slow ones turns a guessed budget into an observed distribution (issue #49).
+#
+# Known limit, stated because it bounds what the number can be used for: this
+# records *completed* hooks only. A hook killed at the runtime's timeout never
+# reaches the line that writes the record, so the censored tail — the case that
+# actually stops supervision — is absent from the distribution. A p99 computed
+# from this is a p99 of the survivors. Observing the kills needs the runtime's
+# own view or a start-record reconciliation, and is not attempted here.
 SLOW_HOOK_MS = 1000.0
 
 
@@ -184,7 +189,8 @@ def _record_if_slow(journal_file: Path, kind: str, elapsed_ms: float) -> None:
     Only the slow ones: stamping every record with its own duration would
     double the journal to describe the common case, which is uninteresting by
     construction. The threshold is a fraction of the configured hook timeout,
-    so the record arrives before the kill, not after.
+    so a hook heading for trouble is recorded before it gets there — but a
+    hook that is actually killed leaves nothing at all. See SLOW_HOOK_MS.
     """
     if elapsed_ms < SLOW_HOOK_MS:
         return

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -10,6 +10,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
@@ -19,7 +20,7 @@ from spotter.config import SpotterConfig
 from spotter.core import SpotterRuntime
 from spotter.gates import Gate
 from spotter.paths import sanitize_session, secure_dir, spotter_home
-from spotter.snapshot import SnapshotError, StepJournal, global_lock, snapshot_worktree
+from spotter.snapshot import SnapshotError, StepJournal, repo_lock, snapshot_worktree
 from spotter.trace import TraceEvent
 
 _PATCH_PATH = re.compile(r"^\*\*\* (?:(?:Add|Update|Delete) File|Move to): (.+)$", re.MULTILINE)
@@ -170,10 +171,34 @@ def _maybe_spawn_shadow_review(
             )
 
 
+# Hooks are registered with a 10s timeout that nobody measured. A hook killed
+# at that limit fails open, so supervision stops silently for exactly the tool
+# calls that mutate files — the one case where it matters most. Recording the
+# slow ones turns a guessed budget into an observed distribution (issue #49).
+SLOW_HOOK_MS = 1000.0
+
+
+def _record_if_slow(journal_file: Path, kind: str, elapsed_ms: float) -> None:
+    """Journal a hook that took long enough to be worth knowing about.
+
+    Only the slow ones: stamping every record with its own duration would
+    double the journal to describe the common case, which is uninteresting by
+    construction. The threshold is a fraction of the configured hook timeout,
+    so the record arrives before the kill, not after.
+    """
+    if elapsed_ms < SLOW_HOOK_MS:
+        return
+    with suppress(SnapshotError, OSError):
+        StepJournal(journal_file).record(
+            TraceEvent("hook_slow", {"kind": kind, "elapsed_ms": round(elapsed_ms, 1)})
+        )
+
+
 def run_hook(
     payload: dict[str, Any], config: SpotterConfig, config_path: Path | None = None
 ) -> str | None:
     """Process one hook invocation. Returns stdout JSON, or None to allow."""
+    started = time.perf_counter()
     cwd = payload.get("cwd")
     gate = Gate(
         forbidden_paths=config.gates.forbidden_paths,
@@ -193,9 +218,10 @@ def run_hook(
     ):
         # PreToolUse captures the state before this patch; PostToolUse captures
         # the state after it, keeping later rollout prefixes aligned with disk.
-        # The global lock closes the ref-created-but-not-yet-journaled window
-        # a concurrent prune --apply could otherwise exploit.
-        with global_lock():
+        # The repository lock closes the ref-created-but-not-yet-journaled
+        # window a concurrent prune --apply could otherwise exploit — scoped to
+        # this repository, because a session elsewhere has no stake in it.
+        with repo_lock(Path(cwd)):
             try:
                 # Reuse the previous snapshot when the tree is unchanged, so a
                 # tool call that touched nothing does not mint a ref (#7).
@@ -205,6 +231,7 @@ def run_hook(
             decision = runtime.observe(event)
     else:
         decision = runtime.observe(event)
+    _record_if_slow(journal_file, event.kind, (time.perf_counter() - started) * 1000)
     if event.kind == "tool_proposal":
         _maybe_spawn_shadow_review(
             config, payload, journal_file, adapter.last_proposal_number, config_path

--- a/src/spotter/metrics.py
+++ b/src/spotter/metrics.py
@@ -65,6 +65,78 @@ def tally_harm(paths: list[Path]) -> HarmTally:
 
 
 @dataclass(frozen=True)
+class InterventionTally:
+    delivered: int = 0
+    assessed: int = 0
+    recovered: int = 0
+    degraded: int = 0
+    ignored: int = 0
+
+    def lines(self, kind: str) -> tuple[str, str]:
+        acted = self.recovered + self.degraded
+        coverage = f"{self.assessed}/{self.delivered} outcomes recorded"
+        if acted < MIN_SAMPLES:
+            recovery = f"{kind} recovery: too few acted interventions ({acted}) to state a rate"
+        else:
+            recovery = f"{kind} recovery: {self.recovered / acted:.0%} of {acted} acted"
+        if self.assessed < MIN_SAMPLES:
+            ignored = (
+                f"{kind} ignored: {coverage} — too few recorded outcomes "
+                f"({self.assessed}) to state a rate"
+            )
+        else:
+            qualifier = "" if self.assessed == self.delivered else " (provisional)"
+            ignored = (
+                f"{kind} ignored: {self.ignored / self.assessed:.0%} of "
+                f"{self.assessed}; {coverage}{qualifier}"
+            )
+        return recovery, ignored
+
+
+def tally_interventions(records: list[StepRecord]) -> dict[str, InterventionTally]:
+    """Join explicit delivery and outcome events; absence is unknown, never ignored."""
+    delivered: dict[str, str] = {}
+    outcomes: dict[str, str] = {}
+    for record in records:
+        payload = record.event.payload
+        intervention_id = str(payload.get("intervention_id") or "")
+        if record.event.kind == "reviewer_injected" and intervention_id:
+            delivered[intervention_id] = str(payload.get("intervention_type") or "unknown")
+        elif record.event.kind == "intervention_outcome" and intervention_id in delivered:
+            outcome = str(payload.get("outcome") or "")
+            if outcome in ("recovered", "degraded", "ignored"):
+                outcomes[intervention_id] = outcome
+    tallies: dict[str, InterventionTally] = {}
+    for intervention_id, kind in delivered.items():
+        old = tallies.get(kind, InterventionTally())
+        recorded_outcome = outcomes.get(intervention_id)
+        tallies[kind] = InterventionTally(
+            delivered=old.delivered + 1,
+            assessed=old.assessed + (recorded_outcome is not None),
+            recovered=old.recovered + (recorded_outcome == "recovered"),
+            degraded=old.degraded + (recorded_outcome == "degraded"),
+            ignored=old.ignored + (recorded_outcome == "ignored"),
+        )
+    return tallies
+
+
+def merge_interventions(
+    left: dict[str, InterventionTally], right: dict[str, InterventionTally]
+) -> dict[str, InterventionTally]:
+    merged = dict(left)
+    for kind, value in right.items():
+        old = merged.get(kind, InterventionTally())
+        merged[kind] = InterventionTally(
+            old.delivered + value.delivered,
+            old.assessed + value.assessed,
+            old.recovered + value.recovered,
+            old.degraded + value.degraded,
+            old.ignored + value.ignored,
+        )
+    return merged
+
+
+@dataclass(frozen=True)
 class Tally:
     labeled: int = 0
     total: int = 0

--- a/src/spotter/metrics.py
+++ b/src/spotter/metrics.py
@@ -1,4 +1,4 @@
-"""Turn labels into the three numbers the plan gates on.
+"""Turn labels and experiments into the numbers the plan gates on.
 
 Every rate is reported with its coverage (labeled / total). A rate computed
 from a handful of labels is not a measurement, and this module refuses to
@@ -6,13 +6,62 @@ present one as if it were: rates below FULL coverage are marked provisional,
 and rates with fewer than MIN_SAMPLES labels are withheld entirely.
 """
 
+import json
 from dataclasses import dataclass
+from pathlib import Path
 
 from spotter.labels import Label, load_labels, matches
 from spotter.snapshot import StepRecord
 
 MIN_SAMPLES = 5
 GATE_KINDS = ("gate_shadow_block", "gate_block")
+
+
+@dataclass(frozen=True)
+class HarmTally:
+    harmed: int = 0
+    complete: int = 0
+    total: int = 0
+
+    def line(self) -> str:
+        coverage = f"{self.complete}/{self.total} complete pairs"
+        if self.complete < MIN_SAMPLES:
+            return f"harm: {coverage} — too few complete pairs ({self.complete}) to state a rate"
+        qualifier = "" if self.complete == self.total else " (provisional: coverage incomplete)"
+        return (
+            f"harm: {self.harmed / self.complete:.0%} of {self.complete} pairs; "
+            f"{coverage}{qualifier}"
+        )
+
+
+def tally_harm(paths: list[Path]) -> HarmTally:
+    """Count control-pass/guidance-fail pairs from durable experiment rows."""
+    harmed = complete = total = 0
+    for path in paths:
+        experiments: dict[str, dict[int, dict[str, tuple[int | None, int | None]]]] = {}
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ValueError(f"{path.name} line {number} is unreadable") from error
+            if "arm" not in row:
+                continue
+            pair = experiments.setdefault(str(row["experiment_id"]), {}).setdefault(
+                int(row["pair"]), {}
+            )
+            pair[str(row["arm"])] = (row.get("agent_exit"), row.get("check_exit"))
+        for pairs in experiments.values():
+            total += len(pairs)
+            for arms in pairs.values():
+                if set(arms) != {"control", "guidance"} or any(
+                    agent != 0 or check is None for agent, check in arms.values()
+                ):
+                    continue
+                complete += 1
+                harmed += arms["control"][1] == 0 and arms["guidance"][1] != 0
+    return HarmTally(harmed, complete, total)
 
 
 @dataclass(frozen=True)

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -8,6 +8,7 @@ the full worktree (including untracked files), and restore never mutates the
 user's checkout.
 """
 
+import hashlib
 import json
 import os
 import subprocess
@@ -31,15 +32,44 @@ class SnapshotError(RuntimeError):
 
 @contextmanager
 def global_lock(spotter_home_override: Path | None = None) -> Iterator[None]:
-    """Serialize snapshot-ref creation+journaling against prune.
+    """Serialize operations that span repositories.
 
-    The ref exists before the journal references it; without this lock a
-    concurrent prune --apply sees an unreferenced ref in that window and
-    deletes a snapshot the journal is about to claim (PR #12 review, P0).
+    Only journal retention needs this: journals are not per repository, so two
+    prunes selecting the same stale journal must not race. Snapshot pinning
+    does *not* belong here — see repo_lock.
     """
     home = spotter_home_override or spotter_home()
     secure_dir(home)
     with (home / "lock").open("w") as handle:
+        flock(handle, LOCK_EX)
+        try:
+            yield
+        finally:
+            flock(handle, LOCK_UN)
+
+
+@contextmanager
+def repo_lock(repo: Path, spotter_home_override: Path | None = None) -> Iterator[None]:
+    """Serialize snapshot-ref creation+journaling against prune, per repository.
+
+    The ref exists before the journal references it; without a lock a
+    concurrent prune --apply sees an unreferenced ref in that window and
+    deletes a snapshot the journal is about to claim (PR #12 review, P0).
+
+    That invariant is per repository — refs live in one repo and prune already
+    filters references by repo — but the lock protecting it was global, so a
+    patch in repository A blocked the PreToolUse hook of an unrelated session
+    in repository B. Measured on a 27,669-file repository, the hold is 397 ms
+    of git work, taken on every mutation (issue #49).
+
+    Keyed by the resolved path so two spellings of the same repository take the
+    same lock, and hashed so the key cannot collide with a sanitised name or
+    outgrow a filename.
+    """
+    home = spotter_home_override or spotter_home()
+    locks = secure_dir(home / "locks")
+    key = hashlib.sha256(str(repo.resolve()).encode()).hexdigest()[:24]
+    with (locks / f"{key}.lock").open("w") as handle:
         flock(handle, LOCK_EX)
         try:
             yield

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -48,6 +48,25 @@ def global_lock(spotter_home_override: Path | None = None) -> Iterator[None]:
             flock(handle, LOCK_UN)
 
 
+def _repo_identity(repo: Path) -> str:
+    """A stable name for the repository containing ``repo``.
+
+    The common git directory is shared by the root, every subdirectory and
+    every linked worktree, which is precisely the set that must contend for
+    one lock. Outside a repository there is nothing to pin and no refs to
+    race over, so the resolved path is a sufficient — and deterministic — key.
+    """
+    common = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        cwd=repo if repo.exists() else Path.cwd(),
+        capture_output=True,
+        text=True,
+    )
+    if common.returncode == 0 and common.stdout.strip():
+        return str(Path(common.stdout.strip()).resolve())
+    return str(repo.resolve())
+
+
 @contextmanager
 def repo_lock(repo: Path, spotter_home_override: Path | None = None) -> Iterator[None]:
     """Serialize snapshot-ref creation+journaling against prune, per repository.
@@ -62,13 +81,16 @@ def repo_lock(repo: Path, spotter_home_override: Path | None = None) -> Iterator
     in repository B. Measured on a 27,669-file repository, the hold is 397 ms
     of git work, taken on every mutation (issue #49).
 
-    Keyed by the resolved path so two spellings of the same repository take the
-    same lock, and hashed so the key cannot collide with a sanitised name or
-    outgrow a filename.
+    Keyed by the repository's own identity, not by the path handed in. A hook
+    runs wherever the agent is working — often a subdirectory — while prune is
+    given the root, and resolving a path only normalises its spelling, not
+    which repository it belongs to. Keying on the path let /repo and
+    /repo/packages/a take different locks inside one repository, which
+    reinstates exactly the race this lock exists to prevent (PR #73 review, P0).
     """
     home = spotter_home_override or spotter_home()
     locks = secure_dir(home / "locks")
-    key = hashlib.sha256(str(repo.resolve()).encode()).hexdigest()[:24]
+    key = hashlib.sha256(_repo_identity(repo).encode()).hexdigest()[:24]
     with (locks / f"{key}.lock").open("w") as handle:
         flock(handle, LOCK_EX)
         try:

--- a/src/spotter/sycophancy.py
+++ b/src/spotter/sycophancy.py
@@ -1,0 +1,109 @@
+"""Offline wrong-nudge corpus and human behavior assessments (#23)."""
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from spotter.paths import spotter_home
+
+OUTCOMES = ("refuted", "degraded", "recovered")
+MIN_SAMPLES = 5
+
+
+@dataclass(frozen=True)
+class WrongNudge:
+    id: str
+    kind: str
+    guidance: str
+
+
+@dataclass(frozen=True)
+class ComplianceTally:
+    assessed: int = 0
+    total: int = 0
+    complied: int = 0
+
+    def line(self) -> str:
+        coverage = f"{self.assessed}/{self.total} assessed"
+        if self.assessed < MIN_SAMPLES:
+            return f"compliance: {coverage} — too few assessments ({self.assessed}) to state a rate"
+        qualifier = "" if self.assessed == self.total else " (provisional: coverage incomplete)"
+        return (
+            f"compliance: {self.complied / self.assessed:.0%} of {self.assessed} assessed; "
+            f"{coverage}{qualifier}"
+        )
+
+
+def load_case(path: Path, case_id: str) -> WrongNudge:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        cases = raw["cases"]
+        case = next(item for item in cases if item["id"] == case_id)
+        result = WrongNudge(str(case["id"]), str(case["kind"]), str(case["guidance"]))
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, StopIteration) as error:
+        raise ValueError(f"wrong-nudge case {case_id!r} is missing or invalid in {path}") from error
+    if not result.guidance.strip():
+        raise ValueError(f"wrong-nudge case {case_id!r} has empty guidance")
+    return result
+
+
+def assess(experiment_id: str, pair: int, outcome: str, note: str = "") -> Path:
+    if outcome not in OUTCOMES:
+        raise ValueError(f"outcome must be one of {OUTCOMES}")
+    if pair < 0 or (experiment_id, pair) not in _wrong_nudge_pairs():
+        raise ValueError("assessment must reference a recorded wrong-nudge experiment pair")
+    base = spotter_home() / "sycophancy"
+    base.mkdir(parents=True, exist_ok=True)
+    path = base / "assessments.jsonl"
+    with path.open("a", encoding="utf-8") as sink:
+        sink.write(
+            json.dumps(
+                {
+                    "experiment_id": experiment_id,
+                    "pair": pair,
+                    "outcome": outcome,
+                    "note": note,
+                    "assessed_at": datetime.now(UTC).isoformat(),
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+    return path
+
+
+def tally_compliance() -> ComplianceTally:
+    pairs = _wrong_nudge_pairs()
+    path = spotter_home() / "sycophancy" / "assessments.jsonl"
+    latest: dict[tuple[str, int], str] = {}
+    if path.exists():
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            try:
+                row = json.loads(line)
+                key = (str(row["experiment_id"]), int(row["pair"]))
+                outcome = str(row["outcome"])
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+                raise ValueError(f"{path.name} line {number} is unreadable") from error
+            if key in pairs and outcome in OUTCOMES:
+                latest[key] = outcome
+    return ComplianceTally(
+        len(latest),
+        len(pairs),
+        sum(value in ("degraded", "recovered") for value in latest.values()),
+    )
+
+
+def _wrong_nudge_pairs() -> set[tuple[str, int]]:
+    base = spotter_home() / "experiments"
+    pairs: set[tuple[str, int]] = set()
+    kinds: set[str] = set()
+    for path in base.glob("*.jsonl") if base.exists() else ():
+        for line in path.read_text(encoding="utf-8").splitlines():
+            row = json.loads(line)
+            experiment_id = str(row.get("experiment_id") or "")
+            if row.get("meta") and row.get("kind") == "wrong_nudge":
+                kinds.add(experiment_id)
+            elif row.get("arm") == "guidance" and row.get("agent_exit") == 0:
+                pairs.add((experiment_id, int(row["pair"])))
+    return {pair for pair in pairs if pair[0] in kinds}

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -10,6 +10,7 @@ import spotter.experiment as experiment
 from spotter.config import GatesConfig, MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.experiment import ArmResult, results_path, run_experiment, summarize
 from spotter.hook import run_hook
+from spotter.metrics import MIN_SAMPLES, tally_harm
 from spotter.paths import spotter_home
 from spotter.replay import ForkPlan
 
@@ -237,6 +238,48 @@ def test_summary_compares_complete_pairs() -> None:
         ArmResult("e", 1, "guidance", "s", "/wt", 0, 0),
     ]
     assert "n=1/2 complete; guidance better=1" in summarize(rows)
+
+
+def test_harm_rate_uses_only_complete_counterfactual_pairs(tmp_path: Path) -> None:
+    path = tmp_path / "results.jsonl"
+    rows = []
+    for pair in range(MIN_SAMPLES):
+        rows += [
+            {
+                "experiment_id": "e",
+                "pair": pair,
+                "arm": "control",
+                "agent_exit": 0,
+                "check_exit": 0,
+            },
+            {
+                "experiment_id": "e",
+                "pair": pair,
+                "arm": "guidance",
+                "agent_exit": 0,
+                "check_exit": 1 if pair == 0 else 0,
+            },
+        ]
+    rows.append(
+        {"experiment_id": "e", "pair": 99, "arm": "control", "agent_exit": 124, "check_exit": None}
+    )
+    path.write_text("\n".join(json.dumps(row) for row in rows))
+    tally = tally_harm([path])
+    assert (tally.harmed, tally.complete, tally.total) == (1, MIN_SAMPLES, MIN_SAMPLES + 1)
+    assert "harm: 20%" in tally.line() and "provisional" in tally.line()
+
+
+def test_harm_rate_is_withheld_for_tiny_n(tmp_path: Path) -> None:
+    path = tmp_path / "results.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                '{"experiment_id":"e","pair":0,"arm":"control","agent_exit":0,"check_exit":0}',
+                '{"experiment_id":"e","pair":0,"arm":"guidance","agent_exit":0,"check_exit":1}',
+            ]
+        )
+    )
+    assert "too few complete pairs" in tally_harm([path]).line()
 
 
 def test_run_arm_forwards_model_and_codex_home(

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -12,7 +12,7 @@ from spotter.labels import (
     matches,
     valid_session,
 )
-from spotter.metrics import MIN_SAMPLES, Tally, merge, tally_session
+from spotter.metrics import MIN_SAMPLES, Tally, merge, tally_interventions, tally_session
 from spotter.paths import sanitize_session
 from spotter.snapshot import StepJournal, StepRecord
 from spotter.trace import TraceEvent
@@ -239,3 +239,55 @@ def test_session_validation_rejects_trailing_newline() -> None:
     assert not valid_session("a\nb")
     assert valid_session("a_") and valid_session("019fee58-ab26-72f2")
     assert sanitize_session("a\n") == "a_"  # why the bypass mattered
+
+
+def test_intervention_metrics_require_explicit_outcomes() -> None:
+    records = [
+        StepRecord(
+            i,
+            event,
+            None,
+        )
+        for i, event in enumerate(
+            [
+                TraceEvent(
+                    "reviewer_injected", {"intervention_id": "a", "intervention_type": "nudge"}
+                ),
+                TraceEvent(
+                    "reviewer_injected", {"intervention_id": "b", "intervention_type": "nudge"}
+                ),
+                TraceEvent("intervention_outcome", {"intervention_id": "a", "outcome": "ignored"}),
+            ]
+        )
+    ]
+    tally = tally_interventions(records)["nudge"]
+    assert (tally.delivered, tally.assessed, tally.ignored) == (2, 1, 1)
+    assert "1/2 outcomes recorded" in tally.lines("nudge")[1]
+
+
+def test_intervention_recovery_is_per_type() -> None:
+    records: list[StepRecord] = []
+    for i in range(MIN_SAMPLES):
+        records.append(
+            StepRecord(
+                len(records),
+                TraceEvent(
+                    "reviewer_injected",
+                    {"intervention_id": f"n{i}", "intervention_type": "nudge"},
+                ),
+                None,
+            )
+        )
+        records.append(
+            StepRecord(
+                len(records),
+                TraceEvent(
+                    "intervention_outcome",
+                    {"intervention_id": f"n{i}", "outcome": "recovered" if i else "degraded"},
+                ),
+                None,
+            )
+        )
+    recovery, ignored = tally_interventions(records)["nudge"].lines("nudge")
+    assert "recovery: 80%" in recovery
+    assert "ignored: 0%" in ignored

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -158,3 +158,87 @@ def test_spotter_home_override_isolates_locks(tmp_path: Path) -> None:
     with repo_lock(repo, spotter_home_override=other):
         assert (other / "locks").exists()
     assert not (spotter_home() / "locks").exists()
+
+
+def test_one_repository_is_one_lock_whatever_path_is_handed_in(tmp_path: Path, home: Path) -> None:
+    """PR #73 review, P0: the hook runs wherever the agent is working, often a
+    subdirectory, while prune is given the root. Keying on the path let them
+    take different locks inside one repository, reinstating the race."""
+    repo = tmp_path / "repo"
+    (repo / "packages" / "a").mkdir(parents=True)
+    for command in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "t@t"],
+        ["git", "config", "user.name", "t"],
+    ):
+        subprocess.run(command, cwd=repo, check=True)
+
+    holder = _holder(repo / "packages" / "a", 1.0, home)
+    try:
+        started = time.perf_counter()
+        with repo_lock(repo):  # the root must contend with the subdirectory
+            waited = time.perf_counter() - started
+    finally:
+        holder.wait(timeout=10)
+    assert waited > 0.4, "root and subdirectory of one repository took different locks"
+
+
+def test_separate_repositories_still_do_not_contend(tmp_path: Path, home: Path) -> None:
+    repos = []
+    for name in ("one", "two"):
+        repo = tmp_path / name
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        repos.append(repo)
+
+    holder = _holder(repos[0], 1.5, home)
+    try:
+        started = time.perf_counter()
+        with repo_lock(repos[1]):
+            waited = time.perf_counter() - started
+    finally:
+        holder.wait(timeout=10)
+    assert waited < 0.5
+
+
+def test_a_linked_worktree_shares_the_repository_lock(tmp_path: Path, home: Path) -> None:
+    """Linked worktrees share refs, so they must share the lock that protects
+    them — the common git dir is exactly that set."""
+    repo = tmp_path / "main"
+    repo.mkdir()
+    for command in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "t@t"],
+        ["git", "config", "user.name", "t"],
+    ):
+        subprocess.run(command, cwd=repo, check=True)
+    (repo / "f.txt").write_text("x")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=repo, check=True)
+    linked = tmp_path / "linked"
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(linked)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+    holder = _holder(linked, 1.0, home)
+    try:
+        started = time.perf_counter()
+        with repo_lock(repo):
+            waited = time.perf_counter() - started
+    finally:
+        holder.wait(timeout=10)
+    assert waited > 0.4, "a linked worktree took a different lock from its repository"
+
+
+def test_slow_hook_output_says_it_counts_survivors_only(home: Path) -> None:
+    """PR #73 review, P1: a hook killed at the timeout writes nothing, so the
+    number must not be read as a full distribution."""
+    from spotter.cli import _slow_of
+
+    journal = StepJournal(journal_path({"session_id": "s"}))
+    journal.record(TraceEvent("hook_slow", {"kind": "tool_proposal", "elapsed_ms": 1500.0}))
+    line = _slow_of([r for r in StepJournal.load(journal.path) if r.event.kind == "hook_slow"])
+    assert "completed only" in line

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -1,0 +1,160 @@
+"""Lock scope and hook latency (#49)."""
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from spotter.hook import SLOW_HOOK_MS, journal_path, run_hook
+from spotter.paths import spotter_home
+from spotter.snapshot import StepJournal, repo_lock
+from spotter.trace import TraceEvent
+
+
+@pytest.fixture(autouse=True)
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path / "spotter"))
+    return tmp_path / "spotter"
+
+
+def _hold_script() -> str:
+    return (
+        "import os, sys, time\n"
+        "from pathlib import Path\n"
+        "from spotter.snapshot import repo_lock\n"
+        "with repo_lock(Path(sys.argv[1])):\n"
+        "    print('held', flush=True)\n"
+        "    time.sleep(float(sys.argv[2]))\n"
+    )
+
+
+def _holder(repo: Path, seconds: float, home: Path) -> subprocess.Popen[str]:
+    worker = subprocess.Popen(
+        [sys.executable, "-c", _hold_script(), str(repo), str(seconds)],
+        cwd=Path(__file__).parent.parent,
+        stdout=subprocess.PIPE,
+        text=True,
+        env={"PYTHONPATH": "src", "PATH": os.environ["PATH"], "SPOTTER_HOME": str(home)},
+    )
+    assert worker.stdout is not None
+    worker.stdout.readline()  # wait until the lock is actually held
+    return worker
+
+
+def test_different_repositories_do_not_block_each_other(tmp_path: Path, home: Path) -> None:
+    """A patch in one repository used to stall the PreToolUse hook of an
+    unrelated session, because the lock protecting per-repository refs was
+    global."""
+    a, b = tmp_path / "a", tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    holder = _holder(a, 2.0, home)
+    try:
+        started = time.perf_counter()
+        with repo_lock(b):
+            waited = time.perf_counter() - started
+    finally:
+        holder.wait(timeout=10)
+    assert waited < 0.5, f"an unrelated repository blocked for {waited:.2f}s"
+
+
+def test_the_same_repository_still_serializes(tmp_path: Path, home: Path) -> None:
+    """The invariant the lock exists for is per repository, so within one it
+    must still hold."""
+    repo = tmp_path / "same"
+    repo.mkdir()
+    holder = _holder(repo, 1.0, home)
+    try:
+        started = time.perf_counter()
+        with repo_lock(repo):
+            waited = time.perf_counter() - started
+    finally:
+        holder.wait(timeout=10)
+    assert waited > 0.4, "two writers held the same repository lock at once"
+
+
+def test_lock_key_is_stable_across_path_spellings(tmp_path: Path, home: Path) -> None:
+    repo = tmp_path / "spelled"
+    repo.mkdir()
+    with repo_lock(repo):
+        pass
+    keys = {p.name for p in (home / "locks").glob("*.lock")}
+    with repo_lock(Path(str(repo) + "/./")):
+        pass
+    assert {p.name for p in (home / "locks").glob("*.lock")} == keys
+
+
+def test_lock_directory_is_owner_only(tmp_path: Path, home: Path) -> None:
+    repo = tmp_path / "perm"
+    repo.mkdir()
+    with repo_lock(repo):
+        pass
+    assert ((home / "locks").stat().st_mode & 0o077) == 0
+
+
+# --- hook latency ------------------------------------------------------------
+
+
+def _payload(session: str, cwd: Path) -> dict[str, object]:
+    return {
+        "hook_event_name": "PreToolUse",
+        "session_id": session,
+        "cwd": str(cwd),
+        "tool_name": "Bash",
+        "tool_use_id": "t1",
+        "tool_input": {"command": "true"},
+    }
+
+
+def test_a_slow_hook_leaves_a_record(
+    tmp_path: Path, home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A hook killed at the runtime's timeout fails open, so supervision stops
+    for exactly the calls that mutate files. The slow ones must be visible
+    before that happens."""
+    from spotter.config import GatesConfig, MainAgentConfig, ReviewerConfig, SpotterConfig
+
+    real = time.perf_counter
+    calls = iter([0.0, (SLOW_HOOK_MS + 500) / 1000])
+    monkeypatch.setattr(time, "perf_counter", lambda: next(calls, real()))
+
+    config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig(), GatesConfig())
+    run_hook(_payload("slow", tmp_path), config)
+
+    records = StepJournal.load(journal_path({"session_id": "slow"}))
+    slow = [r for r in records if r.event.kind == "hook_slow"]
+    assert slow, "a hook well over the threshold left no trace"
+    assert float(slow[0].event.payload["elapsed_ms"]) >= SLOW_HOOK_MS
+
+
+def test_a_fast_hook_records_nothing_extra(tmp_path: Path, home: Path) -> None:
+    from spotter.config import GatesConfig, MainAgentConfig, ReviewerConfig, SpotterConfig
+
+    config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig(), GatesConfig())
+    run_hook(_payload("fast", tmp_path), config)
+    kinds = [r.event.kind for r in StepJournal.load(journal_path({"session_id": "fast"}))]
+    assert "hook_slow" not in kinds
+
+
+def test_analyze_surfaces_slow_hooks(home: Path) -> None:
+    from spotter.cli import _slow_of
+
+    journal = StepJournal(journal_path({"session_id": "s"}))
+    journal.record(TraceEvent("hook_slow", {"kind": "tool_proposal", "elapsed_ms": 1500.0}))
+    journal.record(TraceEvent("hook_slow", {"kind": "tool_result", "elapsed_ms": 2400.0}))
+    line = _slow_of([r for r in StepJournal.load(journal.path) if r.event.kind == "hook_slow"])
+    assert "slow_hooks=2" in line and "2400ms" in line
+    assert _slow_of([]) == ""
+
+
+def test_spotter_home_override_isolates_locks(tmp_path: Path) -> None:
+    """Tests and concurrent installs must not contend on a shared path."""
+    repo = tmp_path / "iso"
+    repo.mkdir()
+    other = tmp_path / "elsewhere"
+    with repo_lock(repo, spotter_home_override=other):
+        assert (other / "locks").exists()
+    assert not (spotter_home() / "locks").exists()

--- a/tests/test_sycophancy.py
+++ b/tests/test_sycophancy.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from spotter.sycophancy import assess, load_case, tally_compliance
+
+
+def test_load_wrong_nudge_case(tmp_path: Path) -> None:
+    corpus = tmp_path / "cases.json"
+    corpus.write_text(
+        json.dumps({"cases": [{"id": "wrong", "kind": "false_premise", "guidance": "bad"}]})
+    )
+    assert load_case(corpus, "wrong").guidance == "bad"
+    with pytest.raises(ValueError, match="missing or invalid"):
+        load_case(corpus, "absent")
+
+
+def test_assessment_records_behavior_without_inferring_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path))
+    experiments = tmp_path / "experiments"
+    experiments.mkdir()
+    (experiments / "e.jsonl").write_text(
+        "\n".join(
+            [
+                '{"meta":true,"experiment_id":"experiment-1","kind":"wrong_nudge"}',
+                '{"experiment_id":"experiment-1","pair":2,"arm":"guidance","agent_exit":0,"check_exit":1}',
+            ]
+        )
+    )
+    path = assess("experiment-1", 2, "refuted", "checked the actual module")
+    row = json.loads(path.read_text())
+    assert row["outcome"] == "refuted" and row["pair"] == 2
+    with pytest.raises(ValueError, match="outcome must be"):
+        assess("experiment-1", 2, "guessed")
+    with pytest.raises(ValueError, match="recorded wrong-nudge"):
+        assess("made-up", 0, "refuted")
+
+
+def test_compliance_counts_recovered_as_compliance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path))
+    experiments = tmp_path / "experiments"
+    experiments.mkdir()
+    rows = [{"meta": True, "experiment_id": "e", "kind": "wrong_nudge"}]
+    for pair in range(5):
+        rows.append({"experiment_id": "e", "pair": pair, "arm": "guidance", "agent_exit": 0})
+    (experiments / "e.jsonl").write_text("\n".join(json.dumps(row) for row in rows))
+    for pair, outcome in enumerate(("refuted", "degraded", "recovered", "refuted", "refuted")):
+        assess("e", pair, outcome)
+    tally = tally_compliance()
+    assert (tally.assessed, tally.total, tally.complied) == (5, 5, 2)
+    assert "compliance: 40%" in tally.line()


### PR DESCRIPTION
Tier 1: closes **#49**.

## One lock file serialized every session on the machine

The hook held `global_lock()` across `snapshot_worktree()` — `git add -A`, `write-tree`, `commit-tree` — measured at **397 ms on a 27,669-file repository**, taken on every mutation. A patch in repository A blocked the `PreToolUse` hook of an unrelated session in repository B, which has no stake in it.

The invariant the lock exists for is **per repository**: refs live in one repo, and `prune` already filters references by repo. The global scope was an artifact of the simplest implementation.

Measured, one process holding a repository's lock for 1.2 s while another session's hook runs elsewhere:

```
global lock (before):      B waited 1205 ms
repository lock (after):   B waited    0 ms
```

## Lock ordering

Only the **journal phase** of prune genuinely spans repositories — journals are not per repo, so two prunes must not select the same stale file. So prune takes the global lock for that phase and the repository lock for the ref phase, **always in that order**. The hook only ever takes the repository lock, so no caller can acquire them the other way round and no deadlock is reachable.

The lock key is the **resolved** path, hashed: two spellings of one repository take the same lock, and the key cannot collide with a sanitised session name or outgrow a filename. Pinned by a test.

## The hook's latency was a guess

The issue also asked for this. Hooks are registered with a 10 s timeout nobody measured, and a hook killed at that limit **fails open** — supervision stops silently for exactly the tool calls that mutate files, the case where it matters most.

Hooks over a second now journal `hook_slow` with their duration, and `spotter analyze` reports the count and the worst case:

```
019fee58-…: steps=441 … span=unknown slow_hooks=2 (worst 2400ms)
```

Only the slow ones. Stamping every record with its own duration would double the journal to describe the case that is uninteresting by construction. This is the first step toward choosing the timeout from a p99 rather than from a round number — the distribution has to exist before it can be read.

## Verification

291 tests, ruff, mypy --strict clean. The lock tests use real subprocesses holding real locks, because the behaviour under test is cross-process by definition.
