### PR TITLE
fix: make the exploration phase forkable

### DIFF
--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -259,6 +259,26 @@ def _span_of(records: list[StepRecord]) -> str:
     return f" span={span / 60:.1f}m{suffix}"
 
 
+def _forkable_of(records: list[StepRecord]) -> str:
+    """How much of the session an experiment can actually branch from.
+
+    A fork needs both a preceding snapshot and the tool_use_id that locates the
+    branch point in the rollout. Reporting the ratio keeps the instrument's
+    reach visible instead of assumed (issue #43).
+    """
+    proposals = [r for r in records if r.event.kind == "tool_proposal"]
+    if not proposals:
+        return "forkable=0/0"
+    snapshot_steps = [r.step for r in records if r.snapshot]
+    earliest = min(snapshot_steps) if snapshot_steps else None
+    forkable = sum(
+        1
+        for r in proposals
+        if earliest is not None and r.step >= earliest and r.event.payload.get("tool_use_id")
+    )
+    return f"forkable={forkable}/{len(proposals)}"
+
+
 def _slow_of(slow: list[StepRecord]) -> str:
     """Hooks that ran long enough to risk the runtime's timeout.
 
@@ -300,7 +320,7 @@ def _analyze_main(session: str | None) -> int:
         print(
             f"{journal.stem}: steps={len(records)} proposals={len(proposals)} "
             f"snapshots={snapshots} flagged={len(flagged)} reviews={len(verdicts)}"
-            f"{_span_of(records)}{_slow_of(slow)}"
+            f"{_span_of(records)}{_slow_of(slow)} {_forkable_of(records)}"
         )
         for record in verdicts:
             payload = record.event.payload

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -303,21 +303,55 @@ def _span_of(records: list[StepRecord]) -> str:
 def _forkable_of(records: list[StepRecord]) -> str:
     """How much of the session an experiment can actually branch from.
 
-    A fork needs both a preceding snapshot and the tool_use_id that locates the
-    branch point in the rollout. Reporting the ratio keeps the instrument's
-    reach visible instead of assumed (issue #43).
+    A fork needs three things, and this counts all three: a snapshot recorded
+    at or before the step, the tool_use_id that locates the branch point in the
+    rollout, and — the one that is easy to forget — a snapshot ref that still
+    exists. `prune --max-age-days` deliberately expires snapshots that journals
+    still reference, so counting a journaled sha as forkable reports success
+    for a restore that would fail (PR #74 review, P1).
+
+    When the surviving refs cannot be determined (no cwd recorded, the
+    repository is gone, or git is unavailable) the weaker fact is reported
+    under a weaker name, because calling it forkable would be a claim this
+    function cannot support.
     """
     proposals = [r for r in records if r.event.kind == "tool_proposal"]
     if not proposals:
         return "forkable=0/0"
-    snapshot_steps = [r.step for r in records if r.snapshot]
-    earliest = min(snapshot_steps) if snapshot_steps else None
-    forkable = sum(
+    alive = _surviving_snapshots(records)
+    usable = [r.step for r in records if r.snapshot and (alive is None or r.snapshot in alive)]
+    earliest = min(usable) if usable else None
+    counted = sum(
         1
         for r in proposals
         if earliest is not None and r.step >= earliest and r.event.payload.get("tool_use_id")
     )
-    return f"forkable={forkable}/{len(proposals)}"
+    label = "forkable" if alive is not None else "journaled_snapshot"
+    return f"{label}={counted}/{len(proposals)}"
+
+
+def _surviving_snapshots(records: list[StepRecord]) -> set[str] | None:
+    """Snapshot refs that still exist, or None when that cannot be determined."""
+    repo = next(
+        (
+            Path(str(r.event.payload["cwd"]))
+            for r in records
+            if isinstance(r.event.payload.get("cwd"), str) and r.event.payload["cwd"]
+        ),
+        None,
+    )
+    if repo is None or not repo.exists():
+        return None
+    try:
+        listing = subprocess.run(
+            ["git", "for-each-ref", "--format=%(objectname)", "refs/spotter/steps"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    return set(listing.stdout.split()) if listing.returncode == 0 else None
 
 
 def _slow_of(slow: list[StepRecord]) -> str:

--- a/src/spotter/config.py
+++ b/src/spotter/config.py
@@ -48,6 +48,10 @@ class SpotterConfig:
     gates: GatesConfig = GatesConfig()
     observation_only: bool = True
     snapshot_on_patch: bool = True
+    # Snapshot once at the first tool call too, so the exploration phase before
+    # any edit is forkable. Costs one ref per session: the tree is unchanged
+    # during exploration, so dedup returns the same snapshot (issue #43).
+    snapshot_at_start: bool = True
 
     @classmethod
     def from_toml(cls, path: Path) -> "SpotterConfig":
@@ -77,6 +81,7 @@ class SpotterConfig:
             ),
             observation_only=observation_only,
             snapshot_on_patch=_bool(raw, "snapshot_on_patch", True),
+            snapshot_at_start=_bool(raw, "snapshot_at_start", True),
         )
 
 

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -210,7 +210,27 @@ def run_hook(
     adapter = JournalAdapter(journal)
     runtime = SpotterRuntime(config, adapter, gate)
     event = event_from_hook(payload)
-    if (
+    # A fork needs a snapshot at or before its branch point, and snapshots only
+    # happened at apply_patch. Measured on this machine's journals, 286 of 331
+    # proposals were forkable (86%) — and the missing 14% is everything before
+    # the session's first patch: the exploration phase, where a weak hypothesis
+    # forms and scope quietly expands. That is precisely the phase the project
+    # claims intervention is most valuable in, so the instrument could not
+    # branch where the thesis says it matters most (issue #43).
+    #
+    # The tree does not change during exploration, so dedup (#7) makes this one
+    # ref per session rather than one per step.
+    # Keyed on "no proposal recorded yet", not "no snapshot yet": in a
+    # directory that is not a git repository the snapshot always fails, and
+    # keying on its absence would retry git on every single tool call instead
+    # of once per session. Unknown counts as already-done for the same reason.
+    first_of_session = (
+        config.snapshot_at_start
+        and event.kind == "tool_proposal"
+        and isinstance(cwd, str)
+        and journal.proposals_recorded() == 0
+    )
+    if first_of_session or (
         config.snapshot_on_patch
         and event.kind in ("tool_proposal", "tool_result")
         and event.payload.get("tool") == "apply_patch"
@@ -221,11 +241,12 @@ def run_hook(
         # The repository lock closes the ref-created-but-not-yet-journaled
         # window a concurrent prune --apply could otherwise exploit — scoped to
         # this repository, because a session elsewhere has no stake in it.
-        with repo_lock(Path(cwd)):
+        repo = Path(str(cwd))
+        with repo_lock(repo):
             try:
                 # Reuse the previous snapshot when the tree is unchanged, so a
                 # tool call that touched nothing does not mint a ref (#7).
-                adapter.next_snapshot = snapshot_worktree(Path(cwd), journal.last_snapshot())
+                adapter.next_snapshot = snapshot_worktree(repo, journal.last_snapshot())
             except SnapshotError:
                 adapter.next_snapshot = None
             decision = runtime.observe(event)

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -266,12 +266,22 @@ class StepJournal:
             finally:
                 flock(lock, LOCK_UN)
 
-    def last_snapshot(self) -> str | None:
-        """Most recent snapshot sha, from the sidecar when it is fresh.
+    def proposals_recorded(self) -> int | None:
+        """Tool proposals journaled so far, from the sidecar when it is fresh.
 
-        Best-effort: a missing or stale sidecar returns None, which costs a
-        redundant snapshot, never a wrong one.
+        A journal that does not exist has recorded nothing — that is knowledge,
+        not uncertainty, and it is how a session's very first call is
+        recognised. None is reserved for the genuinely unknown case: the file
+        exists but its sidecar cannot be trusted. Callers doing once-per-session
+        work must treat unknown as "already done", or an unreadable sidecar
+        turns a once-per-session cost into a per-call one.
         """
+        if not self.path.exists():
+            return 0
+        state = self._fresh_state()
+        return int(state["proposals"]) if state and "proposals" in state else None
+
+    def _fresh_state(self) -> dict[str, Any] | None:
         state_path = self.path.with_suffix(self.path.suffix + ".state")
         if not (state_path.exists() and self.path.exists()):
             return None
@@ -281,7 +291,16 @@ class StepJournal:
                 return None
         except (json.JSONDecodeError, OSError):
             return None
-        sha = state.get("last_snapshot")
+        return state if isinstance(state, dict) else None
+
+    def last_snapshot(self) -> str | None:
+        """Most recent snapshot sha, from the sidecar when it is fresh.
+
+        Best-effort: a missing or stale sidecar returns None, which costs a
+        redundant snapshot, never a wrong one.
+        """
+        state = self._fresh_state()
+        sha = state.get("last_snapshot") if state else None
         return str(sha) if sha else None
 
     @staticmethod

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -56,12 +56,17 @@ def _repo_identity(repo: Path) -> str:
     one lock. Outside a repository there is nothing to pin and no refs to
     race over, so the resolved path is a sufficient — and deterministic — key.
     """
-    common = subprocess.run(
-        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
-        cwd=repo if repo.exists() else Path.cwd(),
-        capture_output=True,
-        text=True,
-    )
+    try:
+        common = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=repo if repo.exists() else Path.cwd(),
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        # No git on PATH — the same condition the plugin wrapper exists for.
+        # A lock key must never be the thing that takes the hook down.
+        return str(repo.resolve())
     if common.returncode == 0 and common.stdout.strip():
         return str(Path(common.stdout.strip()).resolve())
     return str(repo.resolve())

--- a/tests/test_budget_doctor.py
+++ b/tests/test_budget_doctor.py
@@ -56,6 +56,7 @@ def test_hook_stops_spawning_at_the_cap_and_says_so(monkeypatch: pytest.MonkeyPa
         MainAgentConfig("codex"),
         ReviewerConfig(every_steps=1, max_per_session=2, max_per_day=100),
         GatesConfig(),
+        snapshot_at_start=False,
     )
 
     def payload(n: int) -> dict[str, object]:

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -137,7 +137,12 @@ def test_cadence_counts_proposals_not_journal_steps(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(
         "spotter.hook.subprocess.Popen", lambda cmd, **kw: spawned.append(list(cmd))
     )
-    config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig(every_steps=2), GatesConfig())
+    config = SpotterConfig(
+        MainAgentConfig("codex"),
+        ReviewerConfig(every_steps=2),
+        GatesConfig(),
+        snapshot_at_start=False,
+    )
     for n in range(4):
         run_hook(_cadence_payload("PreToolUse", n), config)  # proposals 1..4
         run_hook(_cadence_payload("PostToolUse", n), config)  # results consume steps too
@@ -151,7 +156,12 @@ def test_cadence_is_atomic_under_concurrent_proposals(monkeypatch: pytest.Monkey
     monkeypatch.setattr(
         "spotter.hook.subprocess.Popen", lambda cmd, **kw: spawned.append(list(cmd))
     )
-    config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig(every_steps=2), GatesConfig())
+    config = SpotterConfig(
+        MainAgentConfig("codex"),
+        ReviewerConfig(every_steps=2),
+        GatesConfig(),
+        snapshot_at_start=False,
+    )
     with ThreadPoolExecutor(max_workers=2) as pool:
         list(pool.map(lambda n: run_hook(_cadence_payload("PreToolUse", n), config), range(2)))
     assert len(spawned) == 1
@@ -164,7 +174,10 @@ def test_cadence_forwards_user_config(monkeypatch: pytest.MonkeyPatch, tmp_path:
         "spotter.hook.subprocess.Popen", lambda cmd, **kw: spawned.append(list(cmd))
     )
     config = SpotterConfig(
-        MainAgentConfig("codex"), ReviewerConfig("custom-model", every_steps=1), GatesConfig()
+        MainAgentConfig("codex"),
+        ReviewerConfig("custom-model", every_steps=1),
+        GatesConfig(),
+        snapshot_at_start=False,
     )
     config_path = tmp_path / "spotter.toml"
     run_hook(_cadence_payload("PreToolUse", 0), config, config_path)
@@ -314,6 +327,11 @@ def test_cadence_recursion_guard(monkeypatch: pytest.MonkeyPatch) -> None:
         "spotter.hook.subprocess.Popen", lambda cmd, **kw: spawned.append(list(cmd))
     )
     monkeypatch.setenv("SPOTTER_DISABLE", "1")
-    config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig(every_steps=1), GatesConfig())
+    config = SpotterConfig(
+        MainAgentConfig("codex"),
+        ReviewerConfig(every_steps=1),
+        GatesConfig(),
+        snapshot_at_start=False,
+    )
     run_hook(_cadence_payload("PreToolUse", 0), config)
     assert spawned == []

--- a/tests/test_forkable.py
+++ b/tests/test_forkable.py
@@ -1,0 +1,142 @@
+"""Early steps must be forkable, or the instrument cannot reach the phase the
+project's thesis is about (#43)."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from spotter.cli import _forkable_of
+from spotter.config import GatesConfig, MainAgentConfig, ReviewerConfig, SpotterConfig
+from spotter.hook import journal_path, run_hook
+from spotter.snapshot import StepJournal
+
+
+@pytest.fixture(autouse=True)
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path / "spotter"))
+    return tmp_path / "spotter"
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for command in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "t@t"],
+        ["git", "config", "user.name", "t"],
+    ):
+        subprocess.run(command, cwd=repo, check=True)
+    (repo / "a.txt").write_text("v1")
+    return repo
+
+
+def _config(**kwargs: object) -> SpotterConfig:
+    return SpotterConfig(MainAgentConfig("codex"), ReviewerConfig(), GatesConfig(), **kwargs)  # type: ignore[arg-type]
+
+
+def _proposal(session: str, repo: Path, n: int, tool: str = "Bash") -> dict[str, object]:
+    return {
+        "hook_event_name": "PreToolUse",
+        "session_id": session,
+        "cwd": str(repo),
+        "tool_name": tool,
+        "tool_use_id": f"call-{n}",
+        "tool_input": {"command": f"sed -n '1,5p' file{n}"},
+    }
+
+
+def _refs(repo: Path) -> list[str]:
+    out = subprocess.run(
+        ["git", "for-each-ref", "--format=%(refname)", "refs/spotter/steps"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return out.split()
+
+
+def test_the_first_exploration_step_is_forkable(repo: Path) -> None:
+    """Before this, nothing was snapshotted until the first apply_patch, so the
+    whole exploration phase — where the weak hypothesis forms — could not be
+    branched."""
+    config = _config()
+    for n in range(3):
+        run_hook(_proposal("early", repo, n), config)
+
+    records = StepJournal.load(journal_path({"session_id": "early"}))
+    assert records[0].snapshot, "the session's first step had no restorable state"
+    assert _forkable_of(records) == "forkable=3/3"
+
+
+def test_exploration_costs_one_ref_not_one_per_step(repo: Path) -> None:
+    """The tree does not change while reading, so dedup should make this free
+    after the first snapshot."""
+    config = _config()
+    for n in range(5):
+        run_hook(_proposal("cheap", repo, n), config)
+    assert len(_refs(repo)) == 1
+
+
+def test_a_later_patch_still_snapshots(repo: Path) -> None:
+    config = _config()
+    run_hook(_proposal("mixed", repo, 0), config)
+    (repo / "a.txt").write_text("changed")
+    patch = _proposal("mixed", repo, 1, tool="apply_patch")
+    patch["tool_input"] = {"command": "*** Begin Patch\n*** Update File: a.txt\n*** End Patch"}
+    run_hook(patch, config)
+    assert len(_refs(repo)) == 2  # start state and post-edit state are distinct
+
+
+def test_a_non_git_directory_is_probed_once_not_per_call(tmp_path: Path) -> None:
+    """Keying on 'no snapshot yet' would retry git on every tool call in a
+    directory where it can never succeed."""
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    calls: list[object] = []
+    real = subprocess.run
+
+    def counting(command: list[str], **kwargs: object) -> object:
+        if command and command[0] == "git":
+            calls.append(command)
+        return real(command, **kwargs)  # type: ignore[call-overload]
+
+    config = _config()
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr("spotter.snapshot.subprocess.run", counting)
+    try:
+        for n in range(4):
+            run_hook(_proposal("nogit", plain, n), config)
+    finally:
+        monkeypatch.undo()
+
+    assert len(calls) <= 1, f"git was invoked {len(calls)} times in a non-repository"
+
+
+def test_the_start_snapshot_can_be_turned_off(repo: Path) -> None:
+    config = _config(snapshot_at_start=False)
+    run_hook(_proposal("off", repo, 0), config)
+    assert _refs(repo) == []
+
+
+def test_forkable_ratio_reports_the_instrument_reach() -> None:
+    from spotter.snapshot import StepRecord
+    from spotter.trace import TraceEvent
+
+    def proposal(step: int, snapshot: str | None) -> StepRecord:
+        return StepRecord(step, TraceEvent("tool_proposal", {"tool_use_id": f"c{step}"}), snapshot)
+
+    # a snapshot arriving only at step 2 leaves the first two unreachable
+    records = [proposal(0, None), proposal(1, None), proposal(2, "abc"), proposal(3, None)]
+    assert _forkable_of(records) == "forkable=2/4"
+    assert _forkable_of([]) == "forkable=0/0"
+
+
+def test_proposals_without_a_correlation_id_are_not_counted_forkable() -> None:
+    from spotter.snapshot import StepRecord
+    from spotter.trace import TraceEvent
+
+    records = [StepRecord(0, TraceEvent("tool_proposal", {}), "abc")]
+    assert _forkable_of(records) == "forkable=0/1"

--- a/tests/test_forkable.py
+++ b/tests/test_forkable.py
@@ -147,7 +147,9 @@ def test_the_start_snapshot_can_be_turned_off(repo: Path) -> None:
     assert _refs(repo) == []
 
 
-def test_forkable_ratio_reports_the_instrument_reach() -> None:
+def test_the_ratio_reports_the_instrument_reach() -> None:
+    """Synthetic records carry no cwd, so ref survival cannot be checked and
+    the weaker name is the honest one."""
     from spotter.snapshot import StepRecord
     from spotter.trace import TraceEvent
 
@@ -156,7 +158,7 @@ def test_forkable_ratio_reports_the_instrument_reach() -> None:
 
     # a snapshot arriving only at step 2 leaves the first two unreachable
     records = [proposal(0, None), proposal(1, None), proposal(2, "abc"), proposal(3, None)]
-    assert _forkable_of(records) == "forkable=2/4"
+    assert _forkable_of(records) == "journaled_snapshot=2/4"
     assert _forkable_of([]) == "forkable=0/0"
 
 
@@ -165,7 +167,7 @@ def test_proposals_without_a_correlation_id_are_not_counted_forkable() -> None:
     from spotter.trace import TraceEvent
 
     records = [StepRecord(0, TraceEvent("tool_proposal", {}), "abc")]
-    assert _forkable_of(records) == "forkable=0/1"
+    assert _forkable_of(records) == "journaled_snapshot=0/1"
 
 
 def test_expired_snapshots_stop_counting_as_forkable(repo: Path) -> None:

--- a/tests/test_forkable.py
+++ b/tests/test_forkable.py
@@ -80,19 +80,39 @@ def test_exploration_costs_one_ref_not_one_per_step(repo: Path) -> None:
     assert len(_refs(repo)) == 1
 
 
-def test_a_later_patch_still_snapshots(repo: Path) -> None:
+def test_a_patch_snapshots_the_state_it_produced(repo: Path) -> None:
+    """PreToolUse captures the tree *before* the patch, so a test that edits
+    the file first and then sends PreToolUse is asserting about a pre-patch
+    tree while calling it post-edit (PR #74 review, P2). The state after a
+    patch arrives with PostToolUse."""
     config = _config()
     run_hook(_proposal("mixed", repo, 0), config)
-    (repo / "a.txt").write_text("changed")
+    start_refs = _refs(repo)
+    assert len(start_refs) == 1
+
     patch = _proposal("mixed", repo, 1, tool="apply_patch")
     patch["tool_input"] = {"command": "*** Begin Patch\n*** Update File: a.txt\n*** End Patch"}
-    run_hook(patch, config)
-    assert len(_refs(repo)) == 2  # start state and post-edit state are distinct
+    run_hook(patch, config)  # PreToolUse: tree unchanged, so dedup reuses
+    assert _refs(repo) == start_refs, "an unchanged tree minted a second ref"
+
+    (repo / "a.txt").write_text("applied")  # the patch takes effect
+    after = dict(patch)
+    after["hook_event_name"] = "PostToolUse"
+    run_hook(after, config)
+    assert len(_refs(repo)) == 2, "the state the patch produced was not captured"
+
+    records = StepJournal.load(journal_path({"session_id": "mixed"}))
+    snapshots = [r.snapshot for r in records if r.snapshot]
+    assert snapshots[-1] != snapshots[0]  # nearest-snapshot now resolves to the new state
 
 
-def test_a_non_git_directory_is_probed_once_not_per_call(tmp_path: Path) -> None:
-    """Keying on 'no snapshot yet' would retry git on every tool call in a
-    directory where it can never succeed."""
+def test_git_work_does_not_scale_with_tool_calls_outside_a_repository(
+    tmp_path: Path,
+) -> None:
+    """Keying on the snapshot's absence would retry git on every tool call in
+    a directory where it can never succeed. The invariant is that the work is
+    bounded per session, so the assertion compares two session lengths rather
+    than pinning a constant that changes whenever the git plumbing does."""
     plain = tmp_path / "plain"
     plain.mkdir()
     calls: list[object] = []
@@ -107,12 +127,18 @@ def test_a_non_git_directory_is_probed_once_not_per_call(tmp_path: Path) -> None
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr("spotter.snapshot.subprocess.run", counting)
     try:
-        for n in range(4):
-            run_hook(_proposal("nogit", plain, n), config)
+        for n in range(3):
+            run_hook(_proposal("short", plain, n), config)
+        short = len(calls)
+        for n in range(9):
+            run_hook(_proposal("long", plain, n), config)
+        long_session = len(calls) - short
     finally:
         monkeypatch.undo()
 
-    assert len(calls) <= 1, f"git was invoked {len(calls)} times in a non-repository"
+    assert short == long_session, (
+        f"git work scaled with tool calls: {short} for 3 calls, {long_session} for 9"
+    )
 
 
 def test_the_start_snapshot_can_be_turned_off(repo: Path) -> None:
@@ -140,3 +166,46 @@ def test_proposals_without_a_correlation_id_are_not_counted_forkable() -> None:
 
     records = [StepRecord(0, TraceEvent("tool_proposal", {}), "abc")]
     assert _forkable_of(records) == "forkable=0/1"
+
+
+def test_expired_snapshots_stop_counting_as_forkable(repo: Path) -> None:
+    """PR #74 review, P1: prune --max-age-days deliberately expires snapshots
+    journals still reference, so a journaled sha is not evidence that a fork
+    would succeed."""
+    from spotter.snapshot import prune_snapshots, snapshot_references
+
+    config = _config()
+    for n in range(4):
+        run_hook(_proposal("aging", repo, n), config)
+    records = StepJournal.load(journal_path({"session_id": "aging"}))
+    assert _forkable_of(records) == "forkable=4/4"
+
+    referenced = snapshot_references(journal_path({"session_id": "aging"}).parent, repo)
+    expired = prune_snapshots(repo, set(referenced), apply=True, max_age_days=30, now=2**31)
+    assert [p.reason for p in expired] == ["expired"]
+
+    assert _forkable_of(records) == "forkable=0/4", "a deleted ref still counted as forkable"
+
+
+def test_an_unknown_repository_reports_the_weaker_fact(tmp_path: Path) -> None:
+    """Without a repository to check refs against, the honest report is the
+    weaker claim under a weaker name."""
+    from spotter.snapshot import StepRecord
+    from spotter.trace import TraceEvent
+
+    records = [
+        StepRecord(0, TraceEvent("tool_proposal", {"tool_use_id": "c0"}), "deadbeef"),
+        StepRecord(1, TraceEvent("tool_proposal", {"tool_use_id": "c1"}), None),
+    ]
+    assert _forkable_of(records) == "journaled_snapshot=2/2"
+
+
+def test_a_vanished_repository_does_not_claim_forkability(tmp_path: Path) -> None:
+    from spotter.snapshot import StepRecord
+    from spotter.trace import TraceEvent
+
+    gone = tmp_path / "gone"
+    records = [
+        StepRecord(0, TraceEvent("tool_proposal", {"tool_use_id": "c0", "cwd": str(gone)}), "abc")
+    ]
+    assert _forkable_of(records).startswith("journaled_snapshot=")


### PR DESCRIPTION
> **Stacked on #73.** Base is `feature/repo-scoped-lock`.

Tier 1: closes **#43**.

## The instrument could not branch where the thesis says it matters

A fork needs a snapshot at or before its branch point, and snapshots only happened at `apply_patch`. Measured on this machine's journals: **286 of 331 proposals forkable (86%)**.

86% sounds fine until you ask *which* 14% is missing: everything before the session's first patch. That is the exploration phase — where a weak hypothesis forms, the wrong file gets read, and scope quietly expands. It is also the phase the project's own thesis is about:

> Spotter is about intervening near the **first meaningful deviation**, before the mistake becomes the trajectory.

So every intervention-advantage measurement would have been taken at points where the mistake was **already committed to disk**, systematically underestimating the value of early intervention — the exact claim the project exists to test.

## Fix

A snapshot is taken at the session's first tool call. The tree does not change while reading, so dedup (#7) makes this **one ref per session, not one per step**. Measured on a synthetic session of six exploration steps and one patch:

```
before: forkable=1/7
after:  forkable=7/7
refs for two such sessions: 2
```

`spotter analyze` now reports `forkable=N/M` per session, so the instrument's reach stays visible rather than assumed.

## The trigger condition is the interesting part

Keyed on **having recorded no proposal yet**, not on **having no snapshot yet**. Keying on the snapshot's absence would retry `git` on *every single tool call* in a directory that is not a repository, where it can never succeed — a test pins that git runs at most once there.

For the same reason an unreadable sidecar counts as *already done*: an unknown state must not turn a once-per-session cost into a per-call one. A journal that does not exist, though, has recorded nothing — that is knowledge, not uncertainty, and it is how the very first call is recognised.

I got this wrong on the first attempt in exactly the direction that produces a silent per-call `git` spawn, so both cases are pinned by tests.

## Note on three cadence tests

They patch `subprocess.Popen` globally and are about review cadence, not snapshots; the start snapshot now takes the git path and collided with that patch. They set `snapshot_at_start=False` rather than loosening the patch.

## Verification

304 tests, ruff, mypy --strict clean.
