### PR TITLE
docs: realign documentation around the standalone runtime architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,30 @@ Maintained by [@bogyie / Bogyoeng Kim](https://github.com/Bogyie) and [@zerone /
 >
 > Your coding agent drives. Spotter watches the trajectory, challenges bad assumptions, and steps in before wasted work compounds.
 
-Spotter is an experimental runtime supervision layer for coding agents, starting with Codex.
+Spotter is an experimental runtime supervision system for coding agents, starting with Codex.
+
+The project is moving from a hook/plugin-centered prototype toward a **standalone local supervision runtime**. The target architecture is tracked in [#66](https://github.com/Bogyie/spotter/issues/66): a long-lived `spotterd` owns live supervision state, Codex App Server becomes the primary observation/control plane, and hooks shrink to the minimum synchronous enforcement boundary.
+
+> **Important:** that standalone architecture is the project direction, not the current shipping behavior. The current prototype still uses agent hooks/plugins for event collection and deterministic gates.
 
 ## Contents
 
-- [How it works](#the-idea)
-- [Installation](#installation)
-- [First run](#first-run)
-- [Install the agent plugins](#install-the-agent-plugins)
-- [Manual hook setup](#manual-hook-setup)
+- [The idea](#the-idea)
+- [Why trajectory-level supervision](#why-trajectory-level-supervision)
+- [Intervention ladder](#intervention-ladder)
+- [Architecture direction](#architecture-direction)
+- [Current status](#current-status)
+- [Use the current prototype](#use-the-current-prototype)
+- [Target installation experience](#target-installation-experience)
+- [Inspect and evaluate sessions](#inspect-and-evaluate-sessions)
 - [Documentation](#documentation)
 - [Development](#development)
 
+## The idea
+
 Modern coding agents are good at moving forward. They are less reliable at noticing when they are confidently moving in the wrong direction: drifting from the request, locking onto a weak hypothesis, repeating low-information actions, expanding scope, skipping validation, or carrying a stale assumption deep into an implementation.
 
-Spotter pairs the main coding agent with an **independent reviewer model** that observes the work as it unfolds and intervenes only when intervention is likely to help.
+Spotter pairs the main coding agent with an **independent reviewer** that observes work while it unfolds and intervenes only when intervention is likely to help.
 
 ```text
                  User Goal
@@ -29,11 +38,11 @@ Spotter pairs the main coding agent with an **independent reviewer model** that 
               Main Agent
             drives the work
                     │
-       action / tool / result / diff
+       trajectory / tools / results / diffs
                     │
                     ▼
                  Spotter
-          observes the trajectory
+          observes and maintains state
                     │
        ┌────────────┼────────────┐
        ▼            ▼            ▼
@@ -41,8 +50,6 @@ Spotter pairs the main coding agent with an **independent reviewer model** that 
                                 │
                      BLOCK / INTERRUPT / RESTART
 ```
-
-## The idea
 
 A good gym spotter does not lift every rep for you. They watch, stay out of the way, and intervene when the lift is about to fail.
 
@@ -52,14 +59,14 @@ Spotter applies the same principle to coding agents:
 - Review the **execution path**, not just the final diff.
 - Prefer **evidence and executable verification** over agent-to-agent debate.
 - Use deterministic checks for deterministic constraints; spend LLM reasoning only on ambiguous cases.
-- Let the main agent and Spotter use **different models and isolated judgment contexts**.
+- Keep the reviewer judgment context independent from the main agent where practical.
 - Escalate intervention gradually: `CONTINUE → VERIFY → NUDGE → BLOCK → INTERRUPT → RESTART`.
 
-The goal is not to add more reasoning. The goal is to keep reasoning and execution **grounded, economical, and recoverable**.
+The goal is not to maximize reasoning. The goal is to keep reasoning and execution **grounded, economical, and recoverable**.
 
-## Why trajectory-level supervision?
+## Why trajectory-level supervision
 
-Traditional code review starts after code exists. Spotter starts earlier.
+Traditional review starts after code exists. Spotter starts earlier.
 
 ```text
 Traditional review
@@ -71,13 +78,11 @@ intent → reasoning → exploration → edit → test → diff
              runtime supervision
 ```
 
-Many agent failures are processes, not isolated bad outputs. A weak assumption can trigger unnecessary exploration, which triggers the wrong edit, which creates misleading test failures, which causes further compensating changes. By the time a post-hoc reviewer sees the diff, most of the cost has already been paid.
+Many agent failures are processes, not isolated bad outputs. A weak assumption can trigger unnecessary exploration, which triggers the wrong edit, which creates misleading failures, which causes further compensating changes. By the time a post-hoc reviewer sees the diff, most of the cost has already been paid.
 
 Spotter is about intervening near the **first meaningful deviation**, before the mistake becomes the trajectory.
 
-## What Spotter watches for
-
-Spotter focuses on execution failures such as:
+Typical targets include:
 
 - specification or scope drift
 - unsupported or stale assumptions
@@ -90,57 +95,92 @@ Spotter focuses on execution failures such as:
 - edits without adequate validation
 - continuing from a premise that later evidence invalidated
 
-It is intentionally not just another static code reviewer.
-
 ## Intervention ladder
 
-| Decision | Meaning |
-| --- | --- |
-| `CONTINUE` | Work looks healthy. Stay silent. |
-| `VERIFY` | A consequential assumption needs evidence before more work depends on it. |
-| `NUDGE` | The trajectory is starting to drift or waste effort. Add a small course correction. |
-| `BLOCK` | A pending action clearly violates a known constraint or policy. Stop it before execution. |
-| `INTERRUPT` | Continuing the current turn is likely to compound a bad trajectory. |
-| `RESTART` | The current reasoning context itself is no longer trustworthy; restart from verified state. |
+| Decision | Meaning | Current state |
+| --- | --- | --- |
+| `CONTINUE` | Work looks healthy. Stay silent. | reviewer decision implemented in shadow mode |
+| `VERIFY` | A consequential assumption needs evidence. | reviewer decision implemented in shadow mode; live delivery not yet implemented |
+| `NUDGE` | The trajectory is drifting or wasting effort. | reviewer decision implemented in shadow mode; live delivery not yet implemented |
+| `BLOCK` | A pending action clearly violates a deterministic constraint. | deterministic gates implemented; default posture remains observation/shadow unless explicitly enabled |
+| `INTERRUPT` | Continuing the active turn is likely to compound failure. | target design, not implemented |
+| `RESTART` | The current reasoning context is no longer trustworthy. | target design, not implemented |
 
 A central design question is not only **“Is the agent wrong?”** but **“Is intervening now better than letting it continue?”**
 
-## Codex is a good first target
+## Architecture direction
 
-Current Codex runtime primitives make this design practical:
+The hook-centric prototype proved useful enough to expose its own limits. Long-lived audit state, event-driven signals, reviewer scheduling, asynchronous intervention, multi-session supervision, and recovery all want a persistent runtime rather than a fresh process per hook.
 
-- lifecycle hooks including `PreToolUse`, `PostToolUse`, `SessionStart`, and others
-- `PreToolUse` can inspect, block, or rewrite many local tool calls before execution
-- App Server streams plan, reasoning-summary, tool, message, and diff-related events
-- `turn/steer` can inject a course correction into an active turn
-- `turn/interrupt` can stop an in-flight turn
+The target Codex architecture is:
 
-See [Architecture](docs/architecture.md) for the proposed integration.
+```text
+                     Codex TUI
+                         │
+                         ▼
+                 Codex App Server
+                  │             ▲
+                  │ events      │ steer / interrupt
+                  ▼             │
+                    spotterd
+                  │            │
+             live state     reviewer/control
+                  │
+          deterministic gate only
+                  │
+             PreToolUse Hook
+```
 
-## Main + Spotter
+Responsibility becomes:
 
-Spotter is not meant to become a second user giving orders.
+```text
+Codex App Server = primary observation + live control plane
+spotterd         = long-lived supervision runtime
+PreToolUse Hook  = narrow synchronous enforcement plane
+journal          = durable event log / recovery source
+CLI              = user control plane
+```
 
-> **The user defines the goal. Spotter reviews the path.**
+This also changes the product boundary: Spotter is intended to be an independent runtime that can integrate with multiple coding agents, not a Codex plugin that happens to contain supervision logic.
 
-The main agent remains the driver. Spotter acts as an independent falsifier and runtime controller. When they disagree, the preferred resolution is a cheap empirical probe — a test, compiler result, repository search, log, or other external evidence — rather than a long debate between models.
+See [Architecture](docs/architecture.md) and [Lifecycle](docs/lifecycle.md) for the detailed target design.
 
-## Trajectory Engineering
+## Current status
 
-Spotter is also an experiment in a broader idea: **Trajectory Engineering**.
+**Prototype / research runtime.** The repository has moved well beyond a scaffold, but the new standalone architecture is not implemented yet.
 
-Prompt engineering shapes an instruction. Context engineering shapes what the model can see. Harness engineering shapes the environment and tools around the agent.
+### Implemented today
 
-Trajectory engineering asks a different question:
+- Codex hook ingestion and journaled trajectories
+- deterministic pre-action gates with shadow/default-safe posture
+- shell-aware command analysis for several destructive command classes
+- crash-tolerant, cross-process step journals
+- Git-backed snapshots and safe detached-worktree restore
+- snapshot deduplication and pruning
+- Codex session fork / continuation replay machinery
+- shadow-mode model-backed reviewer
+- reviewer cadence and detached review execution
+- claim/evidence audit ledger with stale-premise propagation where observable outcomes exist
+- human labels and coverage-aware metrics
+- same-prefix counterfactual experiment harness
+- Codex and Claude Code plugin packaging for the current prototype
 
-> **While the agent is already working, how do we observe, verify, steer, stop, and recover the path it is taking?**
+### Not implemented yet
 
-Spotter is intended as a reference implementation for exploring that layer.
+- standalone Homebrew-installed runtime as the primary distribution path
+- `spotterd` as the owner of live in-memory supervision state
+- Codex App Server as the primary observation stream
+- event-driven two-stage signal → reviewer dispatch
+- live `VERIFY` / `NUDGE` delivery to an active turn
+- `INTERRUPT` / `RESTART`
+- complete side-effect/reversibility handling
+- a ground-truth task set with enough real intervention experiments to establish intervention advantage
 
-## Installation
+The project deliberately keeps strong intervention behind measurement. A detector that sounds plausible is not sufficient evidence that interrupting a working agent helps.
 
-Spotter requires Python 3.11 or newer and has no third-party runtime dependencies. Clone
-the repository and install it in a virtual environment:
+## Use the current prototype
+
+The current repository can be installed from source with Python 3.11+:
 
 ```bash
 git clone https://github.com/bogyie/spotter.git
@@ -150,20 +190,20 @@ source .venv/bin/activate
 python -m pip install -e .
 ```
 
-For a development installation, include the formatter, linter, type checker, and test
-runner with `python -m pip install -e '.[dev]'`.
+For development:
 
-## First run
+```bash
+python -m pip install -e '.[dev]'
+```
 
-Copy the example rather than editing the tracked file, then start Spotter:
+Copy the example configuration and validate the runtime:
 
 ```bash
 cp spotter.example.toml spotter.toml
 spotter --config spotter.toml
 ```
 
-The command validates the configuration and reports the selected adapter, reviewer, and
-operating mode. The example selects Codex and defaults to safe, passive observation:
+The example defaults to passive observation:
 
 ```toml
 observation_only = true
@@ -175,99 +215,100 @@ adapter = "codex"
 model = "default"
 ```
 
-`"default"` delegates reviewer model choice to the codex account, so the `[reviewer]`
-table may be omitted. Pin a specific id only if your auth supports it: ChatGPT-account
-auth rejects unknown or unavailable ids with a slow retry loop rather than a fast error —
-and the message ("not supported when using Codex with a ChatGPT account") does not
-distinguish a wrong slug from a restricted one. Check `codex` for the slugs your account
-actually has. Which reviewer model works best is an open experimental question (see
-docs/research.md RQ3), not a constant.
+### Current plugin integration
 
-## Install the agent plugins
+The current prototype can be installed as a Codex or Claude Code plugin. This is now considered a **compatibility/prototype path**, not the target product boundary.
 
-The repository is a native plugin for both Codex and Claude Code. The plugin bundles the
-hook bridge, so installing the Python package separately is not required; Python 3.11 or
-newer must still be available as `python3`.
-
-### Codex
-
-Add the Spotter GitHub repository as a marketplace, then add the qualified plugin:
+Codex:
 
 ```bash
 codex plugin marketplace add bogyie/spotter
 codex plugin add spotter@spotter
 ```
 
-Restart Codex after installation. Codex discovers `.codex-plugin/plugin.json` and the
-bundled `hooks/hooks.json` configuration.
-
-### Claude Code
-
-Add the Spotter GitHub repository as a marketplace and install its qualified plugin:
+Claude Code:
 
 ```bash
 claude plugin marketplace add bogyie/spotter
 claude plugin install spotter@spotter
 ```
 
-Restart Claude Code after installation. Claude Code discovers `.claude-plugin/plugin.json`
-and the same bundled hooks.
+The bundled integration currently uses lifecycle/tool hooks and writes journals under `~/.spotter/sessions`.
 
-By default, plugin hooks observe only and write journals under `~/.spotter/sessions`. To
-customize gates, copy `spotter.example.toml` to `spotter.toml` in the project being
-supervised. For Claude Code, change `main_agent.adapter` to `"claude-code"`. A config path
-in `SPOTTER_CONFIG` takes precedence over the project-local file:
+## Target installation experience
+
+The target standalone experience from [#66](https://github.com/Bogyie/spotter/issues/66) is intentionally different:
 
 ```bash
-export SPOTTER_CONFIG=/absolute/path/to/spotter.toml
+brew install spotter
+spotter setup codex
+spotter doctor
+
+# normal use after setup
+codex
 ```
 
-The wrapper resolves Spotter from the plugin checkout and therefore keeps working when the
-marketplace caches the plugin in another directory.
+The user should not need to manually start `spotterd` or a Codex App Server before ordinary use. Manual daemon commands remain operational/debugging escape hatches.
 
-## Manual hook setup
+Planned control-plane shape:
 
-If the plugin manager is unavailable, install the Python package as described above and add
-the bridge to the agent's hook configuration manually. For Codex, add this to
-`.codex/hooks.json`; for Claude Code, use `.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [{"hooks": [{"type": "command", "command": "spotter hook --config /absolute/path/to/spotter.toml"}]}],
-    "PostToolUse": [{"hooks": [{"type": "command", "command": "spotter hook --config /absolute/path/to/spotter.toml"}]}]
-  }
-}
+```text
+spotter setup codex|claude|--all
+spotter teardown codex|claude
+spotter doctor
+spotter status
+spotter daemon start|stop|restart|status|logs
+spotter sessions
+spotter analyze
+spotter review
+spotter label
+spotter metrics
+spotter fork
+spotter experiment
+spotter prune
+spotter config
+spotter version
 ```
 
-Without `--config`, the hook only records observations. Set `observation_only = false`
-explicitly to enforce configured gates.
+The exact App Server lifecycle strategy is deliberately gated on an E2E PoC because current Codex can choose an embedded App Server when no reusable external daemon is present. See [Lifecycle](docs/lifecycle.md).
 
-Recorded sessions can then be summarized with `spotter analyze`, judged one flag at a
-time with `spotter label`, and scored with `spotter metrics`:
+## Inspect and evaluate sessions
+
+Recorded sessions can be summarized, labeled, and measured:
 
 ```bash
-spotter analyze                                              # what was flagged, with context
+spotter analyze
 spotter label --session <id> --step 7 --verdict fp --note "quoted, not executed"
-spotter metrics                                              # gate FP rate, reviewer precision
+spotter metrics
 ```
 
-Labels are stored outside the session journal, so a reviewer never reads its own report
-card. `spotter metrics` reports every rate with its coverage and withholds rates that
-rest on too few labels. Run `spotter --help` for the complete command and option list.
+The shadow reviewer can be run explicitly:
+
+```bash
+spotter review --session <id>
+```
+
+Counterfactual continuations can be prepared or executed where a mechanically decidable `--check` exists:
+
+```bash
+spotter experiment --session <id> --step <k> --guidance "..." --check "..."
+```
+
+Labels live outside the session journal so the reviewer does not read its own report card. Metrics report coverage and avoid publishing rates from very small samples.
 
 ## Documentation
 
-- [Concept](docs/concept.md) — the problem definition, design principles, terminology,
-  non-goals, and evaluation questions
-- [Architecture](docs/architecture.md) — components, event flow, intervention policy,
-  and the proposed Codex integration
-- [Research](docs/research.md) — related work and the ideas Spotter borrows
-- [Roadmap](docs/roadmap.md) — implementation stages, milestones, and evaluation plan
+- [Concept](docs/concept.md) — the problem, principles, intervention semantics, and product boundary
+- [Architecture](docs/architecture.md) — current/target runtime structure, observation, state, gates, review, and control paths
+- [Lifecycle](docs/lifecycle.md) — install, setup, service/App Server lifecycle, sessions, recovery, upgrades, teardown, purge, and migration
+- [Research](docs/research.md) — related work, borrowed ideas, open hypotheses, and evidence gaps
+- [Roadmap](docs/roadmap.md) — migration sequence, implementation milestones, and evaluation plan
+
+The umbrella direction is tracked in [#66](https://github.com/Bogyie/spotter/issues/66).
 
 ## Development
 
-Install the development extras as described above, then run every local check with:
+Run the local checks with:
 
 ```bash
 ruff format --check .
@@ -276,16 +317,20 @@ mypy src tests
 pytest
 ```
 
-The package deliberately keeps normalized trace events and orchestration separate from
-the Codex adapter. The hook bridge records tool events and applies deterministic gates;
-model-backed review is the next implementation milestone.
+The architectural migration should preserve the useful boundaries already present in the prototype: normalized trace data, deterministic gates, review policy, snapshots/replay, and evaluation tooling should not become coupled to one Codex transport.
 
-## Status
+## Trajectory Engineering
 
-**Prototype.** Codex hook ingestion and deterministic gates are implemented. Reviewer
-decisions and replay are not.
+Spotter is also an experiment in a broader idea: **Trajectory Engineering**.
 
-The first milestone is deliberately small: observe a Codex trajectory with a separate reviewer model, identify high-confidence misbehavior, and measure whether intervention helps more than it harms.
+- Prompt engineering shapes the instruction.
+- Context engineering shapes what the model can see.
+- Harness engineering shapes tools and execution constraints around the model.
+- **Trajectory engineering shapes what happens while the agent is already executing.**
+
+The question is:
+
+> **While the agent is working, how do we observe, verify, steer, stop, and recover its path without making supervision more expensive than the mistakes it prevents?**
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,185 +2,346 @@ Maintained by [@bogyie / Bogyoeng Kim](https://github.com/Bogyie) and [@zerone /
 
 # Spotter
 
-> **A runtime spotter for coding agents.**
->
+> **A runtime spotter for coding agents.**  
 > Your coding agent drives. Spotter watches the trajectory, challenges bad assumptions, and steps in before wasted work compounds.
 
-Spotter is an experimental runtime supervision system for coding agents, starting with Codex.
+Spotter is an experimental **runtime supervision system for coding agents**, starting with Codex.
 
-The project is moving from a hook/plugin-centered prototype toward a **standalone local supervision runtime**. The target architecture is tracked in [#66](https://github.com/Bogyie/spotter/issues/66): a long-lived `spotterd` owns live supervision state, Codex App Server becomes the primary observation/control plane, and hooks shrink to the minimum synchronous enforcement boundary.
+---
 
-> **Important:** that standalone architecture is the project direction, not the current shipping behavior. The current prototype still uses agent hooks/plugins for event collection and deterministic gates.
+## 30초 요약
 
-## Contents
+Spotter가 해결하려는 문제는 **“에이전트가 틀렸는가?”**보다 조금 더 구체적이다.
 
-- [The idea](#the-idea)
-- [Why trajectory-level supervision](#why-trajectory-level-supervision)
-- [Intervention ladder](#intervention-ladder)
-- [Architecture direction](#architecture-direction)
-- [Current status](#current-status)
-- [Use the current prototype](#use-the-current-prototype)
-- [Target installation experience](#target-installation-experience)
-- [Inspect and evaluate sessions](#inspect-and-evaluate-sessions)
-- [Documentation](#documentation)
-- [Development](#development)
+> **에이전트가 잘못된 가정·반복·범위 이탈을 계속 누적하기 전에, 실행 중간에 이를 감지하고 가장 약한 개입으로 경로를 되돌릴 수 있는가?**
 
-## The idea
+현재 repository는 이미 단순 scaffold를 넘었다. Hook 기반 trajectory 수집, deterministic gate, snapshot/fork/replay, shadow reviewer, audit ledger, labels/metrics, counterfactual experiment harness가 구현돼 있다.
 
-Modern coding agents are good at moving forward. They are less reliable at noticing when they are confidently moving in the wrong direction: drifting from the request, locking onto a weak hypothesis, repeating low-information actions, expanding scope, skipping validation, or carrying a stale assumption deep into an implementation.
-
-Spotter pairs the main coding agent with an **independent reviewer** that observes work while it unfolds and intervenes only when intervention is likely to help.
+다만 **현재 shipping prototype**과 **목표 architecture**는 다르다.
 
 ```text
-                 User Goal
-                    │
-                    ▼
-              Main Agent
-            drives the work
-                    │
-       trajectory / tools / results / diffs
-                    │
-                    ▼
-                 Spotter
-          observes and maintains state
-                    │
-       ┌────────────┼────────────┐
-       ▼            ▼            ▼
-    CONTINUE      VERIFY      NUDGE
-                                │
-                     BLOCK / INTERRUPT / RESTART
+현재 prototype
+
+Codex / Claude Code
+       │ hooks
+       ▼
+ spotter-hook process
+       │
+       ├─ journal
+       ├─ deterministic gate
+       ├─ snapshot
+       └─ periodic shadow review
+
+
+목표 architecture
+
+Codex TUI
+    │
+    ▼
+External Codex App Server
+    ↕ event stream / steer / interrupt
+ spotterd
+    │
+    └─ PreToolUse Hook
+       (deterministic synchronous gate만)
 ```
 
-A good gym spotter does not lift every rep for you. They watch, stay out of the way, and intervene when the lift is about to fail.
+**가장 가까운 다음 단계는 App Server lifecycle/attach PoC다.** 사용자 TUI와 Spotter가 동일한 외부 App Server를 공유하고, Spotter가 실제 active turn에 `turn/steer`를 보낼 수 있는지 먼저 E2E로 검증한다. 이 전제가 실패하면 daemon migration을 밀어붙이지 않는다.
 
-Spotter applies the same principle to coding agents:
+빠른 현재 상태는 [Status](docs/status.md), 상세 방향은 [#66](https://github.com/Bogyie/spotter/issues/66)을 본다.
 
-- **Always observe. Rarely interrupt.**
-- Review the **execution path**, not just the final diff.
-- Prefer **evidence and executable verification** over agent-to-agent debate.
-- Use deterministic checks for deterministic constraints; spend LLM reasoning only on ambiguous cases.
-- Keep the reviewer judgment context independent from the main agent where practical.
-- Escalate intervention gradually: `CONTINUE → VERIFY → NUDGE → BLOCK → INTERRUPT → RESTART`.
+---
 
-The goal is not to maximize reasoning. The goal is to keep reasoning and execution **grounded, economical, and recoverable**.
+## 빠른 탐색
 
-## Why trajectory-level supervision
+| 알고 싶은 것 | 바로 보기 |
+| --- | --- |
+| 지금 실제로 되는 기능 | [현재 상태](#현재-상태) / [docs/status.md](docs/status.md) |
+| Spotter가 정확히 무엇인가 | [핵심 개념](#핵심-개념) / [docs/concept.md](docs/concept.md) |
+| 목표 process/data flow | [목표 architecture](#목표-architecture) / [docs/architecture.md](docs/architecture.md) |
+| 설치→setup→세션→업데이트→제거 | [docs/lifecycle.md](docs/lifecycle.md) |
+| 다음 구현 순서와 dependency | [docs/roadmap.md](docs/roadmap.md) |
+| 근거 논문·연구 질문·미검증 가설 | [docs/research.md](docs/research.md) |
+| umbrella direction issue | [#66](https://github.com/Bogyie/spotter/issues/66) |
 
-Traditional review starts after code exists. Spotter starts earlier.
+---
 
-```text
-Traditional review
-intent → reasoning → exploration → edit → test → diff → REVIEW
+## 현재 상태
 
-Spotter
-intent → reasoning → exploration → edit → test → diff
-           ↑          ↑          ↑      ↑
-             runtime supervision
-```
+### 기능 상태 한눈에 보기
 
-Many agent failures are processes, not isolated bad outputs. A weak assumption can trigger unnecessary exploration, which triggers the wrong edit, which creates misleading failures, which causes further compensating changes. By the time a post-hoc reviewer sees the diff, most of the cost has already been paid.
-
-Spotter is about intervening near the **first meaningful deviation**, before the mistake becomes the trajectory.
-
-Typical targets include:
-
-- specification or scope drift
-- unsupported or stale assumptions
-- premature implementation
-- tunnel vision around one hypothesis
-- repetitive exploration with little new evidence
-- tool-error loops
-- unnecessary refactors or dependency creep
-- missed constraints
-- edits without adequate validation
-- continuing from a premise that later evidence invalidated
-
-## Intervention ladder
-
-| Decision | Meaning | Current state |
+| 기능 | 상태 | 설명 |
 | --- | --- | --- |
-| `CONTINUE` | Work looks healthy. Stay silent. | reviewer decision implemented in shadow mode |
-| `VERIFY` | A consequential assumption needs evidence. | reviewer decision implemented in shadow mode; live delivery not yet implemented |
-| `NUDGE` | The trajectory is drifting or wasting effort. | reviewer decision implemented in shadow mode; live delivery not yet implemented |
-| `BLOCK` | A pending action clearly violates a deterministic constraint. | deterministic gates implemented; default posture remains observation/shadow unless explicitly enabled |
-| `INTERRUPT` | Continuing the active turn is likely to compound failure. | target design, not implemented |
-| `RESTART` | The current reasoning context is no longer trustworthy. | target design, not implemented |
+| Hook trajectory collection | ✅ 구현 | `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse` 기록 |
+| Deterministic gate | ✅ 구현 | destructive command/path/dependency 등 rule-based 판단 |
+| Crash-safe journal | ✅ 구현 | cross-process locking, fsync, torn-tail recovery |
+| Git snapshot / restore | ✅ 구현 | user HEAD/index를 건드리지 않는 snapshot + detached restore |
+| Fork / continuation replay | ✅ 구현 | 동일 prefix에서 Codex continuation 분기 |
+| Shadow reviewer | ✅ 구현 | `CONTINUE / VERIFY / NUDGE` 판단 기록, live delivery는 없음 |
+| Claim/evidence audit ledger | 🟡 부분 | observable outcome 범위에서 stale premise propagation |
+| Label / metrics | ✅ 구현 | coverage-aware precision/FP 측정 |
+| Counterfactual experiment harness | ✅ 구현 | control/guidance same-prefix pair 실행 기반 |
+| Standalone `spotterd` runtime | ❌ 미구현 | #66 target |
+| App Server primary observation | 🧪 PoC 필요 | 가장 먼저 검증할 architecture 전제 |
+| Event-driven signal engine | ❌ 미구현 | 현재 reviewer는 periodic cadence 기반 |
+| Live `VERIFY / NUDGE` | ❌ 미구현 | target: `turn/steer` |
+| `INTERRUPT` | ❌ 미구현 | target: `turn/interrupt` |
+| `RESTART` | ❌ 미구현 | verified state + recovery design 필요 |
+| Homebrew/setup lifecycle | 🎯 target | `brew install spotter` / `spotter setup codex` |
 
-A central design question is not only **“Is the agent wrong?”** but **“Is intervening now better than letting it continue?”**
+> 구현 여부와 효과 입증은 다르다. 예를 들어 reviewer가 `NUDGE`를 생성할 수 있다는 사실은 NUDGE가 실제 task outcome을 개선한다는 증거가 아니다.
 
-## Architecture direction
-
-The hook-centric prototype proved useful enough to expose its own limits. Long-lived audit state, event-driven signals, reviewer scheduling, asynchronous intervention, multi-session supervision, and recovery all want a persistent runtime rather than a fresh process per hook.
-
-The target Codex architecture is:
-
-```text
-                     Codex TUI
-                         │
-                         ▼
-                 Codex App Server
-                  │             ▲
-                  │ events      │ steer / interrupt
-                  ▼             │
-                    spotterd
-                  │            │
-             live state     reviewer/control
-                  │
-          deterministic gate only
-                  │
-             PreToolUse Hook
-```
-
-Responsibility becomes:
+### 지금 가장 중요한 blocker
 
 ```text
-Codex App Server = primary observation + live control plane
-spotterd         = long-lived supervision runtime
-PreToolUse Hook  = narrow synchronous enforcement plane
-journal          = durable event log / recovery source
-CLI              = user control plane
+P0 — Codex App Server lifecycle / attach PoC
 ```
 
-This also changes the product boundary: Spotter is intended to be an independent runtime that can integrate with multiple coding agents, not a Codex plugin that happens to contain supervision logic.
+검증할 질문:
 
-See [Architecture](docs/architecture.md) and [Lifecycle](docs/lifecycle.md) for the detailed target design.
+1. 외부 App Server가 준비돼 있을 때 plain `codex`가 이를 안정적으로 재사용하는가?
+2. Spotter가 second client로 붙어 같은 thread/turn event를 받는가?
+3. active `turn_id`를 정확하게 추적할 수 있는가?
+4. `turn/steer`가 실제 사용자가 보고 있는 Codex TUI turn에 전달되는가?
+5. 여러 Codex session을 동시에 구분할 수 있는가?
+6. attach/control이 불가능한 경우 `status/doctor`가 이를 명확한 degraded mode로 보여줄 수 있는가?
 
-## Current status
+자세한 PoC와 exit criteria는 [Roadmap P0](docs/roadmap.md)을 본다.
 
-**Prototype / research runtime.** The repository has moved well beyond a scaffold, but the new standalone architecture is not implemented yet.
+---
 
-### Implemented today
+## 핵심 개념
 
-- Codex hook ingestion and journaled trajectories
-- deterministic pre-action gates with shadow/default-safe posture
-- shell-aware command analysis for several destructive command classes
-- crash-tolerant, cross-process step journals
-- Git-backed snapshots and safe detached-worktree restore
-- snapshot deduplication and pruning
-- Codex session fork / continuation replay machinery
-- shadow-mode model-backed reviewer
-- reviewer cadence and detached review execution
-- claim/evidence audit ledger with stale-premise propagation where observable outcomes exist
-- human labels and coverage-aware metrics
-- same-prefix counterfactual experiment harness
-- Codex and Claude Code plugin packaging for the current prototype
+Coding agent는 보통 긴 실행 경로를 만든다.
 
-### Not implemented yet
+```text
+understand
+   ↓
+inspect
+   ↓
+hypothesize
+   ↓
+edit
+   ↓
+run
+   ↓
+observe
+   ↓
+revise
+   ↓
+validate
+```
 
-- standalone Homebrew-installed runtime as the primary distribution path
-- `spotterd` as the owner of live in-memory supervision state
-- Codex App Server as the primary observation stream
-- event-driven two-stage signal → reviewer dispatch
-- live `VERIFY` / `NUDGE` delivery to an active turn
-- `INTERRUPT` / `RESTART`
-- complete side-effect/reversibility handling
-- a ground-truth task set with enough real intervention experiments to establish intervention advantage
+문제는 많은 실패가 한 번의 잘못된 출력이 아니라 **trajectory failure**라는 점이다.
 
-The project deliberately keeps strong intervention behind measurement. A detector that sounds plausible is not sufficient evidence that interrupting a working agent helps.
+예를 들어:
 
-## Use the current prototype
+```text
+잘못된 가정
+"timeout 원인은 Redis pool이다"
+        │
+        ▼
+관련 파일만 계속 탐색
+        │
+        ▼
+Redis 설정 수정
+        │
+        ▼
+테스트 실패
+        │
+        ▼
+실패를 보정하기 위한 추가 수정
+        │
+        ▼
+scope 확대 + 시간/토큰 낭비
+```
 
-The current repository can be installed from source with Python 3.11+:
+최종 diff review는 마지막에 문제를 발견할 수 있지만, 이미 대부분의 비용을 지불한 뒤다.
+
+Spotter는 다음 지점을 노린다.
+
+```text
+잘못된 가정
+    │
+    ├── evidence 부족 감지
+    │       ↓
+    │    VERIFY
+    │       ↓
+    │  stack trace 확인
+    │
+    └── 잘못된 edit가 누적되기 전에 경로 수정
+```
+
+즉 Spotter의 목적은 **오류 개수를 최대한 많이 찾는 것**이 아니라 **잘못된 진행이 비싸지기 전에 잡는 것**이다.
+
+---
+
+## 개입 단계
+
+Spotter는 가장 약한 개입부터 사용한다.
+
+| Action | 의미 | 현재 상태 | 목표 runtime primitive |
+| --- | --- | --- | --- |
+| `CONTINUE` | 문제 없음 또는 개입 가치 낮음 | ✅ shadow reviewer | no-op |
+| `VERIFY` | 중요한 가정에 근거가 부족함 | ✅ 판단만 구현 | async `turn/steer` |
+| `NUDGE` | trajectory가 이탈/낭비 쪽으로 기울고 있음 | ✅ 판단만 구현 | async `turn/steer` |
+| `BLOCK` | 명확한 deterministic constraint 위반 | ✅ gate 구현 | synchronous `PreToolUse` deny |
+| `INTERRUPT` | 현재 turn을 계속하면 손실이 누적될 가능성이 큼 | ❌ | `turn/interrupt` |
+| `RESTART` | reasoning context 자체를 신뢰하기 어려움 | ❌ | verified state 기반 새 continuation |
+
+중요한 원칙:
+
+> **Semantic reviewer가 “싫다”고 해서 BLOCK하지 않는다.**  
+> BLOCK은 가능한 한 deterministic하고 audit 가능한 규칙에만 사용한다.
+
+---
+
+## 목표 architecture
+
+### 역할 분리
+
+```text
+Observation plane
+  무엇이 일어나고 있는가?
+  → Codex App Server event stream
+
+Control plane
+  이미 실행 중인 trajectory에 어떻게 개입하는가?
+  → turn/steer, turn/interrupt
+
+Enforcement plane
+  실행 전에 반드시 결정해야 하는가?
+  → PreToolUse deterministic gate
+
+Supervision runtime
+  상태·신호·reviewer·policy를 누가 소유하는가?
+  → spotterd
+```
+
+### 목표 data flow
+
+```text
+                     ┌─────────────┐
+                     │  Codex TUI  │
+                     └──────┬──────┘
+                            │
+                            ▼
+                 ┌──────────────────────┐
+                 │ External App Server  │
+                 └──────┬────────▲──────┘
+                        │        │
+                events  │        │ steer / interrupt
+                        ▼        │
+                 ┌──────────────────┐
+                 │     spotterd     │
+                 │                  │
+                 │ SessionManager   │
+                 │ Live State       │
+                 │ Trace IR         │
+                 │ Audit State      │
+                 │ Signal Engine    │
+                 │ Reviewer         │
+                 │ Intervention     │
+                 │ Journal          │
+                 └────────┬─────────┘
+                          │
+                 deterministic gate
+                          │
+                          ▼
+                   PreToolUse Hook
+```
+
+### 상태 ownership
+
+```text
+memory  = 현재 살아 있는 thread/turn의 live supervision state
+journal = durable event history + crash/restart/resume recovery source
+```
+
+현재 prototype처럼 매 Hook마다 journal을 다시 읽어 live state를 복원하는 구조를 steady state로 유지하지 않는다.
+
+---
+
+## 정상 실행은 어떻게 보일까
+
+목표 runtime에서 평상시 event는 다음처럼 처리한다.
+
+```text
+App Server event
+      │
+      ▼
+spotterd normalize
+      │
+      ├─ live state update
+      ├─ journal append
+      └─ cheap signal evaluation
+                  │
+             suspicious?
+              ├─ no → 끝
+              └─ yes
+                    │
+                    ▼
+             async reviewer job
+                    │
+                    ├─ CONTINUE → no-op
+                    ├─ VERIFY   → active turn이면 steer
+                    ├─ NUDGE    → active turn이면 steer
+                    └─ strong action 후보 → 별도 policy
+```
+
+Main agent는 reviewer가 생각하는 동안 계속 실행한다.
+
+Reviewer verdict가 늦게 도착하면 대상 turn이 아직 active인지 확인한다.
+
+```text
+reviewer verdict ready
+        │
+        ▼
+target turn still active?
+   ├─ yes → deliver
+   └─ no  → stale / discard / explicit defer policy
+```
+
+뒤늦은 NUDGE를 unrelated later turn에 무조건 넣지 않는다.
+
+---
+
+## 왜 Hook은 하나만 남기려 하나
+
+현재 prototype은 네 Hook을 사용한다.
+
+| Hook | 현재 역할 | 목표 |
+| --- | --- | --- |
+| `SessionStart` | session 감지 | App Server lifecycle로 대체 후 제거 후보 |
+| `UserPromptSubmit` | user goal 기록 | App Server user-message event로 대체 후 제거 후보 |
+| `PreToolUse` | proposal + deterministic gate | **atomic gate 때문에 유지** |
+| `PostToolUse` | result/snapshot/review trigger | App Server result/diff event로 대체 후 제거 1순위 |
+
+관찰과 semantic review는 App Server/daemon 쪽으로 옮긴다.
+
+`PreToolUse`는 다음과 같은 실행 전 guarantee 때문에 남긴다.
+
+```text
+git reset --hard
+        │
+        ▼
+PreToolUse
+        │
+        ▼
+spotterd Gate Engine
+   ├─ ALLOW
+   └─ DENY  ← command가 실행되기 전에 확정
+```
+
+향후 App Server가 모든 tool call에 대해 신뢰할 수 있는 atomic veto primitive를 제공한다면 Hook 0개도 검토할 수 있다.
+
+---
+
+## 현재 prototype 사용
+
+### Source install
+
+Python 3.11+:
 
 ```bash
 git clone https://github.com/bogyie/spotter.git
@@ -190,20 +351,20 @@ source .venv/bin/activate
 python -m pip install -e .
 ```
 
-For development:
+Development extras:
 
 ```bash
 python -m pip install -e '.[dev]'
 ```
 
-Copy the example configuration and validate the runtime:
+Config:
 
 ```bash
 cp spotter.example.toml spotter.toml
 spotter --config spotter.toml
 ```
 
-The example defaults to passive observation:
+기본 예시는 passive observation을 사용한다.
 
 ```toml
 observation_only = true
@@ -215,9 +376,7 @@ adapter = "codex"
 model = "default"
 ```
 
-### Current plugin integration
-
-The current prototype can be installed as a Codex or Claude Code plugin. This is now considered a **compatibility/prototype path**, not the target product boundary.
+### Current plugin compatibility path
 
 Codex:
 
@@ -233,24 +392,86 @@ claude plugin marketplace add bogyie/spotter
 claude plugin install spotter@spotter
 ```
 
-The bundled integration currently uses lifecycle/tool hooks and writes journals under `~/.spotter/sessions`.
+이 방식은 **현재 prototype을 사용할 수 있는 경로**이고, target product boundary는 standalone runtime이다.
 
-## Target installation experience
+---
 
-The target standalone experience from [#66](https://github.com/Bogyie/spotter/issues/66) is intentionally different:
+## 현재 세션 분석/실험
+
+세션 요약:
+
+```bash
+spotter analyze
+```
+
+Shadow reviewer:
+
+```bash
+spotter review --session <id>
+```
+
+Human label:
+
+```bash
+spotter label \
+  --session <id> \
+  --step 7 \
+  --verdict fp \
+  --note "quoted text, not executed"
+```
+
+Metrics:
+
+```bash
+spotter metrics
+```
+
+Fork:
+
+```bash
+spotter fork --session <id> --step <k>
+```
+
+Counterfactual experiment:
+
+```bash
+spotter experiment \
+  --session <id> \
+  --step <k> \
+  --guidance "Verify the timeout source before editing Redis settings." \
+  --check "pytest tests/test_timeout.py"
+```
+
+Experiment machinery가 존재한다고 해서 intervention advantage가 이미 입증된 것은 아니다. 현재 가장 큰 evaluation gap 중 하나는 mechanically scorable ground-truth task set과 실제 실행 데이터다.
+
+---
+
+## 목표 설치/운영 UX
+
+목표는 다음 세 줄이다.
 
 ```bash
 brew install spotter
 spotter setup codex
 spotter doctor
+```
 
-# normal use after setup
+그 이후에는:
+
+```bash
 codex
 ```
 
-The user should not need to manually start `spotterd` or a Codex App Server before ordinary use. Manual daemon commands remain operational/debugging escape hatches.
+만 실행하면 된다.
 
-Planned control-plane shape:
+사용자가 매번 직접 다음을 실행하게 하지 않는다.
+
+```bash
+spotter daemon start
+codex app-server daemon start
+```
+
+Target control plane:
 
 ```text
 spotter setup codex|claude|--all
@@ -270,45 +491,49 @@ spotter config
 spotter version
 ```
 
-The exact App Server lifecycle strategy is deliberately gated on an E2E PoC because current Codex can choose an embedded App Server when no reusable external daemon is present. See [Lifecycle](docs/lifecycle.md).
+설치부터 update/uninstall/purge/reinstall까지의 정확한 ownership과 failure handling은 [Lifecycle](docs/lifecycle.md)에 정리한다.
 
-## Inspect and evaluate sessions
+---
 
-Recorded sessions can be summarized, labeled, and measured:
+## 다음 구현 순서
 
-```bash
-spotter analyze
-spotter label --session <id> --step 7 --verdict fp --note "quoted, not executed"
-spotter metrics
+```text
+P0  App Server lifecycle / attach PoC
+ ↓
+P1  spotterd + App Server client + IPC + thread/turn identity
+ ↓
+P2  package/setup/status/doctor/teardown lifecycle
+ ↓
+P3  기존 journal/gate/audit/reviewer/snapshot 기능을 runtime 뒤로 이동
+ ↓
+P4  App Server primary observation + Hook 최소화
+ ↓
+P5  cheap signal → event-driven reviewer
+ ↓
+P6  live VERIFY / NUDGE via turn/steer
+ ↓
+P7  INTERRUPT / RESTART / side-effect-aware recovery
+ ↓
+P8  upgrade/migration/retention/purge/multi-agent hardening
 ```
 
-The shadow reviewer can be run explicitly:
+각 phase의 구체적인 deliverable, dependency, exit criteria는 [Roadmap](docs/roadmap.md)을 본다.
 
-```bash
-spotter review --session <id>
-```
+---
 
-Counterfactual continuations can be prepared or executed where a mechanically decidable `--check` exists:
+## 문서
 
-```bash
-spotter experiment --session <id> --step <k> --guidance "..." --check "..."
-```
+- **[Status](docs/status.md)** — 현재 구현/미구현, blocker, 다음 단계 대시보드
+- **[Concept](docs/concept.md)** — Spotter가 무엇이고 왜 필요한지
+- **[Architecture](docs/architecture.md)** — process, state, event, control, failure contract
+- **[Lifecycle](docs/lifecycle.md)** — install → setup → runtime → update → teardown → purge
+- **[Roadmap](docs/roadmap.md)** — dependency 기반 구현 순서와 exit criteria
+- **[Research](docs/research.md)** — prior work, borrowed ideas, 미검증 가설, evaluation questions
+- **[#66](https://github.com/Bogyie/spotter/issues/66)** — standalone runtime 전환 umbrella issue
 
-Labels live outside the session journal so the reviewer does not read its own report card. Metrics report coverage and avoid publishing rates from very small samples.
+---
 
-## Documentation
-
-- [Concept](docs/concept.md) — the problem, principles, intervention semantics, and product boundary
-- [Architecture](docs/architecture.md) — current/target runtime structure, observation, state, gates, review, and control paths
-- [Lifecycle](docs/lifecycle.md) — install, setup, service/App Server lifecycle, sessions, recovery, upgrades, teardown, purge, and migration
-- [Research](docs/research.md) — related work, borrowed ideas, open hypotheses, and evidence gaps
-- [Roadmap](docs/roadmap.md) — migration sequence, implementation milestones, and evaluation plan
-
-The umbrella direction is tracked in [#66](https://github.com/Bogyie/spotter/issues/66).
-
-## Development
-
-Run the local checks with:
+## 개발
 
 ```bash
 ruff format --check .
@@ -317,20 +542,34 @@ mypy src tests
 pytest
 ```
 
-The architectural migration should preserve the useful boundaries already present in the prototype: normalized trace data, deterministic gates, review policy, snapshots/replay, and evaluation tooling should not become coupled to one Codex transport.
+Architecture migration에서 기존 prototype의 유용한 경계를 유지해야 한다.
+
+```text
+adapter-specific runtime events
+        ↓
+normalized Trace IR
+        ↓
+Spotter core policy / state / evaluation
+```
+
+Codex App Server event shape가 Spotter core 전체로 새어 들어가게 만들지 않는다.
+
+---
 
 ## Trajectory Engineering
 
-Spotter is also an experiment in a broader idea: **Trajectory Engineering**.
+Spotter는 **Trajectory Engineering**이라는 더 넓은 문제를 탐구하는 프로젝트이기도 하다.
 
-- Prompt engineering shapes the instruction.
-- Context engineering shapes what the model can see.
-- Harness engineering shapes tools and execution constraints around the model.
-- **Trajectory engineering shapes what happens while the agent is already executing.**
+- Prompt engineering — 무엇을 지시하는가
+- Context engineering — 무엇을 보게 하는가
+- Harness engineering — 어떤 도구와 환경에서 실행하는가
+- **Trajectory engineering — 실행 중인 경로를 어떻게 관찰·검증·조정·중단·복구하는가**
 
-The question is:
+Spotter가 검증하려는 가설은 다음과 같다.
 
-> **While the agent is working, how do we observe, verify, steer, stop, and recover its path without making supervision more expensive than the mistakes it prevents?**
+> **더 좋은 agent는 처음부터 실수하지 않는 agent만을 의미하지 않는다. 실수가 비싸지기 전에 발견되고 복구 가능한 agent도 더 좋은 agent다.**
+
+이 가설은 아직 Spotter에 대해 입증되지 않았다. Null/negative result도 그대로 기록하는 것이 프로젝트 원칙이다.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ External Codex App Server
 
 The immediate next step is **not** to blindly build the daemon. First we must prove that the ordinary Codex TUI and Spotter can share the **same external App Server**, observe the same thread/turn, and that Spotter can steer the real active turn. That is P0 in the roadmap.
 
-For the fastest project snapshot, read [Status](docs/status.md). The umbrella design decision lives in [#66](https://github.com/Bogyie/spotter/issues/66).
+For the fastest project snapshot, read [Status](docs/status.md). To browse all documentation by question, start at [Documentation](docs/README.md). The umbrella design decision lives in [#66](https://github.com/Bogyie/spotter/issues/66).
 
 ---
 
@@ -62,6 +62,7 @@ For the fastest project snapshot, read [Status](docs/status.md). The umbrella de
 | Install → setup → run → recover → upgrade → remove | [docs/lifecycle.md](docs/lifecycle.md) |
 | What to build next and why | [docs/roadmap.md](docs/roadmap.md) |
 | Research basis and evidence gaps | [docs/research.md](docs/research.md) |
+| All docs by question/reading path | [docs/README.md](docs/README.md) |
 | Umbrella direction | [#66](https://github.com/Bogyie/spotter/issues/66) |
 
 ---
@@ -508,6 +509,7 @@ See [Roadmap](docs/roadmap.md) for deliverables, dependencies, and exit criteria
 
 ## Documentation
 
+- **[Docs index](docs/README.md)** — choose a document by question/reading path
 - **[Status](docs/status.md)** — current implementation, blocker, and next steps
 - **[Concept](docs/concept.md)** — problem definition, principles, and intervention semantics
 - **[Architecture](docs/architecture.md)** — process, state, event, control, and failure contracts

--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ Spotter is an experimental **runtime supervision system for coding agents**, sta
 
 ---
 
-## 30초 요약
+## 30-second summary
 
-Spotter가 해결하려는 문제는 **“에이전트가 틀렸는가?”**보다 조금 더 구체적이다.
+Spotter is interested in a more specific question than “is the agent wrong?”
 
-> **에이전트가 잘못된 가정·반복·범위 이탈을 계속 누적하기 전에, 실행 중간에 이를 감지하고 가장 약한 개입으로 경로를 되돌릴 수 있는가?**
+> **Can we detect a bad assumption, loop, scope drift, or missing validation while the agent is still working, and intervene before the mistake becomes expensive?**
 
-현재 repository는 이미 단순 scaffold를 넘었다. Hook 기반 trajectory 수집, deterministic gate, snapshot/fork/replay, shadow reviewer, audit ledger, labels/metrics, counterfactual experiment harness가 구현돼 있다.
+The repository is already beyond a scaffold. The current prototype implements hook-based trajectory collection, deterministic gates, crash-safe journals, Git snapshots, fork/replay, a shadow reviewer, claim/evidence state, labels/metrics, and counterfactual experiment machinery.
 
-다만 **현재 shipping prototype**과 **목표 architecture**는 다르다.
+The current prototype and the target product architecture are different:
 
 ```text
-현재 prototype
+CURRENT PROTOTYPE
 
 Codex / Claude Code
        │ hooks
@@ -33,86 +33,84 @@ Codex / Claude Code
        └─ periodic shadow review
 
 
-목표 architecture
+TARGET ARCHITECTURE
 
 Codex TUI
     │
     ▼
 External Codex App Server
-    ↕ event stream / steer / interrupt
+    ↕ events / steer / interrupt
  spotterd
     │
     └─ PreToolUse Hook
-       (deterministic synchronous gate만)
+       (deterministic synchronous enforcement only)
 ```
 
-**가장 가까운 다음 단계는 App Server lifecycle/attach PoC다.** 사용자 TUI와 Spotter가 동일한 외부 App Server를 공유하고, Spotter가 실제 active turn에 `turn/steer`를 보낼 수 있는지 먼저 E2E로 검증한다. 이 전제가 실패하면 daemon migration을 밀어붙이지 않는다.
+The immediate next step is **not** to blindly build the daemon. First we must prove that the ordinary Codex TUI and Spotter can share the **same external App Server**, observe the same thread/turn, and that Spotter can steer the real active turn. That is P0 in the roadmap.
 
-빠른 현재 상태는 [Status](docs/status.md), 상세 방향은 [#66](https://github.com/Bogyie/spotter/issues/66)을 본다.
+For the fastest project snapshot, read [Status](docs/status.md). The umbrella design decision lives in [#66](https://github.com/Bogyie/spotter/issues/66).
 
 ---
 
-## 빠른 탐색
+## Quick navigation
 
-| 알고 싶은 것 | 바로 보기 |
+| You want to know... | Read |
 | --- | --- |
-| 지금 실제로 되는 기능 | [현재 상태](#현재-상태) / [docs/status.md](docs/status.md) |
-| Spotter가 정확히 무엇인가 | [핵심 개념](#핵심-개념) / [docs/concept.md](docs/concept.md) |
-| 목표 process/data flow | [목표 architecture](#목표-architecture) / [docs/architecture.md](docs/architecture.md) |
-| 설치→setup→세션→업데이트→제거 | [docs/lifecycle.md](docs/lifecycle.md) |
-| 다음 구현 순서와 dependency | [docs/roadmap.md](docs/roadmap.md) |
-| 근거 논문·연구 질문·미검증 가설 | [docs/research.md](docs/research.md) |
-| umbrella direction issue | [#66](https://github.com/Bogyie/spotter/issues/66) |
+| What works today | [Current status](#current-status) / [docs/status.md](docs/status.md) |
+| What Spotter is trying to solve | [Core idea](#core-idea) / [docs/concept.md](docs/concept.md) |
+| The exact target process/data flow | [Target architecture](#target-architecture) / [docs/architecture.md](docs/architecture.md) |
+| Install → setup → run → recover → upgrade → remove | [docs/lifecycle.md](docs/lifecycle.md) |
+| What to build next and why | [docs/roadmap.md](docs/roadmap.md) |
+| Research basis and evidence gaps | [docs/research.md](docs/research.md) |
+| Umbrella direction | [#66](https://github.com/Bogyie/spotter/issues/66) |
 
 ---
 
-## 현재 상태
+## Current status
 
-### 기능 상태 한눈에 보기
+Legend: ✅ implemented · 🟡 partial/shadow · 🧪 PoC required · 🎯 target · ❌ not implemented
 
-| 기능 | 상태 | 설명 |
+| Capability | Status | Notes |
 | --- | --- | --- |
-| Hook trajectory collection | ✅ 구현 | `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse` 기록 |
-| Deterministic gate | ✅ 구현 | destructive command/path/dependency 등 rule-based 판단 |
-| Crash-safe journal | ✅ 구현 | cross-process locking, fsync, torn-tail recovery |
-| Git snapshot / restore | ✅ 구현 | user HEAD/index를 건드리지 않는 snapshot + detached restore |
-| Fork / continuation replay | ✅ 구현 | 동일 prefix에서 Codex continuation 분기 |
-| Shadow reviewer | ✅ 구현 | `CONTINUE / VERIFY / NUDGE` 판단 기록, live delivery는 없음 |
-| Claim/evidence audit ledger | 🟡 부분 | observable outcome 범위에서 stale premise propagation |
-| Label / metrics | ✅ 구현 | coverage-aware precision/FP 측정 |
-| Counterfactual experiment harness | ✅ 구현 | control/guidance same-prefix pair 실행 기반 |
-| Standalone `spotterd` runtime | ❌ 미구현 | #66 target |
-| App Server primary observation | 🧪 PoC 필요 | 가장 먼저 검증할 architecture 전제 |
-| Event-driven signal engine | ❌ 미구현 | 현재 reviewer는 periodic cadence 기반 |
-| Live `VERIFY / NUDGE` | ❌ 미구현 | target: `turn/steer` |
-| `INTERRUPT` | ❌ 미구현 | target: `turn/interrupt` |
-| `RESTART` | ❌ 미구현 | verified state + recovery design 필요 |
-| Homebrew/setup lifecycle | 🎯 target | `brew install spotter` / `spotter setup codex` |
+| Hook trajectory ingestion | ✅ | Current primary observation path |
+| Deterministic pre-action gates | ✅ | Rule-based; safe/shadow-first posture |
+| Crash-tolerant journal | ✅ | Locking, fsync, torn-tail recovery |
+| Git snapshot / detached restore | ✅ | User HEAD/index remain untouched |
+| Fork / continuation replay | ✅ | Same-prefix continuation machinery |
+| Shadow reviewer | ✅ | Produces `CONTINUE / VERIFY / NUDGE`; no live delivery |
+| Claim/evidence audit ledger | 🟡 | Works where observable outcomes exist |
+| Labels / metrics | ✅ | Coverage-aware precision/FP evaluation |
+| Counterfactual experiment harness | ✅ | Control/guidance same-prefix pairs |
+| Standalone `spotterd` runtime | ❌ | Target in #66 |
+| App Server primary observation | 🧪 | P0 PoC first |
+| Event-driven signal engine | ❌ | Current reviewer trigger is periodic |
+| Live `VERIFY / NUDGE` | ❌ | Target: `turn/steer` |
+| `INTERRUPT` | ❌ | Target: `turn/interrupt` |
+| `RESTART` | ❌ | Requires verified-state + side-effect-aware recovery |
+| Homebrew / setup lifecycle | 🎯 | Target product path |
 
-> 구현 여부와 효과 입증은 다르다. 예를 들어 reviewer가 `NUDGE`를 생성할 수 있다는 사실은 NUDGE가 실제 task outcome을 개선한다는 증거가 아니다.
+### Current blocker
 
-### 지금 가장 중요한 blocker
+The architecture depends on one concrete property:
 
-```text
-P0 — Codex App Server lifecycle / attach PoC
-```
+> **When a user runs ordinary `codex`, can the TUI and Spotter attach to the same externally reachable App Server and can Spotter steer that exact active turn?**
 
-검증할 질문:
+P0 must prove:
 
-1. 외부 App Server가 준비돼 있을 때 plain `codex`가 이를 안정적으로 재사용하는가?
-2. Spotter가 second client로 붙어 같은 thread/turn event를 받는가?
-3. active `turn_id`를 정확하게 추적할 수 있는가?
-4. `turn/steer`가 실제 사용자가 보고 있는 Codex TUI turn에 전달되는가?
-5. 여러 Codex session을 동시에 구분할 수 있는가?
-6. attach/control이 불가능한 경우 `status/doctor`가 이를 명확한 degraded mode로 보여줄 수 있는가?
+1. same thread id is visible to TUI and Spotter;
+2. Spotter receives live events for the same turn;
+3. active `turn_id` tracking is reliable;
+4. `turn/steer` affects the real user-visible TUI session;
+5. multiple concurrent Codex sessions remain distinguishable;
+6. reconnect/degraded behavior is observable and diagnosable.
 
-자세한 PoC와 exit criteria는 [Roadmap P0](docs/roadmap.md)을 본다.
+If these properties fail, the daemon/App Server direction must be revisited before P1.
 
 ---
 
-## 핵심 개념
+## Core idea
 
-Coding agent는 보통 긴 실행 경로를 만든다.
+Coding agents work through long trajectories:
 
 ```text
 understand
@@ -132,93 +130,90 @@ revise
 validate
 ```
 
-문제는 많은 실패가 한 번의 잘못된 출력이 아니라 **trajectory failure**라는 점이다.
+Many failures are not one bad output. They are **trajectory failures**.
 
-예를 들어:
-
-```text
-잘못된 가정
-"timeout 원인은 Redis pool이다"
-        │
-        ▼
-관련 파일만 계속 탐색
-        │
-        ▼
-Redis 설정 수정
-        │
-        ▼
-테스트 실패
-        │
-        ▼
-실패를 보정하기 위한 추가 수정
-        │
-        ▼
-scope 확대 + 시간/토큰 낭비
-```
-
-최종 diff review는 마지막에 문제를 발견할 수 있지만, 이미 대부분의 비용을 지불한 뒤다.
-
-Spotter는 다음 지점을 노린다.
+A typical failure chain looks like this:
 
 ```text
-잘못된 가정
-    │
-    ├── evidence 부족 감지
-    │       ↓
-    │    VERIFY
-    │       ↓
-    │  stack trace 확인
-    │
-    └── 잘못된 edit가 누적되기 전에 경로 수정
+Weak assumption
+"the timeout must come from the Redis pool"
+        │
+        ▼
+Search only Redis-related code
+        │
+        ▼
+Edit Redis configuration
+        │
+        ▼
+Tests fail for unrelated reasons
+        │
+        ▼
+Add compensating changes
+        │
+        ▼
+Scope grows; time/tokens are already spent
 ```
 
-즉 Spotter의 목적은 **오류 개수를 최대한 많이 찾는 것**이 아니라 **잘못된 진행이 비싸지기 전에 잡는 것**이다.
+A post-hoc diff reviewer may eventually catch the mistake, but most of the cost has already been paid.
+
+Spotter tries to intervene earlier:
+
+```text
+Weak assumption
+      │
+      ├─ insufficient evidence detected
+      │       ↓
+      │     VERIFY
+      │       ↓
+      │ inspect the stack trace / run focused probe
+      │
+      └─ avoid compounding the wrong branch
+```
+
+The goal is not to maximize the number of alarms. It is to reduce **wasted progress after the first meaningful deviation**.
 
 ---
 
-## 개입 단계
+## Intervention ladder
 
-Spotter는 가장 약한 개입부터 사용한다.
+Spotter prefers the weakest intervention that is likely to help.
 
-| Action | 의미 | 현재 상태 | 목표 runtime primitive |
+| Action | Meaning | Current state | Target runtime primitive |
 | --- | --- | --- | --- |
-| `CONTINUE` | 문제 없음 또는 개입 가치 낮음 | ✅ shadow reviewer | no-op |
-| `VERIFY` | 중요한 가정에 근거가 부족함 | ✅ 판단만 구현 | async `turn/steer` |
-| `NUDGE` | trajectory가 이탈/낭비 쪽으로 기울고 있음 | ✅ 판단만 구현 | async `turn/steer` |
-| `BLOCK` | 명확한 deterministic constraint 위반 | ✅ gate 구현 | synchronous `PreToolUse` deny |
-| `INTERRUPT` | 현재 turn을 계속하면 손실이 누적될 가능성이 큼 | ❌ | `turn/interrupt` |
-| `RESTART` | reasoning context 자체를 신뢰하기 어려움 | ❌ | verified state 기반 새 continuation |
+| `CONTINUE` | No useful intervention | ✅ shadow reviewer | no-op |
+| `VERIFY` | A consequential assumption needs evidence | ✅ decision only | async `turn/steer` |
+| `NUDGE` | The trajectory is drifting or wasting effort | ✅ decision only | async `turn/steer` |
+| `BLOCK` | A deterministic policy violation is about to execute | ✅ gate | synchronous `PreToolUse` deny |
+| `INTERRUPT` | Continuing the active turn is likely to compound failure | ❌ | `turn/interrupt` |
+| `RESTART` | The reasoning context itself is no longer trustworthy | ❌ | fresh continuation from verified state |
 
-중요한 원칙:
-
-> **Semantic reviewer가 “싫다”고 해서 BLOCK하지 않는다.**  
-> BLOCK은 가능한 한 deterministic하고 audit 가능한 규칙에만 사용한다.
+A semantic reviewer disagreement should **not** casually become a synchronous `BLOCK`. Stronger interventions require stronger evidence.
 
 ---
 
-## 목표 architecture
+## Target architecture
 
-### 역할 분리
+### Four responsibilities
 
 ```text
 Observation plane
-  무엇이 일어나고 있는가?
+  What is happening?
   → Codex App Server event stream
 
 Control plane
-  이미 실행 중인 trajectory에 어떻게 개입하는가?
+  How can Spotter influence the active trajectory?
   → turn/steer, turn/interrupt
 
 Enforcement plane
-  실행 전에 반드시 결정해야 하는가?
+  What must be decided before execution?
   → PreToolUse deterministic gate
 
 Supervision runtime
-  상태·신호·reviewer·policy를 누가 소유하는가?
+  Who owns state, signals, reviewers, budgets, recovery?
   → spotterd
 ```
 
-### 목표 data flow
+### Target data flow
 
 ```text
                      ┌─────────────┐
@@ -235,7 +230,7 @@ Supervision runtime
                  ┌──────────────────┐
                  │     spotterd     │
                  │                  │
-                 │ SessionManager   │
+                 │ Thread Manager   │
                  │ Live State       │
                  │ Trace IR         │
                  │ Audit State      │
@@ -251,75 +246,63 @@ Supervision runtime
                    PreToolUse Hook
 ```
 
-### 상태 ownership
+State ownership becomes explicit:
 
 ```text
-memory  = 현재 살아 있는 thread/turn의 live supervision state
-journal = durable event history + crash/restart/resume recovery source
+memory  = live supervision state for active/dormant threads
+journal = durable event history + recovery/analysis source
+snapshot = filesystem/Git state at a branch/recovery point
 ```
 
-현재 prototype처럼 매 Hook마다 journal을 다시 읽어 live state를 복원하는 구조를 steady state로 유지하지 않는다.
+These are different resources and should not be conflated.
 
 ---
 
-## 정상 실행은 어떻게 보일까
+## Normal runtime behavior
 
-목표 runtime에서 평상시 event는 다음처럼 처리한다.
+For ordinary observations:
 
 ```text
 App Server event
       │
       ▼
-spotterd normalize
+spotterd normalizes it
       │
-      ├─ live state update
-      ├─ journal append
-      └─ cheap signal evaluation
-                  │
-             suspicious?
-              ├─ no → 끝
+      ├─ update live state
+      ├─ append journal
+      └─ evaluate cheap signals
+                   │
+              suspicious?
+              ├─ no → done
               └─ yes
                     │
                     ▼
              async reviewer job
                     │
                     ├─ CONTINUE → no-op
-                    ├─ VERIFY   → active turn이면 steer
-                    ├─ NUDGE    → active turn이면 steer
-                    └─ strong action 후보 → 별도 policy
+                    ├─ VERIFY   → steer if target turn is still active
+                    ├─ NUDGE    → steer if target turn is still active
+                    └─ stronger action → separate high-confidence policy
 ```
 
-Main agent는 reviewer가 생각하는 동안 계속 실행한다.
+Main continues while the reviewer thinks.
 
-Reviewer verdict가 늦게 도착하면 대상 turn이 아직 active인지 확인한다.
-
-```text
-reviewer verdict ready
-        │
-        ▼
-target turn still active?
-   ├─ yes → deliver
-   └─ no  → stale / discard / explicit defer policy
-```
-
-뒤늦은 NUDGE를 unrelated later turn에 무조건 넣지 않는다.
+A reviewer verdict is tied to the turn that caused the review. If the verdict arrives after the target turn has ended, it must go through an explicit stale/defer/discard policy. Spotter must not blindly inject a late nudge into an unrelated later turn.
 
 ---
 
-## 왜 Hook은 하나만 남기려 하나
+## Why keep one Hook?
 
-현재 prototype은 네 Hook을 사용한다.
+The current prototype uses four Hook surfaces:
 
-| Hook | 현재 역할 | 목표 |
+| Hook | Current role | Target role |
 | --- | --- | --- |
-| `SessionStart` | session 감지 | App Server lifecycle로 대체 후 제거 후보 |
-| `UserPromptSubmit` | user goal 기록 | App Server user-message event로 대체 후 제거 후보 |
-| `PreToolUse` | proposal + deterministic gate | **atomic gate 때문에 유지** |
-| `PostToolUse` | result/snapshot/review trigger | App Server result/diff event로 대체 후 제거 1순위 |
+| `SessionStart` | session/bootstrap observation | replace with App Server lifecycle if coverage is sufficient |
+| `UserPromptSubmit` | goal capture | replace with App Server user-message events |
+| `PreToolUse` | proposal observation + gate | **retain for atomic deterministic enforcement** |
+| `PostToolUse` | result/snapshot/reviewer trigger | replace with App Server result/diff events |
 
-관찰과 semantic review는 App Server/daemon 쪽으로 옮긴다.
-
-`PreToolUse`는 다음과 같은 실행 전 guarantee 때문에 남긴다.
+The reason to retain `PreToolUse` is the execution guarantee:
 
 ```text
 git reset --hard
@@ -330,16 +313,16 @@ PreToolUse
         ▼
 spotterd Gate Engine
    ├─ ALLOW
-   └─ DENY  ← command가 실행되기 전에 확정
+   └─ DENY  ← decided before execution
 ```
 
-향후 App Server가 모든 tool call에 대해 신뢰할 수 있는 atomic veto primitive를 제공한다면 Hook 0개도 검토할 수 있다.
+If a future App Server surface provides an equally reliable atomic veto for all relevant tools, a zero-hook integration becomes worth reconsidering.
 
 ---
 
-## 현재 prototype 사용
+## Use the current prototype
 
-### Source install
+### Source installation
 
 Python 3.11+:
 
@@ -357,14 +340,14 @@ Development extras:
 python -m pip install -e '.[dev]'
 ```
 
-Config:
+Configuration:
 
 ```bash
 cp spotter.example.toml spotter.toml
 spotter --config spotter.toml
 ```
 
-기본 예시는 passive observation을 사용한다.
+The example is passive by default:
 
 ```toml
 observation_only = true
@@ -392,25 +375,25 @@ claude plugin marketplace add bogyie/spotter
 claude plugin install spotter@spotter
 ```
 
-이 방식은 **현재 prototype을 사용할 수 있는 경로**이고, target product boundary는 standalone runtime이다.
+Plugin installation is the **current prototype path**, not the long-term product boundary.
 
 ---
 
-## 현재 세션 분석/실험
+## Inspect and evaluate current sessions
 
-세션 요약:
+Summarize a recorded session:
 
 ```bash
 spotter analyze
 ```
 
-Shadow reviewer:
+Run the shadow reviewer:
 
 ```bash
 spotter review --session <id>
 ```
 
-Human label:
+Apply a human label:
 
 ```bash
 spotter label \
@@ -426,13 +409,13 @@ Metrics:
 spotter metrics
 ```
 
-Fork:
+Prepare a fork:
 
 ```bash
 spotter fork --session <id> --step <k>
 ```
 
-Counterfactual experiment:
+Run a counterfactual pair where success is mechanically decidable:
 
 ```bash
 spotter experiment \
@@ -442,13 +425,13 @@ spotter experiment \
   --check "pytest tests/test_timeout.py"
 ```
 
-Experiment machinery가 존재한다고 해서 intervention advantage가 이미 입증된 것은 아니다. 현재 가장 큰 evaluation gap 중 하나는 mechanically scorable ground-truth task set과 실제 실행 데이터다.
+The experiment harness existing does **not** mean positive intervention advantage has been established. A ground-truth task set and enough executed runs are still major evidence gaps.
 
 ---
 
-## 목표 설치/운영 UX
+## Target installation and operations UX
 
-목표는 다음 세 줄이다.
+The target first-run experience is intentionally small:
 
 ```bash
 brew install spotter
@@ -456,28 +439,30 @@ spotter setup codex
 spotter doctor
 ```
 
-그 이후에는:
+After setup:
 
 ```bash
 codex
 ```
 
-만 실행하면 된다.
+should be sufficient for ordinary use.
 
-사용자가 매번 직접 다음을 실행하게 하지 않는다.
+The user should not need to manually run:
 
 ```bash
 spotter daemon start
 codex app-server daemon start
 ```
 
-Target control plane:
+Those remain operational/debug escape hatches.
+
+Planned control-plane shape:
 
 ```text
 spotter setup codex|claude|--all
 spotter teardown codex|claude
-spotter doctor
 spotter status
+spotter doctor
 spotter daemon start|stop|restart|status|logs
 spotter sessions
 spotter analyze
@@ -491,11 +476,11 @@ spotter config
 spotter version
 ```
 
-설치부터 update/uninstall/purge/reinstall까지의 정확한 ownership과 failure handling은 [Lifecycle](docs/lifecycle.md)에 정리한다.
+Detailed ownership, rollback, upgrades, uninstall, purge, and reinstall behavior are specified in [Lifecycle](docs/lifecycle.md).
 
 ---
 
-## 다음 구현 순서
+## Implementation order
 
 ```text
 P0  App Server lifecycle / attach PoC
@@ -504,11 +489,11 @@ P1  spotterd + App Server client + IPC + thread/turn identity
  ↓
 P2  package/setup/status/doctor/teardown lifecycle
  ↓
-P3  기존 journal/gate/audit/reviewer/snapshot 기능을 runtime 뒤로 이동
+P3  move current journal/gate/audit/reviewer/snapshot capabilities behind spotterd
  ↓
-P4  App Server primary observation + Hook 최소화
+P4  App Server primary observation + Hook minimization
  ↓
-P5  cheap signal → event-driven reviewer
+P5  cheap signals → event-driven reviewer
  ↓
 P6  live VERIFY / NUDGE via turn/steer
  ↓
@@ -517,23 +502,23 @@ P7  INTERRUPT / RESTART / side-effect-aware recovery
 P8  upgrade/migration/retention/purge/multi-agent hardening
 ```
 
-각 phase의 구체적인 deliverable, dependency, exit criteria는 [Roadmap](docs/roadmap.md)을 본다.
+See [Roadmap](docs/roadmap.md) for deliverables, dependencies, and exit criteria.
 
 ---
 
-## 문서
+## Documentation
 
-- **[Status](docs/status.md)** — 현재 구현/미구현, blocker, 다음 단계 대시보드
-- **[Concept](docs/concept.md)** — Spotter가 무엇이고 왜 필요한지
-- **[Architecture](docs/architecture.md)** — process, state, event, control, failure contract
-- **[Lifecycle](docs/lifecycle.md)** — install → setup → runtime → update → teardown → purge
-- **[Roadmap](docs/roadmap.md)** — dependency 기반 구현 순서와 exit criteria
-- **[Research](docs/research.md)** — prior work, borrowed ideas, 미검증 가설, evaluation questions
-- **[#66](https://github.com/Bogyie/spotter/issues/66)** — standalone runtime 전환 umbrella issue
+- **[Status](docs/status.md)** — current implementation, blocker, and next steps
+- **[Concept](docs/concept.md)** — problem definition, principles, and intervention semantics
+- **[Architecture](docs/architecture.md)** — process, state, event, control, and failure contracts
+- **[Lifecycle](docs/lifecycle.md)** — install → setup → run → recover → upgrade → teardown → purge
+- **[Roadmap](docs/roadmap.md)** — dependency-driven implementation order and evaluation gates
+- **[Research](docs/research.md)** — prior work, borrowed ideas, open hypotheses, and evidence gaps
+- **[#66](https://github.com/Bogyie/spotter/issues/66)** — standalone-runtime umbrella issue
 
 ---
 
-## 개발
+## Development
 
 ```bash
 ruff format --check .
@@ -542,34 +527,34 @@ mypy src tests
 pytest
 ```
 
-Architecture migration에서 기존 prototype의 유용한 경계를 유지해야 한다.
+The migration should preserve a transport-independent boundary:
 
 ```text
-adapter-specific runtime events
+agent-specific runtime events
         ↓
 normalized Trace IR
         ↓
-Spotter core policy / state / evaluation
+Spotter state / policy / evaluation
 ```
 
-Codex App Server event shape가 Spotter core 전체로 새어 들어가게 만들지 않는다.
+Codex App Server event shapes should not leak throughout Spotter core.
 
 ---
 
 ## Trajectory Engineering
 
-Spotter는 **Trajectory Engineering**이라는 더 넓은 문제를 탐구하는 프로젝트이기도 하다.
+Spotter is also an experiment in **Trajectory Engineering**:
 
-- Prompt engineering — 무엇을 지시하는가
-- Context engineering — 무엇을 보게 하는가
-- Harness engineering — 어떤 도구와 환경에서 실행하는가
-- **Trajectory engineering — 실행 중인 경로를 어떻게 관찰·검증·조정·중단·복구하는가**
+- Prompt engineering — what the model is instructed to do
+- Context engineering — what the model can see
+- Harness engineering — what tools and constraints surround execution
+- **Trajectory engineering — how an already-running path is observed, verified, steered, stopped, and recovered**
 
-Spotter가 검증하려는 가설은 다음과 같다.
+The working hypothesis is:
 
-> **더 좋은 agent는 처음부터 실수하지 않는 agent만을 의미하지 않는다. 실수가 비싸지기 전에 발견되고 복구 가능한 agent도 더 좋은 agent다.**
+> **A better agent system is not only one that makes fewer mistakes. It is also one that detects mistakes early enough that they remain cheap to correct.**
 
-이 가설은 아직 Spotter에 대해 입증되지 않았다. Null/negative result도 그대로 기록하는 것이 프로젝트 원칙이다.
+That hypothesis is not yet proven for Spotter. Null and negative intervention results are first-class outcomes.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,88 @@
+# Spotter Documentation
+
+Start here if you are reading the repository for the first time.
+
+## Which document should I read?
+
+| Question | Document | Read time |
+| --- | --- | --- |
+| What works today, what is blocked, what happens next? | **[Status](status.md)** | ~3 min |
+| What problem is Spotter trying to solve? | [Concept](concept.md) | ~8 min |
+| What processes/components/state should exist? | [Architecture](architecture.md) | ~15–20 min |
+| What happens from install through uninstall/reinstall? | [Lifecycle](lifecycle.md) | ~20 min |
+| What should be implemented first, and what gates each phase? | [Roadmap](roadmap.md) | ~15 min |
+| Which papers/ideas inform the design, and what remains unproven? | [Research](research.md) | ~20 min |
+| What is the umbrella direction decision? | [Issue #66](https://github.com/Bogyie/spotter/issues/66) | reference |
+
+## Recommended reading paths
+
+### I only want the current project picture
+
+```text
+Status
+  ↓
+Roadmap (Now / Next)
+```
+
+### I want to implement the standalone runtime
+
+```text
+Status
+  ↓
+Architecture
+  ↓
+Lifecycle
+  ↓
+Roadmap
+  ↓
+#66
+```
+
+### I want to evaluate the research hypothesis
+
+```text
+Concept
+  ↓
+Research
+  ↓
+Roadmap → Evaluation track
+  ↓
+Status → Evidence status
+```
+
+## Current architectural decision in one screen
+
+```text
+CURRENT
+Codex hooks
+   ↓
+per-hook Spotter processes
+   ↓
+journal / gate / snapshot / periodic shadow reviewer
+
+TARGET
+Codex TUI
+   ↓
+External Codex App Server
+   ↕ events / steer / interrupt
+spotterd
+   ↓
+PreToolUse Hook only for deterministic blocking
+```
+
+The target is **conditional on P0**: Spotter must prove that the user’s ordinary Codex TUI and Spotter can share the same external App Server and that `turn/steer` reaches the real active user turn.
+
+If that does not work reliably, the target architecture is revisited before the daemon migration continues.
+
+## Document responsibilities
+
+To avoid duplicating the same material everywhere:
+
+- **Status** owns “where are we now?”
+- **Concept** owns “what problem and principles define Spotter?”
+- **Architecture** owns runtime components, process/data flow, state ownership, and failure contracts.
+- **Lifecycle** owns package/service/integration/session/update/removal behavior.
+- **Roadmap** owns implementation dependencies and exit criteria.
+- **Research** owns prior work, hypotheses, evidence, and evaluation questions.
+
+When a detail belongs to another document, link to it rather than maintaining two competing specifications.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,15 +4,15 @@ Start here if you are reading the repository for the first time.
 
 ## Which document should I read?
 
-| Question | Document | Read time |
+| Question | Document | What you get |
 | --- | --- | --- |
-| What works today, what is blocked, what happens next? | **[Status](status.md)** | ~3 min |
-| What problem is Spotter trying to solve? | [Concept](concept.md) | ~8 min |
-| What processes/components/state should exist? | [Architecture](architecture.md) | ~15–20 min |
-| What happens from install through uninstall/reinstall? | [Lifecycle](lifecycle.md) | ~20 min |
-| What should be implemented first, and what gates each phase? | [Roadmap](roadmap.md) | ~15 min |
-| Which papers/ideas inform the design, and what remains unproven? | [Research](research.md) | ~20 min |
-| What is the umbrella direction decision? | [Issue #66](https://github.com/Bogyie/spotter/issues/66) | reference |
+| What works today, what is blocked, what happens next? | **[Status](status.md)** | implementation dashboard + immediate blocker |
+| What problem is Spotter trying to solve? | [Concept](concept.md) | mental model, principles, intervention semantics |
+| What processes/components/state should exist? | [Architecture](architecture.md) | component, state, IPC, and failure contracts |
+| What happens from install through uninstall/reinstall? | [Lifecycle](lifecycle.md) | command-by-command operational lifecycle |
+| What should be implemented first, and what gates each phase? | [Roadmap](roadmap.md) | dependency graph, deliverables, exit criteria |
+| Which papers/ideas inform the design, and what remains unproven? | [Research](research.md) | literature-to-mechanism map + evidence gates |
+| What is the umbrella direction decision? | [Issue #66](https://github.com/Bogyie/spotter/issues/66) | design rationale and ongoing decisions |
 
 ## Recommended reading paths
 
@@ -21,7 +21,7 @@ Start here if you are reading the repository for the first time.
 ```text
 Status
   ↓
-Roadmap (Now / Next)
+Roadmap → Now / Next
 ```
 
 ### I want to implement the standalone runtime
@@ -70,19 +70,19 @@ spotterd
 PreToolUse Hook only for deterministic blocking
 ```
 
-The target is **conditional on P0**: Spotter must prove that the user’s ordinary Codex TUI and Spotter can share the same external App Server and that `turn/steer` reaches the real active user turn.
+The target is **conditional on P0**: Spotter must prove that the user's ordinary Codex TUI and Spotter can share the same external App Server and that `turn/steer` reaches the real active user turn.
 
 If that does not work reliably, the target architecture is revisited before the daemon migration continues.
 
 ## Document responsibilities
 
-To avoid duplicating the same material everywhere:
+To avoid maintaining duplicate specifications:
 
 - **Status** owns “where are we now?”
 - **Concept** owns “what problem and principles define Spotter?”
-- **Architecture** owns runtime components, process/data flow, state ownership, and failure contracts.
+- **Architecture** owns runtime components, process/data flow, state ownership, IPC, and failure contracts.
 - **Lifecycle** owns package/service/integration/session/update/removal behavior.
-- **Roadmap** owns implementation dependencies and exit criteria.
+- **Roadmap** owns implementation dependencies, deliverables, and exit criteria.
 - **Research** owns prior work, hypotheses, evidence, and evaluation questions.
 
-When a detail belongs to another document, link to it rather than maintaining two competing specifications.
+When a detail belongs to another document, link to it rather than maintaining two competing definitions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,60 +1,32 @@
 # Architecture
 
-> **Status:** current prototype + target architecture.  
-> The target standalone runtime is tracked by [#66](https://github.com/Bogyie/spotter/issues/66) and is not fully implemented yet.
+> **상태:** 현재 Hook 기반 prototype + [#66](https://github.com/Bogyie/spotter/issues/66)의 target architecture를 함께 설명한다.  
+> **중요:** `spotterd`, App Server primary observation, live `turn/steer`는 아직 target이며 현재 shipping behavior가 아니다.
 
-## 1. Goal
+---
 
-Spotter should supervise coding-agent trajectories with the smallest practical impact on normal execution latency.
+## 30초 요약
 
-The design rule is:
-
-> **Observe broadly. Check deterministic facts cheaply. Review semantic ambiguity asynchronously. Intervene only when intervention is worth its cost.**
-
-The first target is Codex because it exposes both runtime observation/control through App Server and synchronous tool interception through hooks.
-
-## 2. Current prototype vs target runtime
-
-The repository currently proves several pieces of the supervision loop through hooks, journals, snapshots, replay, a shadow reviewer, labels, metrics, and counterfactual experiments.
-
-Current prototype shape:
-
-```text
-Codex / Claude Code
-       │
-       │ lifecycle + tool hooks
-       ▼
-  spotter-hook process
-       │
-       ├─ journal
-       ├─ deterministic gate
-       ├─ snapshot
-       └─ periodic shadow review trigger
-```
-
-This was intentionally simple, but it makes every hook invocation pay process/bootstrap and durable-state reconstruction costs.
-
-The target architecture moves state and orchestration into a long-lived runtime:
+Spotter의 target architecture는 다음 한 장으로 요약된다.
 
 ```text
                      ┌─────────────┐
                      │  Codex TUI  │
                      └──────┬──────┘
-                            │
+                            │ same thread / turn
                             ▼
                  ┌──────────────────────┐
                  │ External App Server  │
                  │ observation/control  │
                  └──────┬────────▲──────┘
                         │        │
-             event stream       │ turn/steer
+              events    │        │ turn/steer
                         │        │ turn/interrupt
-                        │        │ thread injection
                         ▼        │
                  ┌──────────────────┐
                  │     spotterd     │
                  │                  │
-                 │ SessionManager   │
+                 │ Thread Manager   │
                  │ Live State       │
                  │ Trace IR         │
                  │ Audit State      │
@@ -66,305 +38,421 @@ The target architecture moves state and orchestration into a long-lived runtime:
                  └────────┬─────────┘
                           │
                  bounded deterministic
-                      request/reply
+                     request/reply
                           │
                           ▼
                    PreToolUse Hook
-                   if still required
 ```
 
-Responsibility becomes:
+핵심 결정은 여섯 가지다.
+
+1. **App Server가 Codex trajectory의 primary observation source다.**
+2. **semantic reviewer는 비동기다.** Main은 reviewer를 기다리지 않는다.
+3. **`PreToolUse`는 deterministic BLOCK에만 남긴다.**
+4. **live state는 `spotterd` 메모리가 소유한다.** journal은 durable log/recovery source다.
+5. **reviewer verdict는 특정 thread/turn에 묶인다.** 늦게 도착한 verdict는 freshness를 검증한다.
+6. **가장 먼저 App Server lifecycle/attach PoC를 통과해야 한다.** 같은 App Server를 공유하지 못하면 이 architecture를 다시 검토한다.
+
+---
+
+## 빠른 탐색
+
+| 찾는 내용 | 섹션 |
+| --- | --- |
+| 현재와 목표 구조 차이 | [1. Current vs Target](#1-current-vs-target) |
+| process별 역할 | [3. Component contracts](#3-component-contracts) |
+| 실제 event가 어떻게 흐르는가 | [4. Runtime flows](#4-runtime-flows) |
+| Hook은 왜/어디에 남는가 | [5. Enforcement path](#5-enforcement-path-pretooluse) |
+| reviewer가 늦으면 어떻게 하나 | [7. Reviewer job / freshness](#7-reviewer-job과-freshness) |
+| state를 어디에 저장하나 | [8. State ownership](#8-state-ownership) |
+| thread/session 용어 | [9. Identity model](#9-identity-model) |
+| App Server가 끊기면 | [11. Failure / degraded mode](#11-failure--degraded-mode) |
+| 어떤 파일/socket이 생기나 | [12. Runtime resources](#12-runtime-resources) |
+| adapter가 제공해야 할 capability | [14. Agent adapter contract](#14-agent-adapter-contract) |
+| 먼저 검증할 architecture 전제 | [15. P0 PoC](#15-p0-app-server-lifecycle--attach-poc) |
+
+---
+
+# 1. Current vs Target
+
+## 1.1 현재 prototype
+
+현재는 Hook이 observation과 execution boundary를 동시에 담당한다.
 
 ```text
-Codex App Server = primary observation + live control plane
-spotterd         = long-lived supervision state and orchestration
-PreToolUse Hook  = narrow synchronous enforcement plane
-journal          = durable event log / recovery source
-CLI              = user control plane
+Codex / Claude Code
+       │
+       │ SessionStart / UserPromptSubmit
+       │ PreToolUse / PostToolUse
+       ▼
+  spotter-hook process
+       │
+       ├─ config load
+       ├─ journal append
+       ├─ deterministic gate
+       ├─ snapshot
+       └─ reviewer cadence trigger
 ```
 
-The architecture should remain adapter-oriented so another coding agent can expose different observation/control/enforcement surfaces without changing Spotter core policy.
+장점:
 
-## 3. Three runtime planes
+- 빠르게 구현할 수 있었다.
+- fail-open boundary가 단순하다.
+- 실제 Codex trajectory 데이터를 모을 수 있었다.
+- gate, snapshot, fork/replay, reviewer 실험을 검증하는 데 충분했다.
 
-Separating the planes prevents every agent event from being forced through the same mechanism.
+한계:
+
+- Hook마다 별도 process/bootstrap 비용이 든다.
+- 여러 Hook process가 durable journal을 중심으로 상태를 공유한다.
+- semantic reviewer의 long-lived state가 없다.
+- reviewer가 판단을 끝낸 뒤 active turn에 독립적으로 개입할 control channel이 없다.
+- periodic reviewer가 long session에서 계속 비용을 쓴다.
+- App Server가 노출하는 더 풍부한 runtime event를 활용하지 못한다.
+
+## 1.2 Target runtime
+
+```text
+App Server event
+      │
+      ▼
+spotterd
+  ├─ normalize
+  ├─ update live state
+  ├─ append journal
+  ├─ evaluate cheap signals
+  └─ schedule semantic reviewer
+
+Main agent는 계속 실행
+
+PreToolUse만 별도 synchronous path
+```
+
+핵심 변화:
+
+```text
+before
+hook → journal → 필요할 때 state rebuild
+
+after
+event → live state → policy
+                 └→ journal append
+```
+
+---
+
+# 2. Runtime planes
+
+세 가지 plane을 분리한다. 이 구분이 architecture의 중심이다.
+
+| Plane | 질문 | Codex target surface | Latency 성격 |
+| --- | --- | --- | --- |
+| Observation | 지금 무엇이 일어나고 있는가? | App Server event stream | async |
+| Control | 이미 진행 중인 trajectory에 어떻게 개입하는가? | `turn/steer`, `turn/interrupt` | async request |
+| Enforcement | 실행 전에 반드시 막아야 하는가? | `PreToolUse` | sync / bounded |
 
 ### Observation plane
 
-Answers: **What is happening?**
+수집 후보:
 
-Target Codex source: App Server event stream.
-
-Relevant information includes:
-
-- thread and turn lifecycle
-- user messages
-- plan updates
-- reasoning summaries exposed by the runtime/model
-- command/tool start and completion
-- stdout/stderr/exit status where available
-- file changes and diffs
-- MCP calls
+- thread start/resume/close
+- turn start/completion
+- user message
+- plan update
+- reasoning summary가 runtime에 노출되는 경우
+- command/tool start/completion
+- stdout/stderr/exit status
+- file change / diff
+- MCP call
 - web search
 - token usage
 
 ### Control plane
 
-Answers: **How can Spotter influence an already-running trajectory?**
+사용 후보:
 
-Target Codex primitives include:
-
-- `turn/steer` for soft course correction
-- `turn/interrupt` for strong intervention
-- thread/context injection primitives where appropriate
-
-Control is asynchronous relative to most observation. Main does not pause while an LLM reviewer thinks.
+```text
+VERIFY  → turn/steer(evidence request)
+NUDGE   → turn/steer(course correction)
+INTERRUPT → turn/interrupt
+RESTART → interrupt + fresh continuation (later)
+```
 
 ### Enforcement plane
 
-Answers: **What must be decided atomically before execution?**
-
-Target Codex primitive: `PreToolUse` while it remains the reliable synchronous veto boundary.
-
-Only narrow deterministic policy belongs here.
-
-## 4. Why App Server becomes primary for Codex
-
-Hook collection proved useful, but it is a limited observation surface and a poor place for long-lived semantic supervision.
-
-The target architecture prefers App Server because it can provide richer trajectory events and a live control channel in the same integration.
-
-The project must first validate one critical lifecycle property: Spotter must attach to the **same App Server used by the user's Codex TUI**. A separate App Server process that hosts a different thread cannot steer the active user session.
-
-A plain Codex TUI may choose an embedded App Server when no reusable external daemon is available. Therefore the architecture cannot rely on waking Spotter for the first time at `PreToolUse`; by then the App Server target may already be fixed.
-
-The canonical App Server strategy is deliberately gated on an E2E PoC. See [Lifecycle](lifecycle.md) and #66.
-
-## 5. `spotterd`
-
-`spotterd` is the target owner of live supervision state.
-
-Conceptual responsibilities:
-
-```text
-Session / Thread Manager
-Trace normalization
-Independent audit state
-Cheap signal detection
-Deterministic gate policy
-Reviewer scheduling and budgets
-Intervention freshness and delivery
-Journal persistence
-Recovery / reconciliation
-```
-
-The key state rule is:
-
-```text
-memory  = live state
-journal = durable history + recovery
-```
-
-Journal replay is appropriate at daemon restart, thread resume, offline analysis, and experiment boundaries. It should not be the normal way to reconstruct state for every event.
-
-## 6. Agent thread, turn, and attachment model
-
-The word “session” is currently overloaded. The target runtime should distinguish:
-
-```text
-Agent Thread
-  └─ Turn
-       └─ Events
-
-Runtime Attachment
-  = one TUI/runtime connection period to the thread
-```
-
-A thread can outlive one TUI process:
-
-```text
-Thread A
-├─ attachment #1
-│  ├─ turn 1
-│  └─ turn 2
-└─ attachment #2 after resume
-   ├─ turn 3
-   └─ turn 4
-```
-
-Audit state generally belongs to the thread. Runtime health/latency may belong to an attachment. Intervention freshness belongs to a specific turn.
-
-The durable/runtime model should preserve enough identity to correlate:
-
-- agent thread id
-- Spotter thread/session id if separate
-- runtime attachment id
-- turn id
-- tool/item id
-- repository/worktree
-
-## 7. Event collector and Trace IR
-
-Backend-specific runtime events should be normalized before they reach policy.
-
-Conceptually:
-
-```text
-App Server event / Hook event / future adapter event
-                   │
-                   ▼
-                Trace IR
-                   │
-       ┌───────────┴───────────┐
-       ▼                       ▼
-   live state               journal
-       │
-       ├─ signals
-       ├─ reviewer
-       └─ metrics
-```
-
-Example IR:
-
-```text
-STEP 42
-thread: T7
-turn: U12
-kind: TOOL_PROPOSAL
-tool: apply_patch
-files: [src/redis.ts]
-constraints: [C1, C2]
-risk: medium
-```
-
-The IR should retain provenance. A normalized event must still be traceable to the underlying runtime event/tool id so live intervention and replay do not rely on journal adjacency.
-
-## 8. Independent audit state
-
-Spotter should not treat Main's own explanation as ground truth.
-
-Minimum useful live state:
-
-```text
-Goal
-Constraints
-Hypotheses
-Evidence
-Open questions
-Touched scope
-Validation state
-Recent failures
-Intervention history
-Active turn
-Pending reviewer jobs
-Reviewer budget
-External side effects (later)
-```
-
-Claims should be linked to evidence. When supporting evidence is retracted or contradicted, dependent hypotheses and plans become stale and require revalidation.
-
-The current prototype already implements a typed claim/evidence ledger and mechanical stale propagation for observable outcomes. In the target runtime this ledger should become live state instead of being rebuilt before every review.
-
-## 9. Deterministic Gate Engine
-
-Some supervision decisions should bypass the reviewer LLM entirely.
-
-Examples:
-
-- path allow/deny rules
-- dependency-manifest changes
-- destructive shell commands
-- workspace escape
-- explicit user execution restrictions
-- eventually external-write classes with clear rules
-
-Target synchronous path:
+실행 전 deterministic policy만 둔다.
 
 ```text
 PreToolUse
-    │
-    ▼
+  ↓
+ALLOW / DENY
+```
+
+LLM reviewer가 synchronous path에 들어가면 안 된다.
+
+---
+
+# 3. Component contracts
+
+아래 표는 구현 시 component boundary의 기준이다.
+
+| Component | 책임 | 입력 | 출력 | 소유 상태 | 실패 시 기본 동작 |
+| --- | --- | --- | --- | --- | --- |
+| `spotter` CLI | setup/status/doctor/review 등 user control plane | argv/config | 사용자 출력, daemon RPC | 없음 또는 짧은 command state | 명시적 error |
+| `spotterd` | long-lived supervision runtime | App Server events, Hook IPC, CLI RPC | journal, reviewer jobs, interventions | thread/live state | coding session을 깨지 않도록 degraded |
+| `CodexAppServerClient` | App Server 연결·subscribe·control | endpoint/capabilities | normalized runtime events, RPC result | connection state | reconnect/degraded |
+| `SessionManager` | thread/turn/attachment lifecycle | normalized events | current identities/state transitions | thread registry | 해당 thread만 degraded |
+| `TraceNormalizer` | backend event → Trace IR | raw adapter event | TraceEvent | 없음 | unknown event 기록/skip |
+| `AuditState` | claim/evidence/constraints/progress | TraceEvent | live audit view | per thread | incomplete state 명시 |
+| `SignalEngine` | cheap candidate detection | live state/event | candidate signal | small rolling counters | no candidate |
+| `ReviewerScheduler` | async reviewer 실행·budget·dedupe | candidate + context | ReviewerJob | queues/budgets | job failed, Main 계속 |
+| `InterventionController` | verdict freshness/전달/escalation | reviewer decision | steer/interrupt/no-op | intervention history | stale/discard/degraded |
+| `GateEngine` | deterministic pre-action 판단 | PreToolUse proposal + config | allow/deny | rule config + small state | fail-open |
+| `JournalStore` | durable history | normalized records | append/read | disk | write failure telemetry; gate는 fail-open |
+| `SnapshotManager` | Git state checkpoint/restore | repo state | snapshot ref/worktree | repo resources | snapshot failure가 Main을 깨지 않음 |
+| `IntegrationManager` | setup/teardown/migration | agent config | manifest/config mutation | integration manifest | transactional rollback |
+
+이 표에서 중요한 점은 **Spotter core policy가 Codex-specific transport shape를 직접 알지 않는 것**이다.
+
+---
+
+# 4. Runtime flows
+
+## 4.1 Codex startup
+
+Full managed mode의 이상적인 흐름:
+
+```text
+user login / runtime ready
+        │
+        ├─ spotterd ready
+        └─ external App Server available
+
+사용자: codex
+        │
+        ▼
+Codex TUI attaches to external App Server
+        │
+        ├─ TUI = client A
+        └─ Spotter = client B
+```
+
+**주의:** 현재 plain `codex`는 reusable external daemon이 없으면 Embedded App Server를 선택할 수 있다. 따라서 첫 `PreToolUse`에서 daemon을 띄우는 것은 full mode에는 늦을 수 있다.
+
+이 때문에 P0 PoC가 먼저다.
+
+## 4.2 일반 observation event
+
+예: command 완료 event.
+
+```text
+App Server
+  │ command completed
+  ▼
+CodexAdapter
+  │ raw event → TraceEvent
+  ▼
+SessionManager
+  │ thread/turn identity resolve
+  ▼
+Live State
+  ├─ recent failures update
+  ├─ validation state update
+  └─ touched scope update
+  │
+  ├──────────────► Journal append
+  │
+  ▼
+SignalEngine
+  │
+  ├─ no candidate → 끝
+  └─ candidate → ReviewerScheduler
+```
+
+Normal observation은 Hook을 거치지 않는다.
+
+## 4.3 Semantic review
+
+```text
+SignalEngine
+  │ POSSIBLE_TOOL_FAILURE_LOOP
+  ▼
+ReviewerScheduler
+  │ create job(thread=T1, turn=U7)
+  ▼
+Reviewer runs asynchronously
+
+          Main continues
+
+ReviewerDecision
+  │ NUDGE
+  ▼
+InterventionController
+  │ target U7 still active?
+  ├─ yes → turn/steer
+  └─ no  → stale policy
+```
+
+## 4.4 Deterministic gate
+
+```text
+Codex proposes: git reset --hard
+        │
+        ▼
+PreToolUse
+        │ stdin JSON
+        ▼
 spotter-hook
-    │ Unix socket / bounded IPC
-    ▼
-spotterd Gate Engine
-    ├─ ALLOW
-    └─ DENY
+        │ bounded IPC
+        ▼
+spotterd GateEngine
+        │
+        ├─ ALLOW
+        └─ DENY(rule=git_reset_hard)
+        │
+        ▼
+Hook response
 ```
 
-Do not perform these operations synchronously:
+이 path에서는 network/model call을 하지 않는다.
 
-- semantic LLM review
-- long journal replay
-- whole-state reconstruction
-- metrics aggregation
-- broad repository analysis
-
-The gate must have a measured latency budget and fail-open semantics when Spotter itself is unavailable, unless a future explicitly configured fail-closed mode is designed separately.
-
-## 10. Fast Signal Engine
-
-Cheap heuristics create **candidate failure hypotheses**, not semantic verdicts.
-
-Candidate signals include:
-
-- same tool repeatedly invoked with equivalent arguments
-- failure streaks
-- repeated reads with no expansion in the dependency frontier
-- sudden growth in touched scope
-- edits accumulating without validation
-- stale hypothesis reuse
-- unusual tool/token/time budgets
-- attempted circumvention after a deterministic block
-
-Output should look like:
+## 4.5 Turn completion
 
 ```text
-candidate: POSSIBLE_EXPLORATION_LOOP
-support: repeated equivalent search 4x
+turn/completed(U7)
+      │
+      ├─ active_turn = none
+      ├─ finalize timing/tool counters
+      ├─ validation state finalize
+      └─ pending ReviewerJob(target=U7) freshness 재평가
 ```
 
-not:
+Thread state는 사라지지 않는다.
+
+## 4.6 Resume
 
 ```text
-verdict: EXPLORATION_LOOP
+Codex resumes existing thread T1
+        │
+        ▼
+App Server thread event
+        │
+        ▼
+SessionManager finds durable Spotter history
+        │
+        ├─ hydrate missing live state from journal
+        ├─ reconcile App Server current thread state
+        └─ create new RuntimeAttachment
 ```
 
-The reviewer remains responsible for ambiguous semantic judgment.
+Journal replay는 이런 recovery/resume boundary에서 사용한다.
 
-The signal layer is also how Spotter should move away from fixed periodic reviewer calls once the signal quality is measured.
+---
 
-## 11. Reviewer Scheduler
+# 5. Enforcement path: `PreToolUse`
 
-The Pair Reviewer is independently configured from Main where practical.
+Target Codex integration에서 Hook은 가능하면 `PreToolUse` 하나만 남긴다.
 
-Its job is not to solve the task again. It tests candidate failure hypotheses and proposes the weakest useful intervention.
+| Hook | 현재 | Target |
+| --- | --- | --- |
+| `SessionStart` | session bootstrap | App Server lifecycle로 대체 |
+| `UserPromptSubmit` | user goal capture | App Server user-message event로 대체 |
+| `PreToolUse` | proposal + gate | **deterministic atomic gate 유지** |
+| `PostToolUse` | result/snapshot/review cadence | App Server result/diff로 대체 |
 
-Useful reviewer input:
+### Gate가 판단해도 되는 것
 
-- user goal and explicit constraints
-- relevant Trace IR window
-- relevant independent audit state
-- candidate failure hypothesis
-- available verification actions
-- prior interventions for the same issue
-- which inputs are missing or truncated
+- destructive command class
+- forbidden path
+- dependency manifest policy
+- workspace escape
+- 명시된 user/project execution restriction
+- 나중에 충분히 deterministic하게 분류 가능한 external write
 
-Example output:
+### Gate가 판단하면 안 되는 것
 
-```json
-{
-  "decision": "VERIFY",
-  "target": "hypothesis:H3",
-  "reason": "The proposed change depends on an unverified timeout-source assumption.",
-  "probe": "Inspect the timeout stack trace before editing Redis configuration.",
-  "confidence": 0.91
-}
+- “이 refactor는 불필요해 보인다”
+- “이 가정은 아마 틀린 것 같다”
+- “이 접근보다 다른 구현이 좋아 보인다”
+- 전체 repository를 다시 읽어야 하는 의미론적 판단
+
+이런 건 async reviewer 영역이다.
+
+### Failure policy
+
+```text
+spotterd unavailable
+IPC timeout
+unsupported syntax
+unknown workspace
 ```
 
-### Reviewer job lifecycle
+기본은 **fail-open + telemetry**다.
 
-Reviewer work is asynchronous:
+Spotter 장애가 supervised agent 자체를 중단시키면 안 된다.
+
+---
+
+# 6. Trace IR
+
+Raw runtime event를 policy에 직접 전달하지 않는다.
+
+```text
+Codex App Server event
+Claude event
+future agent event
+       │
+       ▼
+   Adapter
+       │
+       ▼
+   Trace IR
+       │
+       ├─ live state
+       ├─ signal
+       ├─ reviewer
+       ├─ metrics
+       └─ journal
+```
+
+최소 필드 예시:
+
+```text
+TraceEvent
+  event_id
+  agent
+  agent_thread_id
+  turn_id
+  item/tool_id
+  timestamp
+  kind
+  operation
+  files/resources
+  result/outcome
+  repository/worktree
+  provenance(raw event reference)
+```
+
+Policy가 필요로 하는 semantic field는 점진적으로 추가한다.
+
+```text
+constraint ids
+candidate hypothesis ids
+validation relation
+side-effect class
+```
+
+중요한 원칙:
+
+> Normalization 때문에 provenance를 잃지 않는다.
+
+`turn/steer`, replay, causal analysis가 raw runtime item과 normalized event를 다시 연결할 수 있어야 한다.
+
+---
+
+# 7. Reviewer Job과 freshness
+
+Semantic reviewer는 process라기보다 **job lifecycle**로 다룬다.
 
 ```text
 QUEUED
@@ -374,239 +462,506 @@ RUNNING
 DECIDED
   ├─ DELIVERED
   ├─ STALE
+  ├─ DISCARDED
   ├─ CANCELLED
   └─ FAILED
 ```
 
-Each job is anchored to the thread/turn that motivated it.
-
-## 12. Intervention Controller
-
-Spotter prefers the weakest sufficient action.
+ReviewerJob 최소 metadata:
 
 ```text
-CONTINUE    → no-op
-VERIFY      → async steer / evidence request
-NUDGE       → async steer
-BLOCK       → synchronous deterministic deny
-INTERRUPT   → turn interrupt
-RESTART     → fresh continuation from verified state
+job_id
+thread_id
+target_turn_id
+candidate_id
+created_at
+started_at
+finished_at
+reviewer model/config fingerprint
+input coverage/truncation
+verdict
+confidence
+delivery status
 ```
 
-### Freshness
+### Freshness rule
 
-A reviewer verdict can become obsolete while Main continues.
+Reviewer가 5초 생각하는 동안 Main이 turn을 끝낼 수 있다.
 
 ```text
-signal at turn U12
-      ↓
-reviewer thinks
-      ↓
-verdict ready
-      ↓
-is U12 still the active target?
-   ├─ yes → deliver
-   └─ no  → stale policy
+U7 signal
+ ↓
+reviewer running
+ ↓
+U7 completed
+ ↓
+reviewer says NUDGE
 ```
 
-A stale verdict must not be blindly injected into a later turn.
+이때 U8에 무조건 NUDGE를 넣으면 안 된다.
 
-Record:
-
-- detection time/step
-- reviewer start/end
-- target turn
-- attempted delivery
-- delivered/stale/discarded outcome
-- intervention latency
-
-This turns responsiveness into a measurable quantity.
-
-## 13. Pair-aware Main contract
-
-Runtime supervision changes Main's environment. A small contract should clarify:
-
-- the user remains the source of task intent
-- Spotter messages are supervision, not new requirements
-- `VERIFY` and `NUDGE` request reassessment, not blind compliance
-- blocked actions should not be retried through superficial reformulation
-- interruptions require replanning
-- disagreement should be resolved with evidence where possible
-- Main should not wait for Spotter during ordinary execution
-
-The target delivery mechanism should not depend on keeping a hook process alive after it returns.
-
-## 14. Action reversibility and side effects
-
-A practical policy distinguishes actions by reversibility.
-
-### Class A — observational / freely reversible
-
-Examples: read, grep/search, ls, diff.
-
-Default: asynchronous observation.
-
-### Class B — locally reversible
-
-Examples: patching files, local builds, local dependency operations.
-
-Default: checkpoint where useful + asynchronous review; deterministic gates for explicit constraints.
-
-### Class C — external or semantically irreversible
-
-Examples: push, deploy, database writes, issue/PR creation, arbitrary MCP writes.
-
-Target: stronger synchronous policy and side-effect recording.
-
-Reasoning rollback does not undo external state. Before `RESTART` can claim meaningful recovery, Spotter needs an effect ledger that can say what remains changed outside the local worktree.
-
-## 15. Snapshots, replay, and counterfactuals
-
-The current prototype already provides Git-backed snapshots, detached-worktree restore, Codex continuation fork machinery, and a same-prefix experiment harness.
-
-These remain important in the target architecture because they support two different goals:
-
-1. recovery primitives
-2. causal evaluation of intervention advantage
-
-Resource lifecycle must be explicit:
+초기 policy 후보:
 
 ```text
-snapshot / fork worktree
-CREATED → IN_USE → RETAINED or CLEANED
+same active target turn
+  → deliver via steer
+
+target turn ended
+  → default STALE/DISCARD
+  → 일부 VERIFY만 명시적인 next-turn defer를 허용할 수 있음
 ```
 
-Never manipulate user worktrees or refs outside Spotter-owned namespaces. Cleanup should be Git-aware.
+어떤 policy든 journal에 남겨 다음을 측정한다.
 
-## 16. Durability and recovery
+- reviewer latency
+- delivery latency
+- stale rate
+- reviewer spend wasted by stale verdict
 
-### Current journal contract
+---
 
-The prototype step journal is append-only JSONL and includes cross-process locking, fsync, torn-tail recovery, and strict reads for destructive operations.
+# 8. State ownership
 
-That durability work remains useful, but the target runtime should reduce the number of independent writers because `spotterd` becomes the primary live writer.
+## 8.1 Live state
 
-### Target recovery path
-
-On daemon restart:
+`spotterd`가 per-thread로 유지할 최소 state:
 
 ```text
-spotterd starts
-    ↓
-reconnect App Server
-    ↓
-list/reconcile active threads
-    ↓
-hydrate durable Spotter state as needed
-    ↓
-resume live supervision
+ThreadState
+  identity
+  repository/worktree
+  user goal
+  constraints
+  active turn
+  hypotheses
+  evidence
+  open questions
+  touched files
+  validation state
+  recent failures
+  recent actions
+  intervention history
+  pending reviewer jobs
+  reviewer budget
+  connection/capability state
 ```
 
-Recovery is a boundary condition, not the normal event-processing loop.
+## 8.2 Durable journal
 
-### Degraded state
+Journal은 다음을 위해 존재한다.
 
-Observation/control health must be visible independently from daemon health:
+- crash recovery
+- resume hydration
+- analyze
+- labels/metrics
+- replay/fork
+- experiment provenance
+- forensic inspection
+
+Journal은 **live state database가 아니다.**
+
+## 8.3 Snapshot state
+
+Git snapshot은 repository state를 복원하는 별도 resource다.
+
+```text
+ThreadState ≠ Journal ≠ Snapshot
+```
+
+- ThreadState: 현재 판단을 위한 memory state
+- Journal: 실행 history
+- Snapshot: 특정 시점의 filesystem/Git state
+
+이 셋을 섞지 않는다.
+
+---
+
+# 9. Identity model
+
+현재 `session`이라는 단어가 여러 의미를 담는다. Target에서는 분리한다.
+
+```text
+Agent Thread
+  장기 대화/작업 identity
+
+Turn
+  한 번의 user→agent 실행 단위
+
+Runtime Attachment
+  TUI/client가 thread에 붙어 있는 한 번의 실행 구간
+
+Reviewer Job
+  특정 candidate/turn을 평가하는 독립 작업
+```
+
+예:
+
+```text
+Thread T1
+├─ Attachment A1 (오늘 오전)
+│  ├─ Turn U1
+│  └─ Turn U2
+└─ Attachment A2 (내일 resume)
+   ├─ Turn U3
+   └─ Turn U4
+```
+
+State placement:
+
+| State | Identity scope |
+| --- | --- |
+| goal/constraints/hypotheses | Thread |
+| active turn | Turn |
+| reviewer freshness | Turn |
+| connection latency | Attachment |
+| journal lineage | Thread |
+| fork branch point | Thread + Turn/Step |
+
+---
+
+# 10. App Server connection / capability model
+
+Spotter는 Codex version 문자열 하나만 보고 기능을 가정하지 않는다.
+
+Connection 시 capability를 확인한다.
+
+```text
+observe_thread_lifecycle
+observe_user_message
+observe_tool_start
+observe_tool_result
+observe_diff
+observe_token_usage
+steer_active_turn
+interrupt_active_turn
+atomic_pretool_veto (hook/other surface)
+```
+
+예시 status:
+
+```text
+Codex integration
+  observation.thread:       yes
+  observation.tool_result:  yes
+  observation.diff:         yes
+  control.steer:            yes
+  control.interrupt:        no
+  enforcement.pretool:      yes
+```
+
+이 모델 덕분에 Codex upgrade 후 일부 feature만 깨져도 전체를 binary compatible/incompatible로 단순화하지 않고 degraded mode로 동작할 수 있다.
+
+---
+
+# 11. Failure / degraded mode
+
+각 plane의 건강 상태를 따로 관리한다.
+
+```text
+spotterd health
+App Server connection
+Observation capability
+Control capability
+PreToolUse enforcement
+Journal/storage health
+Reviewer provider health
+```
+
+예:
 
 ```text
 Spotter daemon:       running
-Codex App Server:     unavailable
+App Server:           reconnecting
 Observation:          unavailable
-Live intervention:    unavailable
-PreToolUse gate:      available
+Live steer:           unavailable
+PreToolUse gate:      active
+Journal:              writable
+Reviewer:             available
 ```
 
-Silence cannot mean both “nothing is wrong” and “Spotter is disconnected”.
+### spotterd crash
 
-## 17. Current prototype implementation notes
+```text
+spotterd crash
+  ↓
+service manager restart
+  ↓
+App Server reconnect
+  ↓
+active/loaded thread list
+  ↓
+reconcile + journal hydrate
+  ↓
+READY
+```
 
-The architectural migration should preserve the useful guarantees already built.
+Daemon이 죽어 있는 동안 Hook gate는 fail-open한다.
 
-### Journal durability
+### App Server crash/disconnect
 
-- cross-process append serialization
+State machine 예:
+
+```text
+CONNECTED
+  ↓
+DEGRADED
+  ↓
+RECONNECTING
+  ├─ CONNECTED
+  └─ UNAVAILABLE
+```
+
+Spotter daemon이 살아 있다는 이유만으로 healthy라고 표시하지 않는다.
+
+### Reviewer failure
+
+```text
+reviewer timeout/error
+  → ReviewerJob FAILED
+  → Main unaffected
+  → spend/error telemetry
+```
+
+---
+
+# 12. Runtime resources
+
+정확한 path는 구현에서 확정하되 ownership은 처음부터 분리한다.
+
+Conceptual layout:
+
+```text
+~/.config/spotter/
+  config.toml
+  integrations/
+    codex.json
+
+~/.local/state/spotter/   # 플랫폼에 맞는 state dir 사용 가능
+  sessions/
+  labels/
+  experiments/
+  logs/
+  runtime/
+    spotter.sock
+    daemon metadata
+  repos.json
+```
+
+현재 prototype의 `~/.spotter` data와 migration compatibility를 고려한다.
+
+Repository 내부/ Git namespace에는:
+
+```text
+refs/spotter/...
+Spotter-created detached worktrees
+```
+
+가 존재할 수 있다.
+
+따라서 uninstall과 data purge는 별개다. 자세한 lifecycle은 [lifecycle.md](lifecycle.md).
+
+---
+
+# 13. Snapshots / replay / side effects
+
+## Snapshot
+
+현재 prototype의 안전 원칙을 유지한다.
+
+- user HEAD/index를 수정하지 않는다.
+- Spotter-owned Git refs만 사용한다.
+- restore는 detached worktree로 한다.
+- cleanup은 Git-aware operation으로 한다.
+
+## Replay/Fork
+
+두 목적이 있다.
+
+1. recovery primitive 연구
+2. same-prefix counterfactual evaluation
+
+Lineage 최소 metadata:
+
+```text
+parent_thread
+branch_point
+snapshot
+forked_rollout
+experiment_id
+control/guidance arm
+```
+
+## External side effects
+
+Local Git snapshot으로는 다음을 되돌릴 수 없다.
+
+```text
+git push
+cloud deploy
+DB write
+GitHub issue/PR create
+arbitrary MCP external write
+```
+
+따라서 `RESTART` 전에 side-effect ledger가 필요하다.
+
+```text
+Effect
+  kind
+  target/resource
+  result
+  timestamp
+  reversible?
+  compensation/checkpoint if known
+```
+
+Spotter는 reasoning context를 restart해도 외부 state가 자동 복구됐다고 주장하면 안 된다.
+
+---
+
+# 14. Agent adapter contract
+
+Codex는 첫 adapter다. Spotter core는 아래 capability 중심으로 본다.
+
+```text
+AgentAdapter
+  connect()/disconnect()
+  list_threads()
+  observe_events()
+  read_thread_state()
+
+  optional:
+    steer(turn, message)
+    interrupt(turn)
+    pre_action_veto(proposal)
+    fork/resume primitives
+```
+
+각 adapter는 capability set을 노출한다.
+
+```text
+CodexAdapter
+  observation: rich
+  steer: yes (target PoC)
+  interrupt: yes (target)
+  pre-action veto: Hook
+
+FutureAgentAdapter
+  observation: maybe partial
+  steer: maybe no
+  veto: maybe no
+```
+
+Capability가 없는 agent에서는 기능을 숨기거나 degraded로 표시한다. Codex-specific method name이 Spotter policy layer에 직접 퍼지지 않게 한다.
+
+---
+
+# 15. P0 App Server lifecycle / attach PoC
+
+이 architecture의 구현은 아래 PoC를 먼저 통과해야 한다.
+
+## Path A — Codex managed daemon
+
+```text
+start/ensure Codex App Server daemon
+      ↓
+plain `codex`
+      ↓
+TUI attaches to default external daemon
+      ↓
+Spotter second-client attach
+      ↓
+observe same thread/turn
+      ↓
+turn/steer reaches TUI
+```
+
+## Path B — Spotter-managed process
+
+```text
+Spotter starts external `codex app-server`
+      ↓
+TUI + Spotter attach same endpoint
+      ↓
+normal plain-codex UX can be preserved?
+```
+
+## Path C — Embedded baseline
+
+외부 attach가 불가능할 때 실제 가능한 capability를 측정한다.
+
+```text
+Observation: limited/unavailable
+Live steer:  unavailable
+Interrupt:   unavailable
+PreToolUse:  possibly available
+```
+
+## Exit criteria
+
+- ordinary `codex` UX 유지
+- same App Server / same thread 증명
+- live event subscription
+- active turn identity
+- real `turn/steer` delivery
+- concurrent sessions 구분
+- reconnect/degraded behavior 이해
+- App Server ownership/lifecycle strategy 결정
+
+**하나라도 핵심 전제가 성립하지 않으면 P1 daemon migration 전에 architecture를 다시 검토한다.**
+
+---
+
+# 16. Current prototype guarantees to preserve
+
+Target으로 옮긴다고 기존 안전성을 버리지 않는다.
+
+### Journal
+
+- cross-process serialization
 - monotonic step/proposal allocation
-- flush/fsync before releasing the write lock
-- torn-tail recovery for normal readers
-- strict reads for destructive cleanup decisions
+- fsync durability
+- torn-tail recovery
+- destructive reader strictness
 
-### Snapshot safety
+### Snapshot
 
-- snapshots use Git objects/refs without touching user HEAD/index
-- restore happens in detached worktrees
-- refs are pinned under Spotter-owned namespaces
-- unchanged states can be deduplicated
-- prune is conservative and dry-run by default
+- user HEAD/index untouched
+- detached restore
+- Spotter-owned refs
+- dedup / conservative prune
 
 ### Audit ledger
 
-- Main reasoning summaries are not accepted as evidence
-- only observable outcomes can become evidence
-- contradicting outcomes retract previous evidence
-- stale propagation is transitive
+- Main summary를 evidence로 승격하지 않음
+- observable outcome만 evidence
+- contradictory outcome → retraction
+- transitive stale propagation
 
-The hook-collected prototype measured observable outcomes on only 33 of 340 real tool results (10%). This figure is specific to the current observation surface. The App Server migration must re-measure it instead of treating 10% as a permanent architectural limit.
+### Gate
 
-### Gate ambiguity
+- shell-aware bounded parsing
+- unsupported ambiguity는 fail-open
+- blind spot을 FP와 별도로 측정
 
-Where deterministic parsing cannot support a safe judgment, the current gate fails open and records the blind spot separately from false-positive metrics.
+Hook corpus에서 audit ledger가 직접 outcome을 읽을 수 있던 tool result는 33/340(10%)이었다. 이 숫자는 **현재 Hook observation surface의 측정값**이며 App Server 전환 후 다시 측정한다.
 
-That distinction should survive the migration.
+---
 
-## 18. Integration lifecycle and service ownership
+# 17. Non-goals for the first migration
 
-Runtime architecture does not end at the event loop. Spotter must also own setup, service lifecycle, upgrades, teardown, and repair coherently.
+첫 architecture migration에서 하지 않는다.
 
-Target user flow:
+- Spotter 전체 Rust/Go rewrite
+- graph database 도입
+- automatic compensating rollback
+- adaptive/learned intervention policy
+- 모든 agent 동시 지원
+- RESTART 완성
+- reviewer가 실제로 task outcome을 개선한다는 주장
 
-```bash
-brew install spotter
-spotter setup codex
-spotter doctor
+첫 성공 기준은 더 작다.
 
-# normal use
-codex
-```
+> **같은 사용자 Codex thread를 안정적으로 관찰하고, live state를 유지하고, deterministic gate는 빠르게 처리하며, async reviewer verdict를 active turn에 안전하게 전달할 수 있는 runtime boundary를 만든다.**
 
-The user should not need to manually start `spotterd` or an App Server before each Codex launch.
-
-Because an external App Server may need to exist before Codex chooses its target, a fully lazy “start on first tool hook” daemon can conflict with the full target experience. The App Server lifecycle PoC decides whether managed mode needs a login-scoped service.
-
-Detailed lifecycle and ownership rules live in [lifecycle.md](lifecycle.md).
-
-## 19. Adapter boundary
-
-Codex is the first target, not the permanent core API.
-
-An agent adapter should expose normalized capabilities such as:
-
-```text
-observe thread/turn events
-observe tool/result/diff
-synchronous pre-action veto (optional)
-soft steer active turn (optional)
-interrupt active turn (optional)
-thread resume/fork primitives (optional)
-```
-
-Spotter core should degrade explicitly when a capability is missing rather than assuming every agent has Codex's exact surfaces.
-
-## 20. First migration boundary
-
-The architecture migration should intentionally avoid turning into a rewrite of everything at once.
-
-First prove:
-
-1. a stable external App Server path can host the same Codex TUI thread that Spotter observes
-2. Spotter can receive the event stream as a second client
-3. Spotter can track the active turn
-4. `turn/steer` reaches the real user session
-5. the `PreToolUse` gate can remain a small bounded synchronous path
-
-Only then move the existing reviewer/state/metrics machinery into the daemon.
-
-The MVP hypothesis remains:
-
-> **Can an independent runtime spotter detect a useful subset of trajectory failures early enough that intervention improves task outcomes without becoming an expensive source of false positives or latency?**
-
-Architecture makes that experiment possible; it does not answer it by itself.
+구현 lifecycle은 [Lifecycle](lifecycle.md), 순서는 [Roadmap](roadmap.md), 현재 상태는 [Status](status.md)를 본다.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,122 +1,249 @@
 # Architecture
 
-## Goal
+> **Status:** current prototype + target architecture.  
+> The target standalone runtime is tracked by [#66](https://github.com/Bogyie/spotter/issues/66) and is not fully implemented yet.
 
-Spotter should supervise a coding-agent trajectory with the smallest practical impact on normal execution latency.
+## 1. Goal
 
-The main design rule is:
+Spotter should supervise coding-agent trajectories with the smallest practical impact on normal execution latency.
 
-> **Cheap checks first. Semantic review only when needed. Strong intervention only when justified.**
+The design rule is:
 
-The initial target is Codex because its current extension/runtime surface exposes useful interception and control points.
+> **Observe broadly. Check deterministic facts cheaply. Review semantic ambiguity asynchronously. Intervene only when intervention is worth its cost.**
 
-## High-level architecture
+The first target is Codex because it exposes both runtime observation/control through App Server and synchronous tool interception through hooks.
+
+## 2. Current prototype vs target runtime
+
+The repository currently proves several pieces of the supervision loop through hooks, journals, snapshots, replay, a shadow reviewer, labels, metrics, and counterfactual experiments.
+
+Current prototype shape:
 
 ```text
-                         User Goal
-                            │
-                            ▼
-                    ┌──────────────┐
-                    │  Main Agent  │
-                    │    Codex     │
-                    └──────┬───────┘
-                           │
-              events / tools / diffs / results
-                           │
-                           ▼
-                    ┌──────────────┐
-                    │   Trace IR   │
-                    └──────┬───────┘
-                           │
-               ┌───────────┴───────────┐
-               ▼                       ▼
-       Deterministic checks        Fast signals
-               │                       │
-               └───────────┬───────────┘
-                           │ candidate issue
-                           ▼
-                    ┌──────────────┐
-                    │ Pair Reviewer│
-                    │ separate LLM │
-                    └──────┬───────┘
-                           │
-                           ▼
-                 Intervention Controller
-                           │
-       ┌──────────┬────────┼─────────┬─────────┐
-       ▼          ▼        ▼         ▼         ▼
-   CONTINUE    VERIFY    NUDGE      BLOCK   INTERRUPT
-                                               │
-                                            RESTART
+Codex / Claude Code
+       │
+       │ lifecycle + tool hooks
+       ▼
+  spotter-hook process
+       │
+       ├─ journal
+       ├─ deterministic gate
+       ├─ snapshot
+       └─ periodic shadow review trigger
 ```
 
-## Components
+This was intentionally simple, but it makes every hook invocation pay process/bootstrap and durable-state reconstruction costs.
 
-### 1. Main Harness
+The target architecture moves state and orchestration into a long-lived runtime:
 
-The main Codex session performs the task normally.
+```text
+                     ┌─────────────┐
+                     │  Codex TUI  │
+                     └──────┬──────┘
+                            │
+                            ▼
+                 ┌──────────────────────┐
+                 │ External App Server  │
+                 │ observation/control  │
+                 └──────┬────────▲──────┘
+                        │        │
+             event stream       │ turn/steer
+                        │        │ turn/interrupt
+                        │        │ thread injection
+                        ▼        │
+                 ┌──────────────────┐
+                 │     spotterd     │
+                 │                  │
+                 │ SessionManager   │
+                 │ Live State       │
+                 │ Trace IR         │
+                 │ Audit State      │
+                 │ Signal Engine    │
+                 │ Gate Engine      │
+                 │ Reviewer         │
+                 │ Intervention     │
+                 │ Journal          │
+                 └────────┬─────────┘
+                          │
+                 bounded deterministic
+                      request/reply
+                          │
+                          ▼
+                   PreToolUse Hook
+                   if still required
+```
 
-Spotter should inject only a small pair-runtime contract at session start so Main understands supervision signals without waiting for approval on every action.
+Responsibility becomes:
 
-The contract should establish:
+```text
+Codex App Server = primary observation + live control plane
+spotterd         = long-lived supervision state and orchestration
+PreToolUse Hook  = narrow synchronous enforcement plane
+journal          = durable event log / recovery source
+CLI              = user control plane
+```
 
-- the user remains the source of task intent
-- Spotter messages are runtime supervision signals
-- `VERIFY` and `NUDGE` require reassessment, not blind compliance
-- blocked actions must not be trivially retried
-- interruptions require replanning
-- disagreements should be resolved with evidence where possible
+The architecture should remain adapter-oriented so another coding agent can expose different observation/control/enforcement surfaces without changing Spotter core policy.
 
-### 2. Event Collector
+## 3. Three runtime planes
 
-Spotter subscribes to the observable execution surface and normalizes relevant events.
+Separating the planes prevents every agent event from being forced through the same mechanism.
 
-Potential Codex sources include:
+### Observation plane
 
-- session / turn lifecycle
-- plan and agent-message events
-- reasoning-summary events when exposed by the runtime/model
-- tool proposals and results
-- command output
-- patches and diffs
-- test results
-- interruption and completion states
+Answers: **What is happening?**
 
-Spotter should not depend on private chain-of-thought access. The design must remain useful with observable actions, summaries, repository state, and tool results alone.
+Target Codex source: App Server event stream.
 
-### 3. Trace IR
+Relevant information includes:
 
-Raw runtime events are noisy and backend-specific. Spotter should compile them into a compact intermediate representation.
+- thread and turn lifecycle
+- user messages
+- plan updates
+- reasoning summaries exposed by the runtime/model
+- command/tool start and completion
+- stdout/stderr/exit status where available
+- file changes and diffs
+- MCP calls
+- web search
+- token usage
 
-Example:
+### Control plane
+
+Answers: **How can Spotter influence an already-running trajectory?**
+
+Target Codex primitives include:
+
+- `turn/steer` for soft course correction
+- `turn/interrupt` for strong intervention
+- thread/context injection primitives where appropriate
+
+Control is asynchronous relative to most observation. Main does not pause while an LLM reviewer thinks.
+
+### Enforcement plane
+
+Answers: **What must be decided atomically before execution?**
+
+Target Codex primitive: `PreToolUse` while it remains the reliable synchronous veto boundary.
+
+Only narrow deterministic policy belongs here.
+
+## 4. Why App Server becomes primary for Codex
+
+Hook collection proved useful, but it is a limited observation surface and a poor place for long-lived semantic supervision.
+
+The target architecture prefers App Server because it can provide richer trajectory events and a live control channel in the same integration.
+
+The project must first validate one critical lifecycle property: Spotter must attach to the **same App Server used by the user's Codex TUI**. A separate App Server process that hosts a different thread cannot steer the active user session.
+
+A plain Codex TUI may choose an embedded App Server when no reusable external daemon is available. Therefore the architecture cannot rely on waking Spotter for the first time at `PreToolUse`; by then the App Server target may already be fixed.
+
+The canonical App Server strategy is deliberately gated on an E2E PoC. See [Lifecycle](lifecycle.md) and #66.
+
+## 5. `spotterd`
+
+`spotterd` is the target owner of live supervision state.
+
+Conceptual responsibilities:
+
+```text
+Session / Thread Manager
+Trace normalization
+Independent audit state
+Cheap signal detection
+Deterministic gate policy
+Reviewer scheduling and budgets
+Intervention freshness and delivery
+Journal persistence
+Recovery / reconciliation
+```
+
+The key state rule is:
+
+```text
+memory  = live state
+journal = durable history + recovery
+```
+
+Journal replay is appropriate at daemon restart, thread resume, offline analysis, and experiment boundaries. It should not be the normal way to reconstruct state for every event.
+
+## 6. Agent thread, turn, and attachment model
+
+The word “session” is currently overloaded. The target runtime should distinguish:
+
+```text
+Agent Thread
+  └─ Turn
+       └─ Events
+
+Runtime Attachment
+  = one TUI/runtime connection period to the thread
+```
+
+A thread can outlive one TUI process:
+
+```text
+Thread A
+├─ attachment #1
+│  ├─ turn 1
+│  └─ turn 2
+└─ attachment #2 after resume
+   ├─ turn 3
+   └─ turn 4
+```
+
+Audit state generally belongs to the thread. Runtime health/latency may belong to an attachment. Intervention freshness belongs to a specific turn.
+
+The durable/runtime model should preserve enough identity to correlate:
+
+- agent thread id
+- Spotter thread/session id if separate
+- runtime attachment id
+- turn id
+- tool/item id
+- repository/worktree
+
+## 7. Event collector and Trace IR
+
+Backend-specific runtime events should be normalized before they reach policy.
+
+Conceptually:
+
+```text
+App Server event / Hook event / future adapter event
+                   │
+                   ▼
+                Trace IR
+                   │
+       ┌───────────┴───────────┐
+       ▼                       ▼
+   live state               journal
+       │
+       ├─ signals
+       ├─ reviewer
+       └─ metrics
+```
+
+Example IR:
 
 ```text
 STEP 42
+thread: T7
+turn: U12
 kind: TOOL_PROPOSAL
 tool: apply_patch
-intent: fix authentication timeout
 files: [src/redis.ts]
-depends_on: H3
 constraints: [C1, C2]
 risk: medium
-
-H3
-claim: Redis pool exhaustion is the timeout source
-support:
-  - high concurrency correlates with timeout
-  - pool max is 10
-missing:
-  - stack trace has not confirmed Redis as source
-status: UNVERIFIED
 ```
 
-The IR allows rules, replay, benchmark generation, and reviewer-model changes without coupling them to a particular raw Codex event format.
+The IR should retain provenance. A normalized event must still be traceable to the underlying runtime event/tool id so live intervention and replay do not rely on journal adjacency.
 
-### 4. Audit State
+## 8. Independent audit state
 
-Spotter keeps an independent state rather than treating Main's summaries as ground truth.
+Spotter should not treat Main's own explanation as ground truth.
 
-Minimum useful state:
+Minimum useful live state:
 
 ```text
 Goal
@@ -126,47 +253,75 @@ Evidence
 Open questions
 Touched scope
 Validation state
-Recent tool failures
+Recent failures
 Intervention history
-External side effects
+Active turn
+Pending reviewer jobs
+Reviewer budget
+External side effects (later)
 ```
 
-Claims should be connected to evidence. When supporting evidence is retracted or contradicted, dependent hypotheses and actions become stale and require revalidation.
+Claims should be linked to evidence. When supporting evidence is retracted or contradicted, dependent hypotheses and plans become stale and require revalidation.
 
-### 5. Deterministic Verifiers
+The current prototype already implements a typed claim/evidence ledger and mechanical stale propagation for observable outcomes. In the target runtime this ledger should become live state instead of being rebuilt before every review.
+
+## 9. Deterministic Gate Engine
 
 Some supervision decisions should bypass the reviewer LLM entirely.
 
 Examples:
 
 - path allow/deny rules
-- dependency changes
+- dependency-manifest changes
 - destructive shell commands
-- external-write operations
-- test-result requirements
-- file-count or diff-size thresholds
-- explicitly forbidden tools
+- workspace escape
+- explicit user execution restrictions
+- eventually external-write classes with clear rules
 
-These checks are especially suitable for synchronous pre-action gating.
+Target synchronous path:
 
-### 6. Fast Signals
+```text
+PreToolUse
+    │
+    ▼
+spotter-hook
+    │ Unix socket / bounded IPC
+    ▼
+spotterd Gate Engine
+    ├─ ALLOW
+    └─ DENY
+```
 
-Cheap heuristics generate **candidate failure hypotheses**, not final judgments.
+Do not perform these operations synchronously:
 
-Examples:
+- semantic LLM review
+- long journal replay
+- whole-state reconstruction
+- metrics aggregation
+- broad repository analysis
+
+The gate must have a measured latency budget and fail-open semantics when Spotter itself is unavailable, unless a future explicitly configured fail-closed mode is designed separately.
+
+## 10. Fast Signal Engine
+
+Cheap heuristics create **candidate failure hypotheses**, not semantic verdicts.
+
+Candidate signals include:
 
 - same tool repeatedly invoked with equivalent arguments
-- repeated failure exit codes
+- failure streaks
 - repeated reads with no expansion in the dependency frontier
-- sudden growth in touched files
+- sudden growth in touched scope
 - edits accumulating without validation
-- a previously invalidated hypothesis still appearing in proposed actions
-- budget anomalies in tool calls, tokens, or elapsed steps
+- stale hypothesis reuse
+- unusual tool/token/time budgets
+- attempted circumvention after a deterministic block
 
-A signal should say:
+Output should look like:
 
 ```text
 candidate: POSSIBLE_EXPLORATION_LOOP
+support: repeated equivalent search 4x
 ```
 
 not:
@@ -175,274 +330,283 @@ not:
 verdict: EXPLORATION_LOOP
 ```
 
-The semantic reviewer decides ambiguous cases.
+The reviewer remains responsible for ambiguous semantic judgment.
 
-### 7. Pair Reviewer
+The signal layer is also how Spotter should move away from fixed periodic reviewer calls once the signal quality is measured.
 
-The Pair Reviewer is an independently configured model.
+## 11. Reviewer Scheduler
 
-Its job is not to solve the task again. Its job is to test failure hypotheses and propose the smallest useful intervention.
+The Pair Reviewer is independently configured from Main where practical.
 
-A useful reviewer input contains:
+Its job is not to solve the task again. It tests candidate failure hypotheses and proposes the weakest useful intervention.
+
+Useful reviewer input:
 
 - user goal and explicit constraints
 - relevant Trace IR window
-- relevant audit-state subgraph
+- relevant independent audit state
 - candidate failure hypothesis
 - available verification actions
-- prior interventions around the same issue
+- prior interventions for the same issue
+- which inputs are missing or truncated
 
-A useful structured output:
+Example output:
 
 ```json
 {
   "decision": "VERIFY",
   "target": "hypothesis:H3",
-  "reason": "The pending edit depends on an unverified timeout-source assumption.",
+  "reason": "The proposed change depends on an unverified timeout-source assumption.",
   "probe": "Inspect the timeout stack trace before editing Redis configuration.",
   "confidence": 0.91
 }
 ```
 
-### 8. Intervention Controller
+### Reviewer job lifecycle
 
-The controller translates review decisions into runtime actions.
-
-#### CONTINUE
-
-No action.
-
-#### VERIFY
-
-Inject a concise evidence request into Main's active work.
-
-#### NUDGE
-
-Inject a concise course correction.
-
-#### BLOCK
-
-Reject a pending action synchronously.
-
-#### INTERRUPT
-
-Stop the current turn and request replanning from the last sound state.
-
-#### RESTART
-
-Launch a fresh rollout with only the user goal, verified state, current repository state, and deliberately retained changes.
-
-## Why two paths: asynchronous observer + synchronous gate
-
-Using a reviewer model synchronously before every action would create unacceptable latency.
-
-Spotter therefore separates supervision into two paths.
+Reviewer work is asynchronous:
 
 ```text
-                    Main
-                     │
-        ┌────────────┴────────────┐
-        ▼                         ▼
- Async trajectory review     Pre-action gate
- semantic / broad             narrow / fast
-        │                         │
- VERIFY / NUDGE            ALLOW / BLOCK
+QUEUED
+  ↓
+RUNNING
+  ↓
+DECIDED
+  ├─ DELIVERED
+  ├─ STALE
+  ├─ CANCELLED
+  └─ FAILED
 ```
 
-Most reading, searching, and reversible exploration can proceed while Spotter observes asynchronously.
+Each job is anchored to the thread/turn that motivated it.
 
-Actions with meaningful external or hard-to-reverse effects deserve stronger synchronous scrutiny.
+## 12. Intervention Controller
 
-## Action reversibility classes
+Spotter prefers the weakest sufficient action.
 
-A practical policy can classify actions by reversibility.
+```text
+CONTINUE    → no-op
+VERIFY      → async steer / evidence request
+NUDGE       → async steer
+BLOCK       → synchronous deterministic deny
+INTERRUPT   → turn interrupt
+RESTART     → fresh continuation from verified state
+```
 
-### Class A — freely reversible / observational
+### Freshness
 
-Examples:
+A reviewer verdict can become obsolete while Main continues.
 
-- read
-- grep / search
-- ls
-- git diff
+```text
+signal at turn U12
+      ↓
+reviewer thinks
+      ↓
+verdict ready
+      ↓
+is U12 still the active target?
+   ├─ yes → deliver
+   └─ no  → stale policy
+```
+
+A stale verdict must not be blindly injected into a later turn.
+
+Record:
+
+- detection time/step
+- reviewer start/end
+- target turn
+- attempted delivery
+- delivered/stale/discarded outcome
+- intervention latency
+
+This turns responsiveness into a measurable quantity.
+
+## 13. Pair-aware Main contract
+
+Runtime supervision changes Main's environment. A small contract should clarify:
+
+- the user remains the source of task intent
+- Spotter messages are supervision, not new requirements
+- `VERIFY` and `NUDGE` request reassessment, not blind compliance
+- blocked actions should not be retried through superficial reformulation
+- interruptions require replanning
+- disagreement should be resolved with evidence where possible
+- Main should not wait for Spotter during ordinary execution
+
+The target delivery mechanism should not depend on keeping a hook process alive after it returns.
+
+## 14. Action reversibility and side effects
+
+A practical policy distinguishes actions by reversibility.
+
+### Class A — observational / freely reversible
+
+Examples: read, grep/search, ls, diff.
 
 Default: asynchronous observation.
 
 ### Class B — locally reversible
 
-Examples:
+Examples: patching files, local builds, local dependency operations.
 
-- apply patch
-- modify files
-- local dependency installation
-
-Default: checkpoint + asynchronous review; synchronous checks for known constraints.
+Default: checkpoint where useful + asynchronous review; deterministic gates for explicit constraints.
 
 ### Class C — external or semantically irreversible
 
-Examples:
+Examples: push, deploy, database writes, issue/PR creation, arbitrary MCP writes.
 
-- push
-- deploy
-- create external resources
-- database writes
-- issue / PR creation
-- arbitrary MCP writes
+Target: stronger synchronous policy and side-effect recording.
 
-Default: synchronous gate plus side-effect recording.
+Reasoning rollback does not undo external state. Before `RESTART` can claim meaningful recovery, Spotter needs an effect ledger that can say what remains changed outside the local worktree.
 
-## Side-effect ledger
+## 15. Snapshots, replay, and counterfactuals
 
-Reasoning rollback does not undo external state.
+The current prototype already provides Git-backed snapshots, detached-worktree restore, Codex continuation fork machinery, and a same-prefix experiment harness.
 
-Spotter should record external effects before supporting restart/rollback semantics:
+These remain important in the target architecture because they support two different goals:
+
+1. recovery primitives
+2. causal evaluation of intervention advantage
+
+Resource lifecycle must be explicit:
 
 ```text
-EFFECT 18
-kind: github.create_issue
-resource: repo/foo
-result: issue #392
-reversible: false
-
-EFFECT 19
-kind: filesystem.patch
-checkpoint: C14
-reversible: true
+snapshot / fork worktree
+CREATED → IN_USE → RETAINED or CLEANED
 ```
 
-The initial MVP can simply classify and record effects. Full compensating rollback can come later.
+Never manipulate user worktrees or refs outside Spotter-owned namespaces. Cleanup should be Git-aware.
 
-## Durability, retention, and ambiguity policy
+## 16. Durability and recovery
 
-Supervision data is only useful if it survives crashes, stays bounded on disk,
-and is honest about what it could not judge. The three contracts below are what
-the implementation actually guarantees today.
+### Current journal contract
+
+The prototype step journal is append-only JSONL and includes cross-process locking, fsync, torn-tail recovery, and strict reads for destructive operations.
+
+That durability work remains useful, but the target runtime should reduce the number of independent writers because `spotterd` becomes the primary live writer.
+
+### Target recovery path
+
+On daemon restart:
+
+```text
+spotterd starts
+    ↓
+reconnect App Server
+    ↓
+list/reconcile active threads
+    ↓
+hydrate durable Spotter state as needed
+    ↓
+resume live supervision
+```
+
+Recovery is a boundary condition, not the normal event-processing loop.
+
+### Degraded state
+
+Observation/control health must be visible independently from daemon health:
+
+```text
+Spotter daemon:       running
+Codex App Server:     unavailable
+Observation:          unavailable
+Live intervention:    unavailable
+PreToolUse gate:      available
+```
+
+Silence cannot mean both “nothing is wrong” and “Spotter is disconnected”.
+
+## 17. Current prototype implementation notes
+
+The architectural migration should preserve the useful guarantees already built.
 
 ### Journal durability
 
-The step journal is append-only JSONL, one file per session, written by however
-many hook processes the runtime spawns.
+- cross-process append serialization
+- monotonic step/proposal allocation
+- flush/fsync before releasing the write lock
+- torn-tail recovery for normal readers
+- strict reads for destructive cleanup decisions
 
-- **Serialization.** Every append takes an exclusive `flock` on a sidecar lock
-  file. Step numbers and proposal numbers are allocated inside that lock, so
-  concurrent hook processes cannot produce duplicate or reordered steps.
-- **Durability.** Each record is `flush`ed and `fsync`ed before the lock is
-  released. A record is therefore complete on disk or absent — never half
-  applied to the numbering.
-- **Crash recovery.** A process killed mid-write can leave a partial trailing
-  line. Readers keep the valid prefix; the next append truncates the torn tail
-  before writing. Destructive readers (`prune`) instead load strictly and abort,
-  because a torn tail may hold the newest snapshot reference and treating its
-  absence as fact would delete live data.
-- **Cost.** Step allocation reads a size-keyed sidecar cache rather than
-  re-parsing the journal: measured 9.2 ms cold and 0.30 ms warm at 3,000
-  records. A sidecar that does not match the file size is discarded and the
-  full repairing load runs instead.
+### Snapshot safety
 
-### Snapshot lifecycle and retention
+- snapshots use Git objects/refs without touching user HEAD/index
+- restore happens in detached worktrees
+- refs are pinned under Spotter-owned namespaces
+- unchanged states can be deduplicated
+- prune is conservative and dry-run by default
 
-- **When.** Snapshots are taken at mutation boundaries — before and after
-  `apply_patch` — not on every event.
-- **No-op suppression.** If the worktree tree is identical to the session's
-  previous snapshot, that snapshot is reused and no new ref is created.
-- **Pinning.** Each snapshot is a commit pinned under `refs/spotter/steps/`, so
-  `gc` cannot remove a state a later fork depends on. The user's index, HEAD,
-  and worktree are never touched; restores go to a detached worktree.
-- **Reuse re-pins.** A deduped snapshot is re-pinned on every reuse. A pruned
-  commit stays resolvable until `gc` runs, so reusing one without restoring its
-  ref would hand the journal a sha that `gc` later destroys.
-- **Retention.** `spotter prune` deletes snapshots no journal references, in a
-  single `update-ref --stdin` transaction, dry-run by default. Referenced
-  snapshots are kept indefinitely, because deleting one destroys the ability to
-  fork that step. `--max-age-days N` opts into expiring referenced snapshots
-  too. Age is measured from a snapshot's **creation**, and dedup reuses an
-  unchanged snapshot without refreshing it, so expiry drops old *states* rather
-  than old *steps*: a step recorded today that references a month-old unchanged
-  state loses its fork with it. Because that cost is easy to miss, `prune`
-  prints the exact `session`/`step` pairs each expired snapshot takes down, and
-  the flag is never the default.
+### Audit ledger
 
-### Audit ledger (claim/evidence)
+- Main reasoning summaries are not accepted as evidence
+- only observable outcomes can become evidence
+- contradicting outcomes retract previous evidence
+- stale propagation is transitive
 
-The reviewer does not treat the agent's own account as fact. A ledger is
-rebuilt from the journal before every review:
+The hook-collected prototype measured observable outcomes on only 33 of 340 real tool results (10%). This figure is specific to the current observation surface. The App Server migration must re-measure it instead of treating 10% as a permanent architectural limit.
 
-- **Evidence** comes only from observable outcomes of tool calls. A reasoning
-  summary can never become evidence — `EvidenceSource` has no member for it,
-  so mypy rejects the call site.
-- **Hypotheses** come from the reviewer's own flagged assumptions and enter as
-  `unverified`.
-- **Retraction is mechanical**: when the same command later produces a
-  different outcome, the earlier outcome is retracted and every hypothesis
-  resting solely on it goes stale, transitively. Stale premises are listed in
-  the next review prompt so a killed assumption cannot quietly stay in view.
+### Gate ambiguity
 
-**Measured limit.** Only 33 of 340 real Codex tool results (10%) carry an
-observable outcome at all — Codex reports an exit code for `apply_patch` and
-nothing for shell commands. The ledger records outcomes where they exist and
-stays silent where they do not; inferring pass/fail from output text would
-retract evidence every time `git status` changed. This is an
-observability-ceiling fact (P1), not a parser gap, and it bounds how much
-stale-premise detection can do on Codex today.
+Where deterministic parsing cannot support a safe judgment, the current gate fails open and records the blind spot separately from false-positive metrics.
 
-### Gate ambiguity policy
+That distinction should survive the migration.
 
-Deterministic gates judge a parsed token stream. Where the parse cannot support
-a decision, the gate **fails open** and says so, rather than guessing:
+## 18. Integration lifecycle and service ownership
 
-| Class | Behaviour | Telemetry |
-| --- | --- | --- |
-| Command that cannot be tokenized | allow, rule `unparseable_command` | `gate_fail_open` |
-| Absolute path with no known workspace root | allow, rule `unknown_workspace` | `gate_fail_open` |
-| Everything else | allow or block per rule | `gate_shadow_block` / `gate_block` |
+Runtime architecture does not end at the event loop. Spotter must also own setup, service lifecycle, upgrades, teardown, and repair coherently.
 
-Every fail-open decision is journaled as a `gate_fail_open` record carrying the
-rule that abstained, so blindness is countable rather than invisible. Those
-records surface in `spotter analyze` and are counted by `spotter metrics` as
-**blind spots, reported separately from the false-positive rate**. They are
-deliberately not labelable: a fail-open is an abstention, not a judgment, so
-scoring it `tp`/`fp` would mix "the gate was wrong" with "the gate could not
-tell" in one number.
+Target user flow:
 
-## Codex integration points
+```bash
+brew install spotter
+spotter setup codex
+spotter doctor
 
-Current official Codex documentation exposes the primitives that make Spotter plausible:
+# normal use
+codex
+```
 
-### Hooks
+The user should not need to manually start `spotterd` or an App Server before each Codex launch.
 
-Codex supports lifecycle hooks such as `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, and stop-related hooks.
+Because an external App Server may need to exist before Codex chooses its target, a fully lazy “start on first tool hook” daemon can conflict with the full target experience. The App Server lifecycle PoC decides whether managed mode needs a login-scoped service.
 
-`PreToolUse` is particularly important because it can run before supported tool execution and can influence whether/how the call proceeds.
+Detailed lifecycle and ownership rules live in [lifecycle.md](lifecycle.md).
 
-Official documentation:
+## 19. Adapter boundary
 
-- https://developers.openai.com/codex/hooks
+Codex is the first target, not the permanent core API.
 
-### App Server
+An agent adapter should expose normalized capabilities such as:
 
-Codex App Server exposes a programmatic thread/turn interface and streamed runtime events suitable for building richer clients and orchestration around active Codex work.
+```text
+observe thread/turn events
+observe tool/result/diff
+synchronous pre-action veto (optional)
+soft steer active turn (optional)
+interrupt active turn (optional)
+thread resume/fork primitives (optional)
+```
 
-Spotter is particularly interested in:
+Spotter core should degrade explicitly when a capability is missing rather than assuming every agent has Codex's exact surfaces.
 
-- streamed turn/item events
-- `turn/steer` for in-flight course correction
-- `turn/interrupt` for terminating an active turn
+## 20. First migration boundary
 
-Official documentation:
+The architecture migration should intentionally avoid turning into a rewrite of everything at once.
 
-- https://developers.openai.com/codex/app-server
+First prove:
 
-## First implementation boundary
+1. a stable external App Server path can host the same Codex TUI thread that Spotter observes
+2. Spotter can receive the event stream as a second client
+3. Spotter can track the active turn
+4. `turn/steer` reaches the real user session
+5. the `PreToolUse` gate can remain a small bounded synchronous path
 
-The first implementation should intentionally avoid several advanced ideas:
+Only then move the existing reviewer/state/metrics machinery into the daemon.
 
-- no model training
-- no full graph database
-- no automatic harness self-repair
-- no general rollback engine
-- no multi-agent debate
-- no requirement for hidden reasoning traces
+The MVP hypothesis remains:
 
-The MVP should prove one thing first:
+> **Can an independent runtime spotter detect a useful subset of trajectory failures early enough that intervention improves task outcomes without becoming an expensive source of false positives or latency?**
 
-> **Can an independent runtime spotter detect a useful subset of trajectory failures early enough that intervention improves task outcomes without becoming an expensive source of false positives?**
+Architecture makes that experiment possible; it does not answer it by itself.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,13 +1,13 @@
 # Architecture
 
-> **상태:** 현재 Hook 기반 prototype + [#66](https://github.com/Bogyie/spotter/issues/66)의 target architecture를 함께 설명한다.  
-> **중요:** `spotterd`, App Server primary observation, live `turn/steer`는 아직 target이며 현재 shipping behavior가 아니다.
+> **Status:** this document describes both the current hook-based prototype and the target architecture tracked in [#66](https://github.com/Bogyie/spotter/issues/66).  
+> `spotterd`, App Server primary observation, and live `turn/steer` delivery are **target behavior**, not current shipping behavior.
 
 ---
 
-## 30초 요약
+## 30-second summary
 
-Spotter의 target architecture는 다음 한 장으로 요약된다.
+The target architecture fits on one page:
 
 ```text
                      ┌─────────────┐
@@ -44,40 +44,40 @@ Spotter의 target architecture는 다음 한 장으로 요약된다.
                    PreToolUse Hook
 ```
 
-핵심 결정은 여섯 가지다.
+Six decisions define the design:
 
-1. **App Server가 Codex trajectory의 primary observation source다.**
-2. **semantic reviewer는 비동기다.** Main은 reviewer를 기다리지 않는다.
-3. **`PreToolUse`는 deterministic BLOCK에만 남긴다.**
-4. **live state는 `spotterd` 메모리가 소유한다.** journal은 durable log/recovery source다.
-5. **reviewer verdict는 특정 thread/turn에 묶인다.** 늦게 도착한 verdict는 freshness를 검증한다.
-6. **가장 먼저 App Server lifecycle/attach PoC를 통과해야 한다.** 같은 App Server를 공유하지 못하면 이 architecture를 다시 검토한다.
+1. **Codex App Server becomes the primary observation source.**
+2. **Semantic review is asynchronous.** Main does not wait for an LLM reviewer before ordinary actions.
+3. **`PreToolUse` remains only for deterministic, atomic enforcement.**
+4. **`spotterd` memory owns live supervision state.** The journal is durable history and recovery material.
+5. **Reviewer decisions are anchored to a specific thread/turn.** Late decisions must pass a freshness check.
+6. **The App Server lifecycle/attach PoC is a hard prerequisite.** If Spotter cannot share the user's real App Server, this architecture must be revisited.
 
 ---
 
-## 빠른 탐색
+## Quick navigation
 
-| 찾는 내용 | 섹션 |
+| Looking for... | Section |
 | --- | --- |
-| 현재와 목표 구조 차이 | [1. Current vs Target](#1-current-vs-target) |
-| process별 역할 | [3. Component contracts](#3-component-contracts) |
-| 실제 event가 어떻게 흐르는가 | [4. Runtime flows](#4-runtime-flows) |
-| Hook은 왜/어디에 남는가 | [5. Enforcement path](#5-enforcement-path-pretooluse) |
-| reviewer가 늦으면 어떻게 하나 | [7. Reviewer job / freshness](#7-reviewer-job과-freshness) |
-| state를 어디에 저장하나 | [8. State ownership](#8-state-ownership) |
-| thread/session 용어 | [9. Identity model](#9-identity-model) |
-| App Server가 끊기면 | [11. Failure / degraded mode](#11-failure--degraded-mode) |
-| 어떤 파일/socket이 생기나 | [12. Runtime resources](#12-runtime-resources) |
-| adapter가 제공해야 할 capability | [14. Agent adapter contract](#14-agent-adapter-contract) |
-| 먼저 검증할 architecture 전제 | [15. P0 PoC](#15-p0-app-server-lifecycle--attach-poc) |
+| Current vs target structure | [1. Current vs target](#1-current-vs-target) |
+| Component responsibilities | [3. Component contracts](#3-component-contracts) |
+| Exact runtime flows | [4. Runtime flows](#4-runtime-flows) |
+| Why any Hook remains | [5. Enforcement path](#5-enforcement-path-pretooluse) |
+| Reviewer timing/freshness | [7. Reviewer jobs and freshness](#7-reviewer-jobs-and-freshness) |
+| State and persistence boundaries | [8. State ownership](#8-state-ownership) |
+| Thread / turn / attachment terminology | [9. Identity model](#9-identity-model) |
+| Disconnect / crash behavior | [11. Failure and degraded mode](#11-failure-and-degraded-mode) |
+| Runtime files/sockets/resources | [12. Runtime resources](#12-runtime-resources) |
+| Agent adapter interface | [14. Agent adapter contract](#14-agent-adapter-contract) |
+| First architecture PoC | [15. P0 App Server lifecycle / attach PoC](#15-p0-app-server-lifecycle--attach-poc) |
 
 ---
 
-# 1. Current vs Target
+# 1. Current vs target
 
-## 1.1 현재 prototype
+## 1.1 Current prototype
 
-현재는 Hook이 observation과 execution boundary를 동시에 담당한다.
+Today, hooks carry both observation and execution-boundary responsibilities:
 
 ```text
 Codex / Claude Code
@@ -94,93 +94,92 @@ Codex / Claude Code
        └─ reviewer cadence trigger
 ```
 
-장점:
+This shape was useful because it is simple and fail-open by construction. It was enough to collect real trajectories and validate gates, snapshots, fork/replay, shadow review, labels, metrics, and counterfactual experiments.
 
-- 빠르게 구현할 수 있었다.
-- fail-open boundary가 단순하다.
-- 실제 Codex trajectory 데이터를 모을 수 있었다.
-- gate, snapshot, fork/replay, reviewer 실험을 검증하는 데 충분했다.
+Its limitations are now structural:
 
-한계:
-
-- Hook마다 별도 process/bootstrap 비용이 든다.
-- 여러 Hook process가 durable journal을 중심으로 상태를 공유한다.
-- semantic reviewer의 long-lived state가 없다.
-- reviewer가 판단을 끝낸 뒤 active turn에 독립적으로 개입할 control channel이 없다.
-- periodic reviewer가 long session에서 계속 비용을 쓴다.
-- App Server가 노출하는 더 풍부한 runtime event를 활용하지 못한다.
+- every hook invocation pays process/bootstrap cost;
+- durable journal files carry too much responsibility for shared state;
+- there is no long-lived semantic supervision state;
+- a reviewer cannot finish later and independently inject into an active turn through the hook that already returned;
+- periodic review spends tokens even when nothing looks wrong;
+- richer App Server events are not the primary observation surface.
 
 ## 1.2 Target runtime
+
+The target hot path is daemon-owned:
 
 ```text
 App Server event
       │
       ▼
 spotterd
-  ├─ normalize
+  ├─ normalize event
   ├─ update live state
   ├─ append journal
   ├─ evaluate cheap signals
-  └─ schedule semantic reviewer
+  └─ schedule semantic reviewer when needed
 
-Main agent는 계속 실행
+Main continues
 
-PreToolUse만 별도 synchronous path
+PreToolUse remains a separate synchronous path
 ```
 
-핵심 변화:
+The state model flips from:
 
 ```text
-before
-hook → journal → 필요할 때 state rebuild
+hook → journal → rebuild state when needed
+```
 
-after
+to:
+
+```text
 event → live state → policy
-                 └→ journal append
+                 └→ durable journal append
 ```
 
 ---
 
 # 2. Runtime planes
 
-세 가지 plane을 분리한다. 이 구분이 architecture의 중심이다.
+Three planes are intentionally separate.
 
-| Plane | 질문 | Codex target surface | Latency 성격 |
+| Plane | Question | Codex target surface | Latency model |
 | --- | --- | --- | --- |
-| Observation | 지금 무엇이 일어나고 있는가? | App Server event stream | async |
-| Control | 이미 진행 중인 trajectory에 어떻게 개입하는가? | `turn/steer`, `turn/interrupt` | async request |
-| Enforcement | 실행 전에 반드시 막아야 하는가? | `PreToolUse` | sync / bounded |
+| Observation | What is happening? | App Server event stream | asynchronous |
+| Control | How can Spotter influence an active trajectory? | `turn/steer`, `turn/interrupt` | asynchronous request |
+| Enforcement | What must be decided before an action executes? | `PreToolUse` | synchronous and bounded |
 
 ### Observation plane
 
-수집 후보:
+Expected inputs include:
 
-- thread start/resume/close
-- turn start/completion
-- user message
-- plan update
-- reasoning summary가 runtime에 노출되는 경우
-- command/tool start/completion
-- stdout/stderr/exit status
-- file change / diff
-- MCP call
-- web search
-- token usage
+- thread start/resume/archive lifecycle;
+- turn start/completion/interruption;
+- user messages;
+- plan updates;
+- reasoning summaries when exposed by the runtime/model;
+- command/tool start and completion;
+- stdout/stderr/exit status where available;
+- file changes and diffs;
+- MCP calls;
+- web searches;
+- token usage.
 
 ### Control plane
 
-사용 후보:
+Expected mappings:
 
 ```text
-VERIFY  → turn/steer(evidence request)
-NUDGE   → turn/steer(course correction)
-INTERRUPT → turn/interrupt
-RESTART → interrupt + fresh continuation (later)
+VERIFY     → turn/steer(evidence request)
+NUDGE      → turn/steer(course correction)
+INTERRUPT  → turn/interrupt
+RESTART    → interrupt + fresh continuation (later phase)
 ```
 
 ### Enforcement plane
 
-실행 전 deterministic policy만 둔다.
+Only deterministic policy belongs here:
 
 ```text
 PreToolUse
@@ -188,31 +187,31 @@ PreToolUse
 ALLOW / DENY
 ```
 
-LLM reviewer가 synchronous path에 들어가면 안 된다.
+No model call should be required to answer the synchronous request.
 
 ---
 
 # 3. Component contracts
 
-아래 표는 구현 시 component boundary의 기준이다.
+These boundaries are intended to be concrete enough to drive implementation.
 
-| Component | 책임 | 입력 | 출력 | 소유 상태 | 실패 시 기본 동작 |
+| Component | Responsibility | Inputs | Outputs | State owned | Failure posture |
 | --- | --- | --- | --- | --- | --- |
-| `spotter` CLI | setup/status/doctor/review 등 user control plane | argv/config | 사용자 출력, daemon RPC | 없음 또는 짧은 command state | 명시적 error |
-| `spotterd` | long-lived supervision runtime | App Server events, Hook IPC, CLI RPC | journal, reviewer jobs, interventions | thread/live state | coding session을 깨지 않도록 degraded |
-| `CodexAppServerClient` | App Server 연결·subscribe·control | endpoint/capabilities | normalized runtime events, RPC result | connection state | reconnect/degraded |
-| `SessionManager` | thread/turn/attachment lifecycle | normalized events | current identities/state transitions | thread registry | 해당 thread만 degraded |
-| `TraceNormalizer` | backend event → Trace IR | raw adapter event | TraceEvent | 없음 | unknown event 기록/skip |
-| `AuditState` | claim/evidence/constraints/progress | TraceEvent | live audit view | per thread | incomplete state 명시 |
-| `SignalEngine` | cheap candidate detection | live state/event | candidate signal | small rolling counters | no candidate |
-| `ReviewerScheduler` | async reviewer 실행·budget·dedupe | candidate + context | ReviewerJob | queues/budgets | job failed, Main 계속 |
-| `InterventionController` | verdict freshness/전달/escalation | reviewer decision | steer/interrupt/no-op | intervention history | stale/discard/degraded |
-| `GateEngine` | deterministic pre-action 판단 | PreToolUse proposal + config | allow/deny | rule config + small state | fail-open |
-| `JournalStore` | durable history | normalized records | append/read | disk | write failure telemetry; gate는 fail-open |
-| `SnapshotManager` | Git state checkpoint/restore | repo state | snapshot ref/worktree | repo resources | snapshot failure가 Main을 깨지 않음 |
-| `IntegrationManager` | setup/teardown/migration | agent config | manifest/config mutation | integration manifest | transactional rollback |
+| `spotter` CLI | user control plane: setup/status/doctor/review/etc. | argv, config, daemon RPC | command output / mutations | short-lived command state | explicit command error |
+| `spotterd` | long-lived supervision runtime | App Server events, Hook IPC, CLI RPC | journal records, reviewer jobs, interventions | thread/live state | degrade without breaking coding session |
+| `CodexAppServerClient` | connect, subscribe, control | endpoint + capability negotiation | normalized runtime events, RPC results | connection state | reconnect / degraded |
+| `SessionManager` | thread/turn/attachment lifecycle | normalized events | resolved identity/state transitions | thread registry | isolate failure to affected thread when possible |
+| `TraceNormalizer` | backend event → Trace IR | raw adapter event | `TraceEvent` | none | preserve unknown event / skip with telemetry |
+| `AuditState` | goal/constraint/claim/evidence/progress model | `TraceEvent` | current independent state | per thread | mark missing/unknown instead of inventing |
+| `SignalEngine` | cheap candidate detection | event + live state | candidate signal | bounded rolling counters/state | no candidate |
+| `ReviewerScheduler` | async model execution, budget, dedupe | candidate + context | `ReviewerJob` | queues, budgets | job fails; Main continues |
+| `InterventionController` | freshness, delivery, escalation | reviewer decision + live turn state | steer/interrupt/no-op | intervention history | stale/discard/degraded |
+| `GateEngine` | deterministic pre-action policy | `PreToolUse` proposal + config | allow/deny | rule config + bounded state | fail-open |
+| `JournalStore` | durable event history | normalized records | append/read | disk | write telemetry; never invent success |
+| `SnapshotManager` | Git checkpoints and detached restore | repo/worktree state | snapshot ref/worktree | Git resources | snapshot failure does not break Main |
+| `IntegrationManager` | setup/teardown/migration | agent config + runtime environment | integration mutations + manifest | integration manifest | transactional rollback |
 
-이 표에서 중요한 점은 **Spotter core policy가 Codex-specific transport shape를 직접 알지 않는 것**이다.
+The key architectural constraint is that **Spotter core policy must not depend directly on Codex transport/event shapes**.
 
 ---
 
@@ -220,7 +219,7 @@ LLM reviewer가 synchronous path에 들어가면 안 된다.
 
 ## 4.1 Codex startup
 
-Full managed mode의 이상적인 흐름:
+Ideal managed-mode flow:
 
 ```text
 user login / runtime ready
@@ -228,7 +227,7 @@ user login / runtime ready
         ├─ spotterd ready
         └─ external App Server available
 
-사용자: codex
+user runs: codex
         │
         ▼
 Codex TUI attaches to external App Server
@@ -237,13 +236,13 @@ Codex TUI attaches to external App Server
         └─ Spotter = client B
 ```
 
-**주의:** 현재 plain `codex`는 reusable external daemon이 없으면 Embedded App Server를 선택할 수 있다. 따라서 첫 `PreToolUse`에서 daemon을 띄우는 것은 full mode에는 늦을 수 있다.
+Important constraint: plain `codex` can choose an embedded App Server when a reusable external daemon is unavailable. Starting Spotter only at the first `PreToolUse` can therefore be too late for full observation/control.
 
-이 때문에 P0 PoC가 먼저다.
+That is why P0 comes before the daemon migration.
 
-## 4.2 일반 observation event
+## 4.2 Normal observation event
 
-예: command 완료 event.
+Example: a command completes.
 
 ```text
 App Server
@@ -253,23 +252,23 @@ CodexAdapter
   │ raw event → TraceEvent
   ▼
 SessionManager
-  │ thread/turn identity resolve
+  │ resolve thread/turn/item identity
   ▼
 Live State
-  ├─ recent failures update
-  ├─ validation state update
-  └─ touched scope update
+  ├─ update recent failures
+  ├─ update validation state
+  └─ update touched scope
   │
   ├──────────────► Journal append
   │
   ▼
 SignalEngine
   │
-  ├─ no candidate → 끝
+  ├─ no candidate → done
   └─ candidate → ReviewerScheduler
 ```
 
-Normal observation은 Hook을 거치지 않는다.
+Normal observation should not require a Hook process.
 
 ## 4.3 Semantic review
 
@@ -314,7 +313,7 @@ spotterd GateEngine
 Hook response
 ```
 
-이 path에서는 network/model call을 하지 않는다.
+No network/model call belongs on this path.
 
 ## 4.5 Turn completion
 
@@ -323,11 +322,11 @@ turn/completed(U7)
       │
       ├─ active_turn = none
       ├─ finalize timing/tool counters
-      ├─ validation state finalize
-      └─ pending ReviewerJob(target=U7) freshness 재평가
+      ├─ finalize validation state
+      └─ re-evaluate freshness of ReviewerJobs targeting U7
 ```
 
-Thread state는 사라지지 않는다.
+The thread remains durable.
 
 ## 4.6 Resume
 
@@ -338,47 +337,49 @@ Codex resumes existing thread T1
 App Server thread event
         │
         ▼
-SessionManager finds durable Spotter history
+SessionManager finds Spotter durable history
         │
         ├─ hydrate missing live state from journal
-        ├─ reconcile App Server current thread state
-        └─ create new RuntimeAttachment
+        ├─ reconcile current App Server thread state
+        └─ create a new RuntimeAttachment
 ```
 
-Journal replay는 이런 recovery/resume boundary에서 사용한다.
+Journal replay belongs at recovery/resume boundaries, not in the ordinary event loop.
 
 ---
 
 # 5. Enforcement path: `PreToolUse`
 
-Target Codex integration에서 Hook은 가능하면 `PreToolUse` 하나만 남긴다.
+The target Codex integration should keep only the hook surface that provides a unique atomic guarantee.
 
-| Hook | 현재 | Target |
+| Hook | Current use | Target |
 | --- | --- | --- |
-| `SessionStart` | session bootstrap | App Server lifecycle로 대체 |
-| `UserPromptSubmit` | user goal capture | App Server user-message event로 대체 |
-| `PreToolUse` | proposal + gate | **deterministic atomic gate 유지** |
-| `PostToolUse` | result/snapshot/review cadence | App Server result/diff로 대체 |
+| `SessionStart` | session bootstrap/observation | replace with App Server lifecycle if coverage is sufficient |
+| `UserPromptSubmit` | user goal capture | replace with App Server user-message events |
+| `PreToolUse` | proposal observation + gate | **retain for deterministic atomic enforcement** |
+| `PostToolUse` | result/snapshot/reviewer cadence | replace with App Server result/diff events |
 
-### Gate가 판단해도 되는 것
+### Appropriate synchronous policies
 
-- destructive command class
-- forbidden path
-- dependency manifest policy
-- workspace escape
-- 명시된 user/project execution restriction
-- 나중에 충분히 deterministic하게 분류 가능한 external write
+- destructive command classes;
+- forbidden paths;
+- dependency-manifest policy;
+- workspace escape;
+- explicit user/project execution restrictions;
+- later: external writes that can be classified deterministically enough.
 
-### Gate가 판단하면 안 되는 것
+### Inappropriate synchronous policies
 
-- “이 refactor는 불필요해 보인다”
-- “이 가정은 아마 틀린 것 같다”
-- “이 접근보다 다른 구현이 좋아 보인다”
-- 전체 repository를 다시 읽어야 하는 의미론적 판단
+- “this refactor looks unnecessary”;
+- “this hypothesis is probably wrong”;
+- “another implementation approach seems better”;
+- any judgment that requires broad semantic repository analysis.
 
-이런 건 async reviewer 영역이다.
+Those belong in the asynchronous reviewer path.
 
 ### Failure policy
+
+If any of the following occurs:
 
 ```text
 spotterd unavailable
@@ -387,15 +388,15 @@ unsupported syntax
 unknown workspace
 ```
 
-기본은 **fail-open + telemetry**다.
+the default posture remains **fail-open + telemetry**.
 
-Spotter 장애가 supervised agent 자체를 중단시키면 안 된다.
+Spotter failure must not become a coding-agent outage.
 
 ---
 
 # 6. Trace IR
 
-Raw runtime event를 policy에 직접 전달하지 않는다.
+Raw backend events should be normalized before policy consumes them.
 
 ```text
 Codex App Server event
@@ -409,13 +410,13 @@ future agent event
    Trace IR
        │
        ├─ live state
-       ├─ signal
+       ├─ signals
        ├─ reviewer
        ├─ metrics
        └─ journal
 ```
 
-최소 필드 예시:
+Minimum conceptual fields:
 
 ```text
 TraceEvent
@@ -433,7 +434,7 @@ TraceEvent
   provenance(raw event reference)
 ```
 
-Policy가 필요로 하는 semantic field는 점진적으로 추가한다.
+Policy-oriented fields can be layered on later:
 
 ```text
 constraint ids
@@ -442,17 +443,13 @@ validation relation
 side-effect class
 ```
 
-중요한 원칙:
-
-> Normalization 때문에 provenance를 잃지 않는다.
-
-`turn/steer`, replay, causal analysis가 raw runtime item과 normalized event를 다시 연결할 수 있어야 한다.
+Normalization must not discard provenance. Live control, replay, and causal analysis must be able to reconnect normalized records to the underlying runtime item/turn.
 
 ---
 
-# 7. Reviewer Job과 freshness
+# 7. Reviewer jobs and freshness
 
-Semantic reviewer는 process라기보다 **job lifecycle**로 다룬다.
+Semantic review is modeled as a job lifecycle:
 
 ```text
 QUEUED
@@ -467,7 +464,7 @@ DECIDED
   └─ FAILED
 ```
 
-ReviewerJob 최소 metadata:
+Minimum `ReviewerJob` metadata:
 
 ```text
 job_id
@@ -486,37 +483,37 @@ delivery status
 
 ### Freshness rule
 
-Reviewer가 5초 생각하는 동안 Main이 turn을 끝낼 수 있다.
+Main may finish a turn while the reviewer is thinking:
 
 ```text
 U7 signal
  ↓
 reviewer running
  ↓
-U7 completed
+U7 completes
  ↓
-reviewer says NUDGE
+reviewer returns NUDGE
 ```
 
-이때 U8에 무조건 NUDGE를 넣으면 안 된다.
+That NUDGE must not automatically be injected into U8.
 
-초기 policy 후보:
+A conservative initial policy:
 
 ```text
-same active target turn
-  → deliver via steer
+same target turn still active
+  → deliver
 
 target turn ended
-  → default STALE/DISCARD
-  → 일부 VERIFY만 명시적인 next-turn defer를 허용할 수 있음
+  → STALE / DISCARD by default
+  → only explicitly defined classes may be deferred
 ```
 
-어떤 policy든 journal에 남겨 다음을 측정한다.
+Always record enough timing data to measure:
 
-- reviewer latency
-- delivery latency
-- stale rate
-- reviewer spend wasted by stale verdict
+- reviewer latency;
+- delivery latency;
+- stale rate;
+- reviewer spend wasted on stale verdicts.
 
 ---
 
@@ -524,7 +521,7 @@ target turn ended
 
 ## 8.1 Live state
 
-`spotterd`가 per-thread로 유지할 최소 state:
+`spotterd` should hold at least the following per thread:
 
 ```text
 ThreadState
@@ -548,82 +545,80 @@ ThreadState
 
 ## 8.2 Durable journal
 
-Journal은 다음을 위해 존재한다.
+The journal exists for:
 
-- crash recovery
-- resume hydration
-- analyze
-- labels/metrics
-- replay/fork
-- experiment provenance
-- forensic inspection
+- crash recovery;
+- resume hydration;
+- offline analyze;
+- labels/metrics;
+- replay/fork;
+- experiment provenance;
+- forensic inspection.
 
-Journal은 **live state database가 아니다.**
+It is **not** the live-state database.
 
 ## 8.3 Snapshot state
 
-Git snapshot은 repository state를 복원하는 별도 resource다.
+A Git snapshot is a separate resource representing repository state at a branch/recovery point.
 
 ```text
 ThreadState ≠ Journal ≠ Snapshot
 ```
 
-- ThreadState: 현재 판단을 위한 memory state
-- Journal: 실행 history
-- Snapshot: 특정 시점의 filesystem/Git state
-
-이 셋을 섞지 않는다.
+- `ThreadState`: current supervision state;
+- `Journal`: event/history record;
+- `Snapshot`: filesystem/Git state.
 
 ---
 
 # 9. Identity model
 
-현재 `session`이라는 단어가 여러 의미를 담는다. Target에서는 분리한다.
+The word “session” is overloaded. The target runtime should distinguish:
 
 ```text
 Agent Thread
-  장기 대화/작업 identity
+  long-lived coding task/conversation identity
 
 Turn
-  한 번의 user→agent 실행 단위
+  one user→agent execution unit
 
 Runtime Attachment
-  TUI/client가 thread에 붙어 있는 한 번의 실행 구간
+  one TUI/client attachment period to a thread
 
 Reviewer Job
-  특정 candidate/turn을 평가하는 독립 작업
+  one asynchronous evaluation of a candidate/turn
 ```
 
-예:
+Example:
 
 ```text
 Thread T1
-├─ Attachment A1 (오늘 오전)
+├─ Attachment A1 (today)
 │  ├─ Turn U1
 │  └─ Turn U2
-└─ Attachment A2 (내일 resume)
+└─ Attachment A2 (resumed tomorrow)
    ├─ Turn U3
    └─ Turn U4
 ```
 
-State placement:
+State scope:
 
-| State | Identity scope |
+| State | Scope |
 | --- | --- |
-| goal/constraints/hypotheses | Thread |
-| active turn | Turn |
+| goal / constraints / hypotheses | Thread |
+| active work | Turn |
 | reviewer freshness | Turn |
-| connection latency | Attachment |
-| journal lineage | Thread |
+| connection latency | Runtime Attachment |
+| durable journal lineage | Thread |
 | fork branch point | Thread + Turn/Step |
 
 ---
 
-# 10. App Server connection / capability model
+# 10. App Server connection and capability model
 
-Spotter는 Codex version 문자열 하나만 보고 기능을 가정하지 않는다.
+Spotter should negotiate capabilities instead of relying on one minimum Codex version string.
 
-Connection 시 capability를 확인한다.
+Candidate capabilities:
 
 ```text
 observe_thread_lifecycle
@@ -634,10 +629,10 @@ observe_diff
 observe_token_usage
 steer_active_turn
 interrupt_active_turn
-atomic_pretool_veto (hook/other surface)
+atomic_pretool_veto
 ```
 
-예시 status:
+Example status output:
 
 ```text
 Codex integration
@@ -649,13 +644,13 @@ Codex integration
   enforcement.pretool:      yes
 ```
 
-이 모델 덕분에 Codex upgrade 후 일부 feature만 깨져도 전체를 binary compatible/incompatible로 단순화하지 않고 degraded mode로 동작할 수 있다.
+This allows a Codex upgrade to degrade one feature without forcing a binary “supported/unsupported” result for the whole integration.
 
 ---
 
-# 11. Failure / degraded mode
+# 11. Failure and degraded mode
 
-각 plane의 건강 상태를 따로 관리한다.
+Health must be tracked per subsystem:
 
 ```text
 spotterd health
@@ -667,7 +662,7 @@ Journal/storage health
 Reviewer provider health
 ```
 
-예:
+Example:
 
 ```text
 Spotter daemon:       running
@@ -679,7 +674,7 @@ Journal:              writable
 Reviewer:             available
 ```
 
-### spotterd crash
+### `spotterd` crash
 
 ```text
 spotterd crash
@@ -688,18 +683,16 @@ service manager restart
   ↓
 App Server reconnect
   ↓
-active/loaded thread list
+list active/loaded threads
   ↓
 reconcile + journal hydrate
   ↓
 READY
 ```
 
-Daemon이 죽어 있는 동안 Hook gate는 fail-open한다.
+During daemon downtime, the Hook gate fails open.
 
-### App Server crash/disconnect
-
-State machine 예:
+### App Server disconnect
 
 ```text
 CONNECTED
@@ -711,7 +704,7 @@ RECONNECTING
   └─ UNAVAILABLE
 ```
 
-Spotter daemon이 살아 있다는 이유만으로 healthy라고 표시하지 않는다.
+A healthy daemon with no observation/control channel is not fully healthy.
 
 ### Reviewer failure
 
@@ -719,14 +712,14 @@ Spotter daemon이 살아 있다는 이유만으로 healthy라고 표시하지 �
 reviewer timeout/error
   → ReviewerJob FAILED
   → Main unaffected
-  → spend/error telemetry
+  → error/spend telemetry
 ```
 
 ---
 
 # 12. Runtime resources
 
-정확한 path는 구현에서 확정하되 ownership은 처음부터 분리한다.
+Exact platform paths are implementation details, but ownership should be explicit from the start.
 
 Conceptual layout:
 
@@ -736,7 +729,7 @@ Conceptual layout:
   integrations/
     codex.json
 
-~/.local/state/spotter/   # 플랫폼에 맞는 state dir 사용 가능
+~/.local/state/spotter/     # use platform-appropriate state directory
   sessions/
   labels/
   experiments/
@@ -747,40 +740,38 @@ Conceptual layout:
   repos.json
 ```
 
-현재 prototype의 `~/.spotter` data와 migration compatibility를 고려한다.
+The current prototype uses `~/.spotter`; migration must preserve compatibility or provide an explicit data move.
 
-Repository 내부/ Git namespace에는:
+Repository/Git-owned Spotter resources may include:
 
 ```text
 refs/spotter/...
 Spotter-created detached worktrees
 ```
 
-가 존재할 수 있다.
-
-따라서 uninstall과 data purge는 별개다. 자세한 lifecycle은 [lifecycle.md](lifecycle.md).
+That is why uninstall and data purge are separate lifecycle operations. See [Lifecycle](lifecycle.md).
 
 ---
 
-# 13. Snapshots / replay / side effects
+# 13. Snapshots, replay, and side effects
 
-## Snapshot
+## Snapshots
 
-현재 prototype의 안전 원칙을 유지한다.
+Preserve current safety rules:
 
-- user HEAD/index를 수정하지 않는다.
-- Spotter-owned Git refs만 사용한다.
-- restore는 detached worktree로 한다.
-- cleanup은 Git-aware operation으로 한다.
+- do not modify user HEAD/index;
+- use Spotter-owned Git refs;
+- restore into detached worktrees;
+- clean up through Git-aware operations.
 
-## Replay/Fork
+## Replay / fork
 
-두 목적이 있다.
+These serve two different purposes:
 
-1. recovery primitive 연구
-2. same-prefix counterfactual evaluation
+1. recovery research;
+2. same-prefix counterfactual evaluation.
 
-Lineage 최소 metadata:
+Minimum lineage metadata:
 
 ```text
 parent_thread
@@ -793,17 +784,17 @@ control/guidance arm
 
 ## External side effects
 
-Local Git snapshot으로는 다음을 되돌릴 수 없다.
+A local Git snapshot cannot undo:
 
 ```text
 git push
 cloud deploy
-DB write
-GitHub issue/PR create
+database write
+GitHub issue/PR creation
 arbitrary MCP external write
 ```
 
-따라서 `RESTART` 전에 side-effect ledger가 필요하다.
+Before `RESTART` becomes a serious recovery primitive, Spotter needs a side-effect ledger:
 
 ```text
 Effect
@@ -815,13 +806,15 @@ Effect
   compensation/checkpoint if known
 ```
 
-Spotter는 reasoning context를 restart해도 외부 state가 자동 복구됐다고 주장하면 안 된다.
+A reasoning restart must never imply that external state was automatically rolled back.
 
 ---
 
 # 14. Agent adapter contract
 
-Codex는 첫 adapter다. Spotter core는 아래 capability 중심으로 본다.
+Codex is the first adapter, not the permanent core API.
+
+Conceptual interface:
 
 ```text
 AgentAdapter
@@ -837,30 +830,30 @@ AgentAdapter
     fork/resume primitives
 ```
 
-각 adapter는 capability set을 노출한다.
+Every adapter exposes capabilities explicitly.
 
 ```text
 CodexAdapter
   observation: rich
-  steer: yes (target PoC)
-  interrupt: yes (target)
+  steer: target PoC
+  interrupt: target
   pre-action veto: Hook
 
 FutureAgentAdapter
   observation: maybe partial
-  steer: maybe no
-  veto: maybe no
+  steer: maybe unavailable
+  veto: maybe unavailable
 ```
 
-Capability가 없는 agent에서는 기능을 숨기거나 degraded로 표시한다. Codex-specific method name이 Spotter policy layer에 직접 퍼지지 않게 한다.
+When a capability is missing, Spotter should hide/disable the feature or report degraded mode. Codex method names should not leak into core policy interfaces.
 
 ---
 
 # 15. P0 App Server lifecycle / attach PoC
 
-이 architecture의 구현은 아래 PoC를 먼저 통과해야 한다.
+The target architecture is gated by this experiment.
 
-## Path A — Codex managed daemon
+## Path A — Codex-managed daemon
 
 ```text
 start/ensure Codex App Server daemon
@@ -869,26 +862,26 @@ plain `codex`
       ↓
 TUI attaches to default external daemon
       ↓
-Spotter second-client attach
+Spotter attaches as second client
       ↓
 observe same thread/turn
       ↓
 turn/steer reaches TUI
 ```
 
-## Path B — Spotter-managed process
+## Path B — Spotter-managed App Server
 
 ```text
 Spotter starts external `codex app-server`
       ↓
 TUI + Spotter attach same endpoint
       ↓
-normal plain-codex UX can be preserved?
+can normal plain-codex UX still be preserved?
 ```
 
 ## Path C — Embedded baseline
 
-외부 attach가 불가능할 때 실제 가능한 capability를 측정한다.
+Measure the real fallback capability set:
 
 ```text
 Observation: limited/unavailable
@@ -899,69 +892,69 @@ PreToolUse:  possibly available
 
 ## Exit criteria
 
-- ordinary `codex` UX 유지
-- same App Server / same thread 증명
-- live event subscription
-- active turn identity
-- real `turn/steer` delivery
-- concurrent sessions 구분
-- reconnect/degraded behavior 이해
-- App Server ownership/lifecycle strategy 결정
+- ordinary `codex` UX is preserved;
+- TUI and Spotter prove they share the same App Server/thread;
+- live event subscription works;
+- active turn identity remains correct;
+- real `turn/steer` delivery is demonstrated;
+- concurrent sessions are distinguishable;
+- reconnect/degraded behavior is understood;
+- App Server ownership/lifecycle strategy is selected.
 
-**하나라도 핵심 전제가 성립하지 않으면 P1 daemon migration 전에 architecture를 다시 검토한다.**
+**If a core property fails, revisit the architecture before P1.**
 
 ---
 
 # 16. Current prototype guarantees to preserve
 
-Target으로 옮긴다고 기존 안전성을 버리지 않는다.
+The migration should not throw away hardening already earned by real use.
 
 ### Journal
 
-- cross-process serialization
-- monotonic step/proposal allocation
-- fsync durability
-- torn-tail recovery
-- destructive reader strictness
+- cross-process serialization;
+- monotonic step/proposal allocation;
+- fsync durability;
+- torn-tail recovery;
+- strict reads for destructive cleanup.
 
 ### Snapshot
 
-- user HEAD/index untouched
-- detached restore
-- Spotter-owned refs
-- dedup / conservative prune
+- user HEAD/index untouched;
+- detached restore;
+- Spotter-owned refs;
+- deduplication and conservative prune.
 
 ### Audit ledger
 
-- Main summary를 evidence로 승격하지 않음
-- observable outcome만 evidence
-- contradictory outcome → retraction
-- transitive stale propagation
+- Main summaries are not promoted to evidence;
+- only observable outcomes become evidence;
+- contradictory outcomes retract prior evidence;
+- stale propagation is transitive.
 
 ### Gate
 
-- shell-aware bounded parsing
-- unsupported ambiguity는 fail-open
-- blind spot을 FP와 별도로 측정
+- shell-aware bounded parsing;
+- ambiguous/unsupported cases fail open;
+- blind spots are measured separately from false positives.
 
-Hook corpus에서 audit ledger가 직접 outcome을 읽을 수 있던 tool result는 33/340(10%)이었다. 이 숫자는 **현재 Hook observation surface의 측정값**이며 App Server 전환 후 다시 측정한다.
+The hook-era corpus exposed directly usable outcomes in only 33 of 340 real tool results (10%). That is a measurement of the **current observation surface**, not a permanent architectural ceiling. P4 must re-measure it after App Server migration.
 
 ---
 
 # 17. Non-goals for the first migration
 
-첫 architecture migration에서 하지 않는다.
+Do not turn the architecture migration into all of these at once:
 
-- Spotter 전체 Rust/Go rewrite
-- graph database 도입
-- automatic compensating rollback
-- adaptive/learned intervention policy
-- 모든 agent 동시 지원
-- RESTART 완성
-- reviewer가 실제로 task outcome을 개선한다는 주장
+- rewrite all of Spotter in Rust/Go;
+- introduce a graph database;
+- automatic compensating rollback;
+- learned/adaptive intervention policy;
+- support every coding agent immediately;
+- finish `RESTART`;
+- claim that reviewer interventions improve task outcomes.
 
-첫 성공 기준은 더 작다.
+The first runtime success criterion is narrower:
 
-> **같은 사용자 Codex thread를 안정적으로 관찰하고, live state를 유지하고, deterministic gate는 빠르게 처리하며, async reviewer verdict를 active turn에 안전하게 전달할 수 있는 runtime boundary를 만든다.**
+> **Observe the same real Codex thread, maintain live independent state, keep deterministic enforcement fast, and deliver an asynchronous reviewer decision safely to the correct active turn.**
 
-구현 lifecycle은 [Lifecycle](lifecycle.md), 순서는 [Roadmap](roadmap.md), 현재 상태는 [Status](status.md)를 본다.
+For installation/upgrade/removal details, see [Lifecycle](lifecycle.md). For implementation order, see [Roadmap](roadmap.md). For a project dashboard, see [Status](status.md).

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -1,339 +1,616 @@
 # Concept
 
-## What is Spotter?
+> **Purpose:** define the problem Spotter is trying to solve, the intervention model, and the principles that should remain true even if the implementation changes.
+
+---
+
+## 30-second summary
 
 Spotter is a **runtime supervision system for coding agents**.
 
-A primary coding agent remains responsible for doing the work. Spotter observes the execution trajectory, keeps an independent view of what is known and uncertain, and intervenes only when intervention is likely to improve the outcome.
-
-The metaphor is intentional: a good spotter does not perform the lift. They watch closely, avoid unnecessary interference, and step in before a recoverable mistake becomes a failure.
-
-> **The user defines the goal. Spotter reviews the path.**
-
-The project started as a hook/plugin-centered prototype. The target product boundary is now broader: Spotter should be an **independent local runtime** that integrates with coding agents such as Codex through their observation, control, and enforcement surfaces. The agent integration is an adapter; it is not the identity of Spotter itself.
-
-## The problem
-
-Coding agents increasingly operate over long trajectories:
+The main agent still owns the task. Spotter observes the execution path, keeps an independent view of claims/evidence/progress, and intervenes only when intervention is more useful than letting Main continue.
 
 ```text
-understand → inspect → hypothesize → edit → run → observe → revise → validate
-```
-
-Many failures are not single incorrect outputs. They are **trajectory failures**.
-
-A weak assumption can become a plan. The plan can trigger unnecessary edits. Those edits can create secondary failures. The agent then spends more time compensating for consequences of the original mistake. A final-diff reviewer may detect the problem, but only after most of the cost has already been incurred.
-
-Common examples include:
-
-- drifting away from the requested scope
-- treating an unverified hypothesis as fact
-- continuing to use a premise after new evidence invalidates it
-- repetitive exploration that produces little new information
-- repeatedly retrying a failing tool strategy
-- expanding a local fix into an unnecessary refactor
-- forgetting a user constraint midway through a long run
-- editing before gathering enough evidence
-- making changes without validating the behavior they affect
-
-Spotter aims to catch these failures **while the trajectory is still recoverable**.
-
-## What changes with runtime supervision?
-
-Traditional review mainly examines an artifact after execution:
-
-```text
-request → implementation → diff → review
-```
-
-Runtime supervision adds another loop:
-
-```text
-request
+User goal
    ↓
-Main Agent ───────────────► execution continues
+Main Agent ───────────────────────────► keeps working
    │
    │ observable trajectory
    ▼
 Spotter
-   │
    ├─ maintain independent state
-   ├─ detect possible failure
+   ├─ detect possible trajectory failure
    ├─ verify ambiguous cases
-   └─ intervene only when useful
+   └─ choose the weakest useful intervention
 ```
 
-The key distinction is timing. Spotter tries to reduce the amount of **wasted progress after a meaningful deviation**, not merely increase the number of errors noticed eventually.
+Spotter is not trying to make the agent ask for approval before every action. Its core question is:
 
-## Core principles
+> **How do we keep a recoverable mistake from becoming an expensive trajectory?**
 
-### 1. Always observe, rarely interrupt
+The target intervention ladder is:
 
-Silence is a valid and desirable Spotter action.
+```text
+CONTINUE → VERIFY → NUDGE → BLOCK → INTERRUPT → RESTART
+```
 
-An observer that comments on every imperfect decision becomes another source of noise, latency, and anchoring. Spotter should intervene only when the expected value of intervention exceeds the expected value of letting Main continue.
+The target product boundary is also explicit: Spotter should be an **independent local runtime**, not a Codex plugin that happens to contain supervision logic. Codex is the first adapter.
 
-### 2. Review the process, not only the artifact
+---
 
-Static review asks whether the code is correct.
+## Quick reference
+
+| Concept | Meaning |
+| --- | --- |
+| Main | the coding agent that performs the user's task |
+| Spotter | independent runtime supervisor |
+| Trajectory | the sequence of observations, hypotheses, actions, tool calls, edits, results, and revisions |
+| Candidate signal | cheap evidence that something may be going wrong; not yet a semantic verdict |
+| Reviewer | an independent model that evaluates ambiguous candidates |
+| Deterministic gate | executable policy that can allow/deny a pending action without an LLM |
+| Intervention | `VERIFY`, `NUDGE`, `BLOCK`, `INTERRUPT`, or `RESTART` |
+| Audit state | Spotter's independent model of goal, constraints, hypotheses, evidence, progress, and failures |
+| Intervention advantage | whether intervening from a prefix improves the outcome compared with continuing from the same prefix |
+
+---
+
+# 1. The problem: trajectory failures
+
+Coding agents increasingly operate over long sequences:
+
+```text
+understand
+  ↓
+inspect
+  ↓
+hypothesize
+  ↓
+edit
+  ↓
+run
+  ↓
+observe
+  ↓
+revise
+  ↓
+validate
+```
+
+Many important failures are not a single wrong output. They are **trajectory failures**: one weak premise creates a path that keeps generating further work.
+
+Example:
+
+```text
+E1: timeout happens under load
+        │
+        ▼
+H1: Redis pool exhaustion is the cause
+        │   (never verified)
+        ▼
+P1: change Redis pool configuration
+        │
+        ▼
+new failures appear
+        │
+        ▼
+agent compensates with more edits
+        │
+        ▼
+scope expands and the original mistake becomes expensive
+```
+
+A post-hoc reviewer can still catch the bad diff, but by then the agent may already have spent most of the tokens, tool calls, elapsed time, and repository churn.
+
+Spotter tries to act closer to the first meaningful deviation:
+
+```text
+H1 appears
+  ↓
+Spotter notices consequential assumption has weak evidence
+  ↓
+VERIFY: inspect stack trace / focused probe
+  ↓
+H1 confirmed → continue
+or
+H1 refuted → avoid the wrong branch
+```
+
+The optimization target is therefore not “detect every imperfect action.” It is **reduce wasted progress while preserving Main's autonomy**.
+
+---
+
+# 2. What Spotter observes
+
+Typical failure classes include:
+
+### Goal / scope failures
+
+- drifting from the user's request;
+- forgetting a constraint in a long run;
+- expanding a local change into an unnecessary refactor;
+- dependency or file-scope creep.
+
+### Epistemic failures
+
+- treating an unverified hypothesis as fact;
+- continuing from evidence that was later contradicted;
+- mistaking correlation for cause;
+- over-trusting Main's own summary of what happened.
+
+### Search / execution failures
+
+- repeated low-information exploration;
+- retrying equivalent failing commands;
+- staying inside one hypothesis despite contradictory signals;
+- continuing after a tool strategy repeatedly fails.
+
+### Validation failures
+
+- meaningful edits without targeted validation;
+- tests run at the wrong layer;
+- passing a partial check while the affected behavior remains untested;
+- accumulating a large change before any feedback loop.
+
+Not every instance is an error. Exploration can be neutral and repetition can be justified. Cheap signals therefore create **candidates**, while semantic judgment remains a separate step.
+
+---
+
+# 3. Core loop
+
+The intended supervision loop is:
+
+```text
+1. OBSERVE
+   collect runtime events and relevant repository/tool outcomes
+
+2. UPDATE STATE
+   maintain goal, constraints, hypotheses, evidence, touched scope,
+   validation state, recent failures, and intervention history
+
+3. DETECT CANDIDATE
+   use cheap signals or deterministic verifiers
+
+4. REVIEW WHEN NEEDED
+   ask an independent reviewer only for ambiguous semantic judgment
+
+5. CHOOSE ACTION
+   prefer the weakest intervention likely to help
+
+6. DELIVER / ENFORCE
+   async steer for VERIFY/NUDGE; sync deny for deterministic BLOCK
+
+7. MEASURE
+   record timing, cost, precision, harm, recovery, and outcome
+```
+
+Spotter is successful only if this loop improves outcomes **without becoming a larger source of cost, latency, or noise than the failures it prevents**.
+
+---
+
+# 4. Core principles
+
+## 4.1 Always observe, rarely interrupt
+
+Silence is a valid and desirable Spotter outcome.
+
+An observer that comments on every imperfect decision creates:
+
+- latency;
+- token cost;
+- anchoring;
+- unnecessary plan churn;
+- a second source of mistakes.
+
+Spotter should intervene only when expected intervention value exceeds the expected value of letting Main continue.
+
+## 4.2 Review the path, not only the artifact
+
+Static review asks “is this code correct?”
 
 Spotter also asks:
 
 - Why is this file being edited?
-- What evidence supports the current hypothesis?
-- Is this action still connected to the user's goal?
-- Did the agent already invalidate the premise behind this plan?
-- Is exploration producing new information?
-- Has the agent accumulated changes without validating them?
+- Which hypothesis motivates this change?
+- What observable evidence supports that hypothesis?
+- Did later evidence invalidate it?
+- Is the search frontier expanding or repeating?
+- Has the agent changed meaningful behavior without validation?
+- Is the current action still connected to the user's goal?
 
-### 3. Prefer falsification over opinion
+## 4.3 Prefer falsification over model debate
 
-When Main and Spotter disagree, the preferred resolution is not a longer conversation between models.
-
-Spotter should look for the cheapest discriminating evidence:
-
-- run a focused test
-- inspect the stack trace
-- search the call sites
-- check the compiler or type system
-- inspect repository state
-- query logs
-
-The reviewer is not a competing implementation agent. It is an independent falsifier that tries to expose fragile assumptions and move the trajectory toward evidence.
-
-### 4. Deterministic facts deserve deterministic checks
-
-Known constraints do not need an LLM judge.
+When Main and Spotter disagree, the preferred next step is a **cheap discriminating probe**, not a long conversation between models.
 
 Examples:
 
-- “Do not add dependencies” → inspect manifest changes
-- “Only modify this directory” → inspect affected paths
-- forbidden commands → judge the pending tool call
-- explicit execution boundaries → deterministic policy
-
-LLM review should be reserved for semantic ambiguity: scope drift, unsupported reasoning, missed requirements, stale assumptions, premature abstraction, and similar judgments.
-
-This leads to two different control paths:
-
 ```text
-semantic supervision        deterministic enforcement
-asynchronous                synchronous when required
-VERIFY / NUDGE              ALLOW / BLOCK
+focused test
+compiler/type checker
+stack trace inspection
+call-site search
+repository state inspection
+log query
+small reproduction
 ```
 
-### 5. Main and Spotter should fail differently
+The reviewer should not become a second coding agent racing Main to produce an alternate solution.
 
-Spotter should be independently configurable and, where practical, use a different reviewer model or model family from Main.
+## 4.4 Deterministic facts deserve deterministic checks
 
-Its state should also preserve judgment independence. Main's conclusions must not automatically become Spotter's facts. A claim can be recorded as a hypothesis with supporting and contradicting evidence rather than copied into shared state as truth.
-
-Model diversity is still an empirical question. Independent context is valuable even when only the same model family is available.
-
-### 6. Intervention should be incremental
-
-Spotter uses an escalation ladder:
+Examples:
 
 ```text
-CONTINUE
-   ↓
-VERIFY
-   ↓
-NUDGE
-   ↓
-BLOCK
-   ↓
-INTERRUPT
-   ↓
-RESTART
+"Do not add dependencies"
+  → inspect manifest modification
+
+"Only modify src/auth/**"
+  → inspect proposed/changed paths
+
+"Never run destructive git commands"
+  → inspect pending command
 ```
 
-The weakest sufficient intervention is preferred.
+These do not need an LLM.
 
-### 7. Supervision must not become the bottleneck
+Semantic review is reserved for claims such as:
 
-The main agent should not wait for a semantic reviewer before every action.
+```text
+"This approach is drifting from the requested scope."
+"The next edit depends on a weak assumption."
+"The agent is repeating exploration without gaining information."
+```
 
-The target architecture therefore keeps semantic supervision asynchronous: the agent continues, Spotter thinks in parallel, and a decision is delivered to the active turn only if it is still relevant.
+## 4.5 Semantic supervision should be asynchronous
 
-Only narrow deterministic enforcement belongs on a synchronous pre-action path.
+Main should not wait for a reviewer before each ordinary action.
 
-### 8. Live state belongs in the runtime, not in the log
+```text
+Main continues ─────────────────────────────►
 
-The prototype reconstructs substantial state from hook-written journals. That is acceptable for experimentation but not the desired steady-state architecture.
+candidate
+   ↓
+reviewer thinks in parallel
+   ↓
+verdict arrives
+   ↓
+is target turn still relevant?
+   ├─ yes → deliver
+   └─ no  → stale policy
+```
 
-Target responsibility:
+Only narrow deterministic enforcement belongs in a synchronous pre-action path.
+
+## 4.6 Main and Spotter should fail differently
+
+Spotter should preserve judgment independence:
+
+- separate reviewer context;
+- independently configured model where practical;
+- Main's explanation is not automatically evidence;
+- uncertainty and missing evidence remain explicit.
+
+Different model families may reduce correlated errors, but that is an empirical question. Independent state/context is useful even when only the same model family is available.
+
+## 4.7 Live state belongs in the runtime, not the log
+
+Target ownership:
 
 ```text
 memory  = live supervision state
-journal = durable history / recovery source
+journal = durable event history / recovery source
+snapshot = repository state checkpoint
 ```
 
-Journal replay should happen at recovery, resume, and analysis boundaries—not on every ordinary event.
+Journal replay belongs at resume/recovery/offline analysis boundaries, not on every ordinary event.
 
-### 9. Agent integrations are adapters
+## 4.8 Integrations are adapters
 
-Spotter should not be defined by Codex plugin packaging.
+Spotter should not be defined as “a Codex plugin.”
 
-For Codex, the target is to use App Server as the primary observation/control plane and keep hooks only where they provide a unique enforcement primitive such as atomic pre-tool blocking.
+A coding-agent adapter may expose different capabilities:
 
-A future agent integration may expose different primitives. Spotter core should depend on normalized capabilities rather than a specific hook or transcript format.
+```text
+observe events
+soft steer active turn
+interrupt active turn
+atomic pre-action veto
+resume/fork
+```
 
-## Intervention semantics
+Spotter core should reason over normalized capabilities and Trace IR rather than Codex-specific event formats.
 
-### CONTINUE
+---
 
-No meaningful issue is detected, or an issue exists but intervention is unlikely to help. Spotter remains silent.
+# 5. Intervention semantics
 
-### VERIFY
+## `CONTINUE`
 
-A consequential decision depends on a weakly supported assumption. Spotter asks Main to gather a small amount of discriminating evidence before compounding the assumption.
+No useful intervention is justified.
 
-### NUDGE
+Possible reasons:
 
-The trajectory shows early drift, inefficiency, or omission. Spotter injects a concise course correction without taking over the task.
+- trajectory looks healthy;
+- signal was a false alarm;
+- uncertainty exists but the next action is cheap/reversible;
+- intervening would create more disruption than value.
 
-### BLOCK
+Expected behavior: **silent no-op**.
 
-A pending action clearly violates a known deterministic constraint or configured execution boundary. The action is stopped before execution.
+## `VERIFY`
 
-`BLOCK` should remain near-deterministic. Semantic reviewer disagreement should not casually become a synchronous denial.
+A consequential decision depends on weak evidence.
 
-### INTERRUPT
+Good VERIFY:
 
-The active turn has entered a trajectory where continued execution is likely to compound waste or damage. Spotter stops the turn and requires reassessment instead of allowing the same plan to continue indefinitely.
+```text
+Before changing the Redis pool size, inspect the timeout stack trace;
+the current evidence does not yet identify Redis as the source.
+```
 
-### RESTART
+Bad VERIFY:
 
-The current reasoning context itself is considered contaminated by stale assumptions or cascading failures. A fresh continuation begins from the user's goal, verified evidence, current repository state, and deliberately retained artifacts.
+```text
+Think more carefully about the problem.
+```
 
-This should be rare and should not pretend that external side effects have been rolled back when they have not.
+VERIFY should request a small, discriminating piece of evidence.
 
-## Pair-aware Main
+## `NUDGE`
 
-Runtime supervision changes the environment in which the primary agent operates. Main therefore benefits from a small execution contract.
+The path shows early drift, omission, or inefficient commitment.
 
-It should understand that:
+Good NUDGE:
 
-- Spotter signals are runtime supervision, not new user requirements.
-- Spotter feedback should not be accepted blindly.
-- disagreement should preferably be resolved with external evidence.
-- a blocked action should not be retried through superficial reformulation.
-- an interrupt requires reassessment before continuing.
-- Main should not wait for Spotter approval during normal execution.
+```text
+The last three edits expand beyond the requested auth timeout fix.
+Re-check the user scope before continuing the refactor.
+```
+
+A NUDGE is not a replacement implementation plan.
+
+## `BLOCK`
+
+A pending action violates a deterministic constraint.
+
+Examples:
+
+```text
+git reset --hard
+forbidden path mutation
+unapproved dependency manifest change
+workspace escape
+```
+
+BLOCK should remain near-deterministic. Semantic disagreement must not silently become a deny.
+
+## `INTERRUPT`
+
+The current turn is likely to compound a bad trajectory faster than a soft correction can help.
+
+INTERRUPT has a much higher false-positive cost than NUDGE, so it requires a stronger evidence/precision gate.
+
+## `RESTART`
+
+The reasoning context itself is no longer trustworthy.
+
+A fresh continuation should receive deliberately selected state:
+
+```text
+user goal
+explicit constraints
+verified evidence
+current repository state
+intentionally retained artifacts
+```
+
+It should not automatically inherit the entire failed reasoning history.
+
+RESTART must also account for external side effects. Restarting reasoning does not undo a push, deploy, database write, or external API mutation.
+
+---
+
+# 6. Pair-aware Main contract
+
+Runtime supervision changes Main's environment. Main needs a small contract:
+
+- the user remains the source of task intent;
+- Spotter feedback is supervision, not a new requirement;
+- `VERIFY` / `NUDGE` request reassessment, not blind compliance;
+- disagreement should be resolved with evidence when possible;
+- blocked actions should not be retried through superficial reformulation;
+- an interrupt requires replanning;
+- Main should not wait for Spotter during ordinary execution.
 
 A useful rule is:
 
 > **Pair feedback is a request to re-evaluate the path, not authority to redefine the goal.**
 
-The exact delivery mechanism is runtime-specific. In the target Codex architecture, soft feedback should be delivered through the live App Server control path rather than by keeping a hook process alive.
+---
 
-## Independent working state
+# 7. Independent working state
 
-Spotter needs more than a raw transcript, but the first useful implementation does not need a large graph database.
-
-A compact state is enough:
+A useful first state model does not require a graph database.
 
 ```text
-Goal
-Constraints
-Current hypotheses
-Evidence for / against
-Open questions
-Current action
-Files touched
-Validation state
-Recent failures
-Intervention history
-Active thread / turn
-Reviewer jobs / budgets
+ThreadState
+  Goal
+  Constraints
+  Active turn
+  Hypotheses
+  Evidence for/against
+  Open questions
+  Touched scope
+  Validation state
+  Recent actions
+  Recent failures
+  Intervention history
+  Pending reviewer jobs
+  Reviewer budgets
 ```
 
-The important relationship is between **claims and evidence**. If evidence is invalidated, downstream hypotheses and plans that depended on it should become stale and require revalidation.
+The key relationship is claim → evidence dependency.
 
-## Observation, control, and enforcement are different planes
-
-A useful conceptual split is:
+Example:
 
 ```text
-Observation plane
-  → what happened / is happening?
+E1: failures correlate with high concurrency
+        ↓ supports
+H1: Redis pool exhaustion causes timeout
+        ↓ motivates
+P1: change Redis pool settings
 
-Control plane
-  → how can Spotter steer or stop the active trajectory?
-
-Enforcement plane
-  → what must be decided atomically before an action executes?
+E2 arrives: stack trace points to upstream HTTP client
+        ↓
+H1 becomes stale
+        ↓
+P1 must be revalidated
 ```
 
-For the current Codex target, the intended mapping is:
+Main's own prose summary is not enough to turn H1 into verified evidence.
+
+---
+
+# 8. Observation, control, and enforcement
+
+These are different product surfaces.
 
 ```text
-App Server      → primary observation + live control
-PreToolUse Hook → narrow synchronous enforcement
-spotterd        → state, detection, review, policy, orchestration
+Observation
+  What is happening?
+
+Control
+  How can Spotter influence an active trajectory?
+
+Enforcement
+  What must be decided atomically before execution?
 ```
 
-This mapping is a target architecture and depends on the App Server lifecycle/attach PoC tracked by [#66](https://github.com/Bogyie/spotter/issues/66).
+Target Codex mapping:
 
-## Product lifecycle is part of the design
+```text
+Codex App Server
+  → primary observation + live control
 
-A supervision runtime that works only after manually starting several background processes is not a complete product.
+PreToolUse Hook
+  → narrow deterministic enforcement
 
-The target UX is:
+spotterd
+  → state, signals, reviewer, policy, budgets, recovery
+```
+
+This mapping depends on the App Server lifecycle/attach PoC in #66.
+
+---
+
+# 9. Product lifecycle is part of the concept
+
+A runtime supervisor is not complete if the user must manually orchestrate several background processes every time they use Codex.
+
+Target experience:
 
 ```bash
 brew install spotter
 spotter setup codex
 spotter doctor
 
-# thereafter
+# after setup
 codex
 ```
 
-Spotter must also define behavior for:
+The design must also define:
 
-- login/startup
-- multiple simultaneous agent sessions
-- thread resume
-- daemon or App Server crash
-- Spotter upgrade
-- Codex upgrade
-- schema migration
-- integration teardown
-- uninstall without teardown
-- data purge
-- reinstall
+- login/startup behavior;
+- multiple simultaneous coding sessions;
+- thread resume;
+- daemon/App Server crash recovery;
+- Spotter upgrade;
+- Codex upgrade;
+- config/schema migration;
+- teardown;
+- uninstall without teardown;
+- data purge;
+- reinstall;
+- legacy plugin migration.
 
-See [Lifecycle](lifecycle.md) for the full operational model.
+See [Lifecycle](lifecycle.md) for the operational contract.
 
-## What Spotter is not
+---
+
+# 10. What Spotter is not
 
 Spotter is not:
 
-- a second coding agent racing Main to solve the same task
-- a static code-review bot
-- a security-only guardrail
-- a mandatory approval gate for every tool call
-- a multi-agent debate system
-- a mechanism for maximizing the amount of reasoning
-- a Codex-only plugin as a product boundary
+- a second coding agent racing Main to solve the same task;
+- a static code-review bot;
+- a security-only guardrail;
+- a mandatory approval gate before every tool call;
+- a multi-agent debate framework;
+- a mechanism for maximizing the amount of reasoning;
+- a Codex-only plugin as a permanent product boundary;
+- a claim that every detectable mistake should be interrupted.
 
-Its purpose is to reduce **wasted progress** while preserving Main's autonomy.
+Its purpose is narrower: **reduce wasted progress while preserving Main's autonomy**.
 
-## Trajectory Engineering
+---
 
-Spotter is an experiment in a broader layer we call **Trajectory Engineering**.
+# 11. What would count as success?
+
+Implementation success and research success are different.
+
+### Implementation success
+
+Spotter can:
+
+1. observe the real active coding-agent trajectory;
+2. maintain independent live state;
+3. detect candidates cheaply;
+4. run semantic review asynchronously;
+5. deliver a decision to the correct active turn;
+6. deterministically block narrow policy violations;
+7. survive restart/resume/upgrades without losing ownership clarity.
+
+### Research success
+
+Compared with a matched baseline, Spotter demonstrates:
+
+- positive intervention advantage;
+- acceptable false-positive and miss rates;
+- reduced wasted actions/tokens/time;
+- low intervention harm;
+- acceptable runtime and operational overhead.
+
+A plausible reviewer verdict is not enough. A polished daemon is not enough. The system must prove that intervention is worth its cost.
+
+---
+
+# 12. Trajectory Engineering
+
+Spotter is an experiment in a broader layer: **Trajectory Engineering**.
 
 - Prompt engineering shapes the instruction.
 - Context engineering shapes what the model can see.
-- Harness engineering shapes the execution environment, tools, and orchestration.
+- Harness engineering shapes the environment, tools, and constraints.
 - **Trajectory engineering shapes what happens while the agent is already executing.**
 
-Its concerns include observation, state tracking, verification, intervention timing, steering, interruption, rollback boundaries, restart, and recovery.
+Its concerns include:
 
-The working hypothesis behind Spotter is:
+```text
+observation
+state tracking
+verification
+intervention timing
+steering
+blocking
+interruption
+restart boundaries
+recovery
+causal evaluation of interventions
+```
 
-> Better agents are not only agents that reason better. They are agents whose mistakes are detected early enough that they remain cheap to correct.
+The working hypothesis is:
 
-That hypothesis is not yet proven for Spotter. The project should keep mechanisms behind measurement gates and treat negative or null intervention results as first-class outcomes.
+> **A better agent system is not only one that makes fewer mistakes. It is also one that detects mistakes early enough that they remain cheap to correct.**
+
+That hypothesis is not yet proven for Spotter. Null and negative results are first-class outcomes.
+
+For current implementation state, see [Status](status.md). For runtime mechanics, see [Architecture](architecture.md). For implementation order, see [Roadmap](roadmap.md).

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -2,15 +2,17 @@
 
 ## What is Spotter?
 
-Spotter is a runtime supervision layer for coding agents.
+Spotter is a **runtime supervision system for coding agents**.
 
-A primary agent remains responsible for doing the work. A second, independently configured model observes the primary agent's execution trajectory and intervenes only when intervention is likely to improve the outcome.
+A primary coding agent remains responsible for doing the work. Spotter observes the execution trajectory, keeps an independent view of what is known and uncertain, and intervenes only when intervention is likely to improve the outcome.
 
 The metaphor is intentional: a good spotter does not perform the lift. They watch closely, avoid unnecessary interference, and step in before a recoverable mistake becomes a failure.
 
 > **The user defines the goal. Spotter reviews the path.**
 
-## Problem
+The project started as a hook/plugin-centered prototype. The target product boundary is now broader: Spotter should be an **independent local runtime** that integrates with coding agents such as Codex through their observation, control, and enforcement surfaces. The agent integration is an adapter; it is not the identity of Spotter itself.
+
+## The problem
 
 Coding agents increasingly operate over long trajectories:
 
@@ -36,13 +38,40 @@ Common examples include:
 
 Spotter aims to catch these failures **while the trajectory is still recoverable**.
 
+## What changes with runtime supervision?
+
+Traditional review mainly examines an artifact after execution:
+
+```text
+request → implementation → diff → review
+```
+
+Runtime supervision adds another loop:
+
+```text
+request
+   ↓
+Main Agent ───────────────► execution continues
+   │
+   │ observable trajectory
+   ▼
+Spotter
+   │
+   ├─ maintain independent state
+   ├─ detect possible failure
+   ├─ verify ambiguous cases
+   └─ intervene only when useful
+```
+
+The key distinction is timing. Spotter tries to reduce the amount of **wasted progress after a meaningful deviation**, not merely increase the number of errors noticed eventually.
+
 ## Core principles
 
 ### 1. Always observe, rarely interrupt
 
 Silence is a valid and desirable Spotter action.
 
-An observer that comments on every imperfect decision becomes another source of noise and latency. Spotter should intervene only when the expected value of intervention exceeds the expected value of letting the main agent continue.
+An observer that comments on every imperfect decision becomes another source of noise, latency, and anchoring. Spotter should intervene only when the expected value of intervention exceeds the expected value of letting Main continue.
 
 ### 2. Review the process, not only the artifact
 
@@ -54,7 +83,7 @@ Spotter also asks:
 - What evidence supports the current hypothesis?
 - Is this action still connected to the user's goal?
 - Did the agent already invalidate the premise behind this plan?
-- Is this exploration producing new information?
+- Is exploration producing new information?
 - Has the agent accumulated changes without validating them?
 
 ### 3. Prefer falsification over opinion
@@ -66,30 +95,40 @@ Spotter should look for the cheapest discriminating evidence:
 - run a focused test
 - inspect the stack trace
 - search the call sites
-- check the type system or compiler
+- check the compiler or type system
 - inspect repository state
 - query logs
 
-The purpose of the reviewer is not to produce a competing answer. It is to expose fragile assumptions and move the trajectory toward evidence.
+The reviewer is not a competing implementation agent. It is an independent falsifier that tries to expose fragile assumptions and move the trajectory toward evidence.
 
-### 4. Deterministic facts should have deterministic checks
+### 4. Deterministic facts deserve deterministic checks
 
 Known constraints do not need an LLM judge.
 
 Examples:
 
-- “Do not add dependencies” → inspect manifest diffs
+- “Do not add dependencies” → inspect manifest changes
 - “Only modify this directory” → inspect affected paths
-- “Tests must pass” → inspect test result state
-- forbidden commands → match the pending tool call
+- forbidden commands → judge the pending tool call
+- explicit execution boundaries → deterministic policy
 
-LLM review should be reserved for semantic ambiguity: scope drift, unsupported reasoning, missed requirements, premature abstraction, and similar judgments.
+LLM review should be reserved for semantic ambiguity: scope drift, unsupported reasoning, missed requirements, stale assumptions, premature abstraction, and similar judgments.
+
+This leads to two different control paths:
+
+```text
+semantic supervision        deterministic enforcement
+asynchronous                synchronous when required
+VERIFY / NUDGE              ALLOW / BLOCK
+```
 
 ### 5. Main and Spotter should fail differently
 
-Spotter should be independently configurable and preferably use a different model from the main coding agent.
+Spotter should be independently configurable and, where practical, use a different reviewer model or model family from Main.
 
-Its context should also preserve some independence. Main's conclusions must not automatically become Spotter's facts. A claim can be recorded as a hypothesis with supporting and contradicting evidence rather than copied into shared state as truth.
+Its state should also preserve judgment independence. Main's conclusions must not automatically become Spotter's facts. A claim can be recorded as a hypothesis with supporting and contradicting evidence rather than copied into shared state as truth.
+
+Model diversity is still an empirical question. Independent context is valuable even when only the same model family is available.
 
 ### 6. Intervention should be incremental
 
@@ -111,6 +150,35 @@ RESTART
 
 The weakest sufficient intervention is preferred.
 
+### 7. Supervision must not become the bottleneck
+
+The main agent should not wait for a semantic reviewer before every action.
+
+The target architecture therefore keeps semantic supervision asynchronous: the agent continues, Spotter thinks in parallel, and a decision is delivered to the active turn only if it is still relevant.
+
+Only narrow deterministic enforcement belongs on a synchronous pre-action path.
+
+### 8. Live state belongs in the runtime, not in the log
+
+The prototype reconstructs substantial state from hook-written journals. That is acceptable for experimentation but not the desired steady-state architecture.
+
+Target responsibility:
+
+```text
+memory  = live supervision state
+journal = durable history / recovery source
+```
+
+Journal replay should happen at recovery, resume, and analysis boundaries—not on every ordinary event.
+
+### 9. Agent integrations are adapters
+
+Spotter should not be defined by Codex plugin packaging.
+
+For Codex, the target is to use App Server as the primary observation/control plane and keep hooks only where they provide a unique enforcement primitive such as atomic pre-tool blocking.
+
+A future agent integration may expose different primitives. Spotter core should depend on normalized capabilities rather than a specific hook or transcript format.
+
 ## Intervention semantics
 
 ### CONTINUE
@@ -123,25 +191,27 @@ A consequential decision depends on a weakly supported assumption. Spotter asks 
 
 ### NUDGE
 
-The trajectory shows early drift, inefficiency, or omission. Spotter injects a concise course correction without taking control of the task.
+The trajectory shows early drift, inefficiency, or omission. Spotter injects a concise course correction without taking over the task.
 
 ### BLOCK
 
-A pending action clearly violates a known constraint or crosses a configured execution boundary. The action is stopped before execution.
+A pending action clearly violates a known deterministic constraint or configured execution boundary. The action is stopped before execution.
+
+`BLOCK` should remain near-deterministic. Semantic reviewer disagreement should not casually become a synchronous denial.
 
 ### INTERRUPT
 
-The current turn has entered a trajectory where continued execution is likely to compound waste or damage. The turn is stopped and Main must reassess instead of resuming the same plan unchanged.
+The active turn has entered a trajectory where continued execution is likely to compound waste or damage. Spotter stops the turn and requires reassessment instead of allowing the same plan to continue indefinitely.
 
 ### RESTART
 
-The current reasoning context itself is considered contaminated by stale assumptions or cascading failures. A fresh rollout begins from the user's goal, verified evidence, current repository state, and explicitly retained artifacts.
+The current reasoning context itself is considered contaminated by stale assumptions or cascading failures. A fresh continuation begins from the user's goal, verified evidence, current repository state, and deliberately retained artifacts.
 
-This should be rare.
+This should be rare and should not pretend that external side effects have been rolled back when they have not.
 
 ## Pair-aware Main
 
-Runtime supervision changes the environment in which the primary agent operates. Main therefore needs a small execution contract.
+Runtime supervision changes the environment in which the primary agent operates. Main therefore benefits from a small execution contract.
 
 It should understand that:
 
@@ -156,11 +226,13 @@ A useful rule is:
 
 > **Pair feedback is a request to re-evaluate the path, not authority to redefine the goal.**
 
-## Working state
+The exact delivery mechanism is runtime-specific. In the target Codex architecture, soft feedback should be delivered through the live App Server control path rather than by keeping a hook process alive.
 
-Spotter needs more than a raw transcript, but the first implementation does not need a large knowledge-graph system.
+## Independent working state
 
-A compact independent audit state is enough:
+Spotter needs more than a raw transcript, but the first useful implementation does not need a large graph database.
+
+A compact state is enough:
 
 ```text
 Goal
@@ -173,9 +245,67 @@ Files touched
 Validation state
 Recent failures
 Intervention history
+Active thread / turn
+Reviewer jobs / budgets
 ```
 
-The important relationship is between **claims and evidence**. If evidence is invalidated, downstream hypotheses and plans that depended on it should be marked stale and revalidated.
+The important relationship is between **claims and evidence**. If evidence is invalidated, downstream hypotheses and plans that depended on it should become stale and require revalidation.
+
+## Observation, control, and enforcement are different planes
+
+A useful conceptual split is:
+
+```text
+Observation plane
+  → what happened / is happening?
+
+Control plane
+  → how can Spotter steer or stop the active trajectory?
+
+Enforcement plane
+  → what must be decided atomically before an action executes?
+```
+
+For the current Codex target, the intended mapping is:
+
+```text
+App Server      → primary observation + live control
+PreToolUse Hook → narrow synchronous enforcement
+spotterd        → state, detection, review, policy, orchestration
+```
+
+This mapping is a target architecture and depends on the App Server lifecycle/attach PoC tracked by [#66](https://github.com/Bogyie/spotter/issues/66).
+
+## Product lifecycle is part of the design
+
+A supervision runtime that works only after manually starting several background processes is not a complete product.
+
+The target UX is:
+
+```bash
+brew install spotter
+spotter setup codex
+spotter doctor
+
+# thereafter
+codex
+```
+
+Spotter must also define behavior for:
+
+- login/startup
+- multiple simultaneous agent sessions
+- thread resume
+- daemon or App Server crash
+- Spotter upgrade
+- Codex upgrade
+- schema migration
+- integration teardown
+- uninstall without teardown
+- data purge
+- reinstall
+
+See [Lifecycle](lifecycle.md) for the full operational model.
 
 ## What Spotter is not
 
@@ -187,8 +317,9 @@ Spotter is not:
 - a mandatory approval gate for every tool call
 - a multi-agent debate system
 - a mechanism for maximizing the amount of reasoning
+- a Codex-only plugin as a product boundary
 
-Its purpose is to reduce **wasted progress**.
+Its purpose is to reduce **wasted progress** while preserving Main's autonomy.
 
 ## Trajectory Engineering
 
@@ -199,8 +330,10 @@ Spotter is an experiment in a broader layer we call **Trajectory Engineering**.
 - Harness engineering shapes the execution environment, tools, and orchestration.
 - **Trajectory engineering shapes what happens while the agent is already executing.**
 
-Its concerns include observation, state tracking, verification, intervention timing, rollback, restart, and recovery.
+Its concerns include observation, state tracking, verification, intervention timing, steering, interruption, rollback boundaries, restart, and recovery.
 
-The working hypothesis behind Spotter is simple:
+The working hypothesis behind Spotter is:
 
 > Better agents are not only agents that reason better. They are agents whose mistakes are detected early enough that they remain cheap to correct.
+
+That hypothesis is not yet proven for Spotter. The project should keep mechanisms behind measurement gates and treat negative or null intervention results as first-class outcomes.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,0 +1,929 @@
+# Lifecycle and Operations
+
+> **Status:** target design, tracked by [#66](https://github.com/Bogyie/spotter/issues/66).  
+> The current prototype is still hook/plugin-centered. This document defines the lifecycle Spotter should converge on; it is not a claim that every command or runtime component described here ships today.
+
+Spotter is moving from an agent plugin that runs work inside individual hooks to a standalone local supervision runtime. That change is only useful if the entire product lifecycle is coherent: install, integration setup, normal use, session resume, crashes, upgrades, teardown, uninstall, purge, and reinstall.
+
+This document defines that lifecycle and the ownership rules behind it.
+
+## 1. Lifecycle at a glance
+
+From the user's point of view:
+
+```text
+UNINSTALLED
+    │
+    │ brew install spotter
+    ▼
+INSTALLED
+    │
+    │ spotter setup codex
+    ▼
+SETTING_UP
+    │
+    ├─ detect / compatibility check
+    ├─ migrate legacy integration
+    ├─ prepare Spotter runtime/service
+    ├─ ensure a usable Codex App Server path
+    ├─ install the minimum required hook surface
+    └─ verify end-to-end health
+    │
+    ▼
+READY
+    │
+    │ codex
+    ▼
+ACTIVE
+    │
+    ├─ observe
+    ├─ update live state
+    ├─ detect
+    ├─ review asynchronously
+    ├─ steer / block when justified
+    └─ persist durable history
+    │
+    ├───────────────┐
+    │               │
+Codex exits     Spotter/Codex upgrade
+    │               │
+    ▼               ▼
+READY           MIGRATING
+                    │
+                    └──────────► READY
+
+READY
+  │
+  │ spotter teardown codex
+  ▼
+INSTALLED
+  │
+  │ brew uninstall spotter
+  ▼
+UNINSTALLED
+
+User data remains until an explicit purge policy removes it.
+```
+
+Internally this is not one lifecycle. It is the composition of several independent ones:
+
+```text
+Spotter package
+Spotter agent integration
+spotterd
+Codex App Server
+Codex Thread
+Codex Turn
+Reviewer Job
+Journal / Snapshot / Fork Worktree
+```
+
+Each must have explicit ownership, start/stop semantics, and recovery rules.
+
+## 2. Distribution and release lifecycle
+
+The package lifecycle starts before installation:
+
+```text
+source
+  ↓
+version
+  ↓
+test
+  ↓
+build/package
+  ↓
+release artifacts
+  ↓
+Homebrew formula
+```
+
+The project should version independently evolving contracts rather than treating the package version as sufficient:
+
+```text
+spotter_version
+ipc_protocol_version
+config_schema_version
+journal_schema_version
+label_schema_version
+experiment_schema_version
+integration_manifest_version
+```
+
+This is necessary because upgrades can temporarily produce combinations such as a new CLI talking to an older running daemon or a new reader opening old journals.
+
+### Required implementation
+
+- release automation for supported macOS/Linux artifacts
+- stable package-manager paths for `spotter`, `spotterd`, and `spotter-hook`
+- protocol/version handshakes
+- explicit reader compatibility ranges
+- schema migration rules
+- refusal rather than guessing when a newer incompatible schema is encountered
+
+Do not embed Homebrew Cellar version paths in hooks or service definitions. Use stable `bin`/`opt` paths so upgrades do not leave dead integrations.
+
+## 3. Installation
+
+Target primary installation:
+
+```bash
+brew install spotter
+```
+
+Installation should place the Spotter binaries/runtime on the machine but should not silently mutate Codex, Claude Code, or other agent configuration.
+
+Installation and integration setup are intentionally separate operations:
+
+```text
+brew install spotter     = package operation
+spotter setup codex      = integration operation
+```
+
+This separation keeps both upgrade and uninstall behavior predictable.
+
+Target installed entry points:
+
+```text
+spotter       user CLI / control plane
+spotterd      long-lived supervision runtime
+spotter-hook  minimal synchronous hook bridge, if still required
+```
+
+The current Python package remains the implementation substrate during the migration; a native hook client is an optimization, not a prerequisite.
+
+## 4. First-time agent setup
+
+Target command:
+
+```bash
+spotter setup codex
+```
+
+Setup is the integration installer. It should be idempotent and transactional.
+
+Recommended flow:
+
+```text
+inspect
+  ↓
+plan
+  ↓
+backup
+  ↓
+apply
+  ↓
+verify
+  ↓
+commit integration manifest
+```
+
+A partial failure must not leave duplicate hooks, broken Codex configuration, or a service definition that points at missing binaries.
+
+### Setup responsibilities
+
+1. Detect OS, Spotter version, Codex path/version/install type.
+2. Detect current and legacy Spotter integrations.
+3. Probe required Codex capabilities instead of relying only on a minimum version number.
+4. Choose the verified App Server integration strategy.
+5. Install/register the Spotter user runtime if the selected mode requires it.
+6. Install only the minimum hook surface that remains necessary.
+7. Preserve user configuration and create recoverable backups where appropriate.
+8. Run an end-to-end synthetic health check.
+9. Persist an integration manifest describing exactly what Spotter changed.
+
+### Integration manifest
+
+Spotter needs durable knowledge of its own mutations. Conceptually:
+
+```text
+~/.config/spotter/integrations/codex.json
+```
+
+The manifest should record at least:
+
+```json
+{
+  "schema": 1,
+  "setup_by": "0.x.y",
+  "agent": "codex",
+  "agent_path": "...",
+  "agent_version": "...",
+  "app_server_strategy": "...",
+  "hooks_added": ["PreToolUse"],
+  "service_installed": true,
+  "previous_config_fingerprint": "..."
+}
+```
+
+This is what makes `setup`, `repair`, and `teardown` safe and idempotent.
+
+## 5. The App Server prerequisite
+
+The target Codex architecture requires Spotter to observe and control the **same App Server** used by the user's TUI session.
+
+A plain Codex TUI can use an embedded App Server when no reusable external daemon is available. Once that choice has been made, waking Spotter later at the first tool hook is too late to retroactively create an attachable control plane.
+
+Therefore the first architecture PoC in #66 must choose and validate a canonical external App Server strategy.
+
+Candidate paths:
+
+### A. Reuse Codex-managed App Server daemon
+
+```text
+Codex App Server daemon already/automatically available
+        ↓
+plain `codex` attaches
+        ↓
+Spotter attaches as a second client
+```
+
+### B. Spotter ensures an external App Server process
+
+```text
+Spotter runtime
+    ↓
+external App Server ready
+    ↓
+Codex TUI and Spotter both attach
+```
+
+### C. Embedded/degraded mode
+
+If Spotter cannot acquire the observation/control channel, it must expose that state explicitly instead of looking merely quiet:
+
+```text
+Observation:       unavailable/limited
+Live NUDGE:        unavailable
+INTERRUPT:         unavailable
+PreToolUse gate:   available or unavailable independently
+```
+
+### Ownership rule
+
+An App Server may be shared by consumers other than Spotter.
+
+```text
+pre-existing App Server
+    → attach
+    → never stop it merely because Spotter stops
+
+App Server started during Spotter ensure
+    → record provenance
+    → do not automatically couple its lifetime to spotterd exit
+    → stop only under an explicit, safe cleanup policy
+```
+
+`spotter daemon stop` means “stop Spotter”, not “kill Codex infrastructure”.
+
+## 6. User-login / background-service lifecycle
+
+The original daemon idea was fully lazy: start at the first hook and exit when idle. That conflicts with the target full Codex mode if an external App Server must exist **before** the user types `codex`.
+
+The requirement should be stated independently of mechanism:
+
+> In managed mode, whatever runtime is required for full Spotter observation/control must be ready before an ordinary `codex` invocation chooses its App Server target.
+
+If the App Server PoC confirms that requirement, the likely default is a login-scoped lightweight service:
+
+```text
+user login
+   ↓
+spotterd ready
+   ↓
+ensure external App Server path
+   ↓
+user runs `codex` at any later time
+```
+
+Possible implementations:
+
+- macOS: `launchd`
+- Linux: `systemd --user`
+
+A portable mode may intentionally trade capability for zero persistent service installation:
+
+```bash
+spotter setup codex --portable
+```
+
+Portable mode must report the capabilities it cannot guarantee.
+
+## 7. Normal runtime lifecycle
+
+The hot path should be App Server-driven, not hook-driven:
+
+```text
+Codex App Server event
+        │
+        ▼
+     spotterd
+        │
+        ├─ normalize to Trace IR
+        ├─ update live state
+        ├─ append durable journal
+        └─ run cheap signals
+                  │
+             suspicious?
+             ├─ no
+             └─ yes
+                  ↓
+            Reviewer Job
+```
+
+The journal becomes the durable history and recovery source. It should not be reparsed on every event merely to reconstruct state that the daemon already owns in memory.
+
+### Primary App Server observations
+
+Where available, Spotter should prefer App Server data for:
+
+- thread / turn lifecycle
+- user messages
+- plan updates
+- reasoning summaries exposed by the runtime
+- command execution start/completion
+- tool results and exit status
+- file changes / diffs
+- MCP calls
+- web search
+- token usage
+
+The current 10% observed-outcome ceiling was measured on hook-collected data and must be re-measured after the App Server migration.
+
+## 8. Minimal synchronous hook lifecycle
+
+Codex currently still benefits from one hook class: an execution-before-commit boundary for deterministic policy.
+
+Target steady state:
+
+```text
+PreToolUse
+    │
+    ▼
+spotter-hook
+    │ IPC
+    ▼
+spotterd
+    │
+Gate Engine
+    ├─ ALLOW
+    └─ DENY
+```
+
+Only bounded deterministic checks belong here:
+
+- destructive command policy
+- forbidden paths
+- dependency policy
+- workspace escape
+- similarly auditable rules
+
+Do not put semantic LLM review, large journal replay, full-state reconstruction, or metrics calculations on this synchronous path.
+
+Target hook reduction:
+
+| Hook | Target |
+| --- | --- |
+| `SessionStart` | replace with App Server lifecycle if coverage is sufficient |
+| `UserPromptSubmit` | replace with App Server user-message events |
+| `PreToolUse` | retain for atomic deterministic blocking |
+| `PostToolUse` | replace with App Server result/diff events |
+
+If Codex later exposes a reliable atomic veto primitive through the App Server, a zero-hook integration becomes worth reconsidering.
+
+## 9. Thread, turn, and attachment lifecycle
+
+“Session” is too overloaded for the target runtime. Spotter should distinguish at least:
+
+```text
+Agent Thread
+  └─ Turn
+       └─ Events
+
+Runtime Attachment
+  = one client/runtime attachment to that thread
+```
+
+A thread may continue across multiple TUI launches:
+
+```text
+Thread A
+├─ attachment #1
+│  ├─ turn 1
+│  └─ turn 2
+└─ attachment #2 after resume
+   ├─ turn 3
+   └─ turn 4
+```
+
+Audit state naturally belongs primarily to the thread. Some operational metrics belong to an attachment/run.
+
+The internal identity model should therefore preserve:
+
+```text
+agent_thread_id
+spotter_thread_id (if needed)
+runtime_attachment_id
+turn_id
+```
+
+At first attachment Spotter should journal provenance such as Spotter version, agent/App Server versions, repository, config fingerprint, reviewer configuration, and observed capabilities.
+
+## 10. Semantic review and intervention lifecycle
+
+Semantic supervision runs asynchronously. Main should continue while Spotter thinks.
+
+```text
+signal
+  ↓
+Reviewer Job
+  ↓
+QUEUED → RUNNING → DECIDED
+                    │
+                    ├─ DELIVERED
+                    ├─ STALE
+                    ├─ CANCELLED
+                    └─ FAILED
+```
+
+Every reviewer job is bound to the thread/turn that motivated it.
+
+If the target turn is still active when the verdict arrives:
+
+```text
+VERIFY / NUDGE → turn/steer
+critical case  → later turn/interrupt policy
+```
+
+If the target turn has already ended, the verdict must pass an explicit stale policy rather than being blindly injected into a different turn.
+
+Track at least:
+
+- signal time/step
+- reviewer start/end time
+- target thread/turn
+- delivery attempt
+- delivered/stale/discarded state
+- intervention latency
+
+This makes stale rate and actual supervision latency measurable.
+
+## 11. Turn completion, TUI exit, and resume
+
+### Turn completion
+
+On turn completion:
+
+- clear/update active-turn state
+- finalize turn metrics
+- update validation state
+- mark late reviewer jobs stale or defer them according to policy
+
+The thread remains alive.
+
+### TUI exit
+
+TUI exit closes an attachment, not the durable thread model:
+
+```text
+attachment closed
+      ↓
+thread becomes dormant
+      ↓
+journal/audit state remains
+```
+
+### Resume
+
+On resume:
+
+```text
+existing agent thread
+      ↓
+find Spotter durable history
+      ↓
+hydrate live state
+      ↓
+reconcile with App Server thread state
+      ↓
+continue
+```
+
+Journal replay belongs at recovery/resume boundaries, not on every event.
+
+## 12. Fork and experiment lifecycle
+
+Spotter already uses detached Git worktrees and forked continuations for counterfactual experiments. In the target runtime these remain first-class managed resources.
+
+Conceptual lifecycle:
+
+```text
+CREATED
+  ↓
+RUNNING
+  ↓
+COMPLETE / FAILED
+  ↓
+CLEANED
+```
+
+Lineage should remain explicit:
+
+```text
+parent_thread
+branch_step / branch_turn
+snapshot
+control/guidance arm
+experiment_id
+```
+
+Cleanup must use Git-aware worktree/ref operations rather than deleting directories blindly.
+
+## 13. Crash and degraded-mode lifecycle
+
+### spotterd crash
+
+In managed mode the service manager should be able to restart the runtime:
+
+```text
+spotterd crash
+    ↓
+service restart
+    ↓
+reconnect App Server
+    ↓
+list/reconcile active threads
+    ↓
+hydrate from journal where needed
+    ↓
+READY
+```
+
+During daemon unavailability the synchronous gate must retain the project's fail-open posture unless an explicit stronger policy is introduced later.
+
+### App Server disconnect/crash
+
+Observation/control has its own state machine:
+
+```text
+CONNECTED
+   ↓
+DEGRADED
+   ↓
+RECONNECTING
+   ↓
+CONNECTED or UNAVAILABLE
+```
+
+A healthy `spotterd` with no App Server control plane must not be reported as fully healthy.
+
+Example status:
+
+```text
+Spotter daemon:       running
+Codex App Server:     unavailable
+Observation:          unavailable
+Live intervention:    unavailable
+PreToolUse gate:      active
+```
+
+## 14. Status, doctor, and repair
+
+`spotter status` is the concise runtime view. `spotter doctor` is the diagnostic view.
+
+Target doctor surface:
+
+```text
+Spotter
+  ✓ binary/version
+  ✓ config
+  ✓ storage permissions
+  ✓ daemon/service
+  ✓ IPC
+
+Codex
+  ✓ installed
+  ✓ capability-compatible
+  ✓ external App Server path
+  ✓ Spotter attached
+  ✓ event stream
+  ✓ turn/steer
+  ✓ turn/interrupt (when required)
+  ✓ PreToolUse gate
+
+Data
+  ✓ journal writable
+  ✓ schemas supported
+  ✓ repository/snapshot state
+
+Integration
+  ✓ manifest consistent
+  ✓ no duplicate hooks
+  ✓ stable executable paths
+```
+
+A future `spotter doctor --repair` can repair safe, well-understood drift. Destructive repair should require explicit user intent.
+
+## 15. Configuration lifecycle
+
+A reasonable target precedence is:
+
+```text
+runtime override
+    > repository config
+    > user/global config
+    > defaults
+```
+
+Conceptual locations:
+
+```text
+~/.config/spotter/config.toml
+<repo>/spotter.toml
+CLI/runtime overrides
+```
+
+Configuration fields should declare whether they support hot reload or require runtime/integration restart.
+
+Examples:
+
+```text
+reviewer model/cadence     potentially hot-reloadable
+gate rules                 potentially hot-reloadable
+socket/service strategy    restart required
+agent integration strategy setup/migration required
+```
+
+## 16. Codex upgrade lifecycle
+
+Codex and Spotter have independent release cycles. Spotter should negotiate capabilities rather than assuming one global compatible version.
+
+After a Codex upgrade, independently assess features such as:
+
+```text
+thread/turn events
+command/result visibility
+diff visibility
+turn/steer
+turn/interrupt
+hook veto support
+```
+
+This allows explicit degraded modes:
+
+```text
+Observation:  available
+Steer:        available
+Interrupt:    unsupported
+Gate:         available
+```
+
+The experimental Codex App Server daemon lifecycle must remain behind a `CodexAppServerManager` abstraction so Spotter can change strategy without rewriting the supervision runtime.
+
+## 17. Spotter upgrade lifecycle
+
+Target package update remains package-manager-owned:
+
+```bash
+brew upgrade spotter
+```
+
+A running daemon may still be the previous binary image after the package files change. The control plane therefore needs version negotiation and graceful restart:
+
+```text
+new CLI/hook installed
+      ↓
+connect old spotterd
+      ↓
+version/protocol check
+      ↓
+compatible → continue
+incompatible → graceful daemon restart
+      ↓
+schema migration if required
+      ↓
+App Server reconnect
+      ↓
+READY
+```
+
+`spotter update` should not overwrite Homebrew-owned files. It can check/report availability or delegate to the package manager.
+
+## 18. Schema migration lifecycle
+
+For journals, labels, experiments, config, and integration manifests:
+
+- prefer read-old/write-new compatibility where reasonable
+- migrations must be explicit and versioned
+- destructive migrations should follow backup → migrate → verify → replace
+- older readers encountering unknown newer formats should refuse rather than silently reinterpret them
+- mixed-version durable data needs tests
+
+## 19. Teardown, uninstall, purge, and reinstall
+
+These are intentionally separate operations.
+
+### Agent teardown
+
+```bash
+spotter teardown codex
+```
+
+Teardown should:
+
+- read the integration manifest
+- detach Spotter from Codex observation/control
+- remove only hooks/config changes that Spotter owns
+- restore preserved agent configuration when appropriate
+- remove the integration manifest
+- leave Spotter itself installed
+- not stop a shared Codex App Server merely because Spotter detached
+
+Rule:
+
+> Never delete configuration Spotter did not create or explicitly own.
+
+### Package uninstall
+
+```bash
+brew uninstall spotter
+```
+
+Uninstall removes binaries/package state. It should not silently delete durable user research/history data.
+
+The integration must be resilient even if the user uninstalls without running `teardown` first: a dangling Spotter hook must fail open rather than breaking Codex.
+
+### Purge
+
+An explicit purge handles durable Spotter-owned data/resources:
+
+```bash
+spotter purge --data
+spotter purge --snapshots
+spotter purge --all
+```
+
+Purge may need to clean resources outside `~/.spotter`, including:
+
+- `refs/spotter/*`
+- detached fork worktrees / Git worktree metadata
+- repository-specific state
+
+This implies a repository registry or equivalent provenance store that records which repositories Spotter has touched.
+
+### Reinstall
+
+On reinstall/setup:
+
+```text
+existing Spotter data found
+       ↓
+schema compatible?
+  ├─ yes → reuse
+  └─ no  → migrate or clearly refuse
+```
+
+Setup must remain idempotent and repairable.
+
+## 20. Legacy plugin migration
+
+The current plugin installation is a real migration path, not a hypothetical one.
+
+Target transition:
+
+```text
+old
+Codex plugin hooks
+├─ SessionStart
+├─ UserPromptSubmit
+├─ PreToolUse
+└─ PostToolUse
+
+        ↓ spotter setup codex
+
+new
+External App Server ↔ spotterd
+PreToolUse only (while atomic blocking still needs it)
+```
+
+Migration must detect and remove/replace the legacy integration without double-recording events. Existing `~/.spotter` journals, labels, and experiment data should remain usable whenever their schemas are supported.
+
+## 21. Required components
+
+The lifecycle implies a concrete component set:
+
+| Component | Responsibility |
+| --- | --- |
+| `spotter` | user CLI / control plane |
+| `spotterd` | long-lived supervision runtime |
+| `spotter-hook` | minimal synchronous `PreToolUse` bridge |
+| `ServiceManager` | login/user service lifecycle |
+| `CodexIntegration` | setup/teardown/capability negotiation |
+| `CodexAppServerManager` | discover/ensure/attach App Server strategy |
+| `AppServerClient` | event stream + steer/interrupt control |
+| `SessionManager` | thread/turn/attachment lifecycle |
+| `GateEngine` | synchronous deterministic policy |
+| `SignalEngine` | cheap event-driven candidates |
+| `ReviewerScheduler` | asynchronous semantic review |
+| `InterventionController` | freshness, steer, interrupt policy |
+| `JournalStore` | durable event log |
+| `MigrationManager` | config/schema/integration migration |
+| `IntegrationManifest` | record what Spotter owns/changed |
+| `Doctor` | diagnose and safely repair drift |
+| `RepositoryRegistry` | track repos with Spotter resources |
+| `RetentionManager` | journals, snapshots, forks, logs |
+
+These are responsibility boundaries, not a requirement to create one module/class per row immediately.
+
+## 22. Measurements required across the lifecycle
+
+Architecture migration must be measured, not only described:
+
+- App Server event coverage
+- observable tool-result rate
+- hook invocations per session
+- hook latency p50/p95/p99
+- daemon CPU/memory while idle and active
+- journal write overhead
+- reviewer dispatch latency
+- intervention latency
+- stale intervention rate
+- reconnect/recovery latency
+- upgrade/migration failure rate in fixtures
+- storage growth and retention behavior
+
+## 23. Implementation sequence
+
+The lifecycle suggests this order:
+
+### P0 — App Server lifecycle PoC
+
+```text
+external App Server
+→ plain codex auto-attach
+→ Spotter second client
+→ event stream
+→ active turn identity
+→ turn/steer
+```
+
+If this fails, revisit the architecture before building more runtime semantics.
+
+### P1 — Runtime foundation
+
+- `spotterd`
+- service/lifecycle abstraction
+- App Server manager/client
+- session/thread/turn model
+- IPC
+
+### P2 — Product lifecycle
+
+- package/distribution path
+- `setup` / integration manifest
+- `doctor` / `status`
+- `teardown`
+- migration framework
+
+### P3 — Move existing capabilities into the runtime
+
+- journal
+- audit state
+- deterministic gates
+- snapshots/forks
+- reviewer
+- metrics/labels/experiment
+
+### P4 — Make App Server primary and minimize hooks
+
+- migrate observation to App Server
+- re-measure observability
+- remove `SessionStart`
+- remove `UserPromptSubmit`
+- remove `PostToolUse`
+- keep only bounded `PreToolUse` enforcement if required
+
+### P5 — Complete asynchronous supervision
+
+- event-driven signals
+- asynchronous reviewer scheduling
+- intervention freshness/staleness
+- `turn/steer`
+- later `turn/interrupt`
+
+### P6 — Operational hardening
+
+- crash/reconnect recovery
+- upgrade/schema migration
+- retention/purge
+- reinstall
+- multi-agent integration lifecycle
+
+## 24. Non-goals for the first migration
+
+- rewriting the whole runtime in Rust/Go
+- requiring a native hook client before the daemon design is validated
+- Windows support in the first App Server/daemon integration
+- solving compensating rollback for arbitrary external effects
+- implementing full automatic `RESTART` as part of the architecture migration
+- claiming positive intervention value before the evaluation task set and experiments produce evidence

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,15 +1,89 @@
 # Lifecycle and Operations
 
-> **Status:** target design, tracked by [#66](https://github.com/Bogyie/spotter/issues/66).  
-> The current prototype is still hook/plugin-centered. This document defines the lifecycle Spotter should converge on; it is not a claim that every command or runtime component described here ships today.
+> **Status:** target design tracked by [#66](https://github.com/Bogyie/spotter/issues/66).  
+> The current prototype is still hook/plugin-centered. Commands such as Homebrew installation, managed `spotterd`, and full App Server integration described here are the **intended product lifecycle**, not current shipping behavior.
 
-Spotter is moving from an agent plugin that runs work inside individual hooks to a standalone local supervision runtime. That change is only useful if the entire product lifecycle is coherent: install, integration setup, normal use, session resume, crashes, upgrades, teardown, uninstall, purge, and reinstall.
+---
 
-This document defines that lifecycle and the ownership rules behind it.
+## 30-second summary
 
-## 1. Lifecycle at a glance
+The user-facing lifecycle should be understandable as four operations:
 
-From the user's point of view:
+```bash
+# 1. Install the product
+brew install spotter
+
+# 2. Integrate an agent once
+spotter setup codex
+spotter doctor
+
+# 3. Use the agent normally
+codex
+
+# 4. Remove the integration/product
+spotter teardown codex
+brew uninstall spotter
+```
+
+Persistent Spotter data is removed only by an explicit purge:
+
+```bash
+spotter purge --all
+```
+
+Ownership is intentionally split:
+
+```text
+brew install / uninstall
+  owns Spotter package files only
+
+spotter setup / teardown
+  owns agent integration changes only
+
+spotterd
+  owns live supervision state
+
+Codex App Server
+  may be shared Codex infrastructure, not Spotter-private state
+
+journals / snapshots / labels / experiments
+  are user data and survive a normal uninstall unless explicitly purged
+```
+
+The most important lifecycle constraint is this:
+
+> **If full Codex mode requires an external App Server, that server must be available before ordinary `codex` chooses its App Server target.**
+
+That can conflict with a completely lazy “wake Spotter on the first Hook” design. P0 must determine the canonical startup strategy before the service lifecycle is finalized.
+
+---
+
+## Quick navigation
+
+| Task | Command / section |
+| --- | --- |
+| Install Spotter | `brew install spotter` → [3. Install](#3-install-package-only) |
+| Connect Codex | `spotter setup codex` → [4. Setup](#4-spotter-setup-codex) |
+| Understand App Server ownership | [5. App Server lifecycle](#5-app-server-lifecycle) |
+| Understand background service startup | [6. Managed runtime startup](#6-managed-runtime-startup) |
+| Normal day-to-day execution | `codex` → [7. Normal runtime](#7-normal-runtime) |
+| Resume/fork an existing thread | [8. Resume, fork, experiment](#8-resume-fork-and-experiment) |
+| Check health | `spotter status`, `spotter doctor` → [9. Status / doctor / repair](#9-status-doctor-and-repair) |
+| Recover from crashes | [10. Failure recovery](#10-failure-recovery) |
+| Upgrade Codex | [11. Codex upgrade](#11-codex-upgrade) |
+| Upgrade Spotter | `brew upgrade spotter` → [12. Spotter upgrade](#12-spotter-upgrade) |
+| Change config | [13. Configuration lifecycle](#13-configuration-lifecycle) |
+| Disconnect Codex | `spotter teardown codex` → [14. Teardown](#14-spotter-teardown-codex) |
+| Uninstall Spotter | `brew uninstall spotter` → [15. Uninstall](#15-brew-uninstall-spotter) |
+| Remove data too | `spotter purge --all` → [16. Purge](#16-purge) |
+| Reinstall safely | [17. Reinstall](#17-reinstall) |
+| Migrate current plugin users | [18. Legacy plugin migration](#18-legacy-plugin-migration) |
+
+---
+
+# 1. Lifecycle state model
+
+## 1.1 User-visible states
 
 ```text
 UNINSTALLED
@@ -17,17 +91,20 @@ UNINSTALLED
     │ brew install spotter
     ▼
 INSTALLED
+    │ package exists
+    │ no agent integration
     │
     │ spotter setup codex
     ▼
 SETTING_UP
     │
-    ├─ detect / compatibility check
-    ├─ migrate legacy integration
-    ├─ prepare Spotter runtime/service
-    ├─ ensure a usable Codex App Server path
-    ├─ install the minimum required hook surface
-    └─ verify end-to-end health
+    ├─ inspect environment
+    ├─ plan mutations
+    ├─ back up owned config fragments
+    ├─ prepare runtime/service
+    ├─ prepare App Server strategy
+    ├─ install minimal Hook surface
+    └─ verify end-to-end
     │
     ▼
 READY
@@ -38,258 +115,474 @@ ACTIVE
     │
     ├─ observe
     ├─ update live state
-    ├─ detect
-    ├─ review asynchronously
-    ├─ steer / block when justified
-    └─ persist durable history
+    ├─ detect/review
+    ├─ steer/block
+    └─ persist history
     │
-    ├───────────────┐
-    │               │
-Codex exits     Spotter/Codex upgrade
-    │               │
-    ▼               ▼
-READY           MIGRATING
-                    │
-                    └──────────► READY
+    ├──────────────┐
+    │              │
+TUI exits      update/failure
+    │              │
+    ▼              ▼
+READY       MIGRATING / RECOVERING
+                   │
+                   └────► READY
 
 READY
-  │
   │ spotter teardown codex
   ▼
 INSTALLED
-  │
   │ brew uninstall spotter
   ▼
 UNINSTALLED
 
-User data remains until an explicit purge policy removes it.
+DATA may remain until explicit purge
 ```
 
-Internally this is not one lifecycle. It is the composition of several independent ones:
+## 1.2 Internal lifecycles
+
+The product composes several independent state machines:
+
+| Resource | Example states |
+| --- | --- |
+| Spotter package | absent / installed / upgrading |
+| Agent integration | absent / setting-up / ready / drifted / tearing-down |
+| `spotterd` | stopped / starting / ready / degraded / recovering |
+| Codex App Server | absent / embedded / external-ready / disconnected |
+| Agent Thread | new / active / dormant / resumed / archived |
+| Turn | started / active / completed / interrupted |
+| Reviewer Job | queued / running / decided / delivered / stale / failed |
+| Snapshot | created / referenced / expired / pruned |
+| Fork Worktree | created / running / complete / orphaned / cleaned |
+
+Never assume that stopping one resource automatically destroys another:
 
 ```text
-Spotter package
-Spotter agent integration
+spotterd stop
+  ≠ Codex App Server stop
+  ≠ journal delete
+  ≠ snapshot delete
+  ≠ integration teardown
+```
+
+---
+
+# 2. Resource ownership
+
+Safe upgrades and removal depend on Spotter knowing what it owns.
+
+## 2.1 Package-owned resources
+
+Installed by the package manager:
+
+```text
+spotter
 spotterd
-Codex App Server
-Codex Thread
-Codex Turn
-Reviewer Job
-Journal / Snapshot / Fork Worktree
+spotter-hook
+package metadata
 ```
 
-Each must have explicit ownership, start/stop semantics, and recovery rules.
+Homebrew owns these files.
 
-## 2. Distribution and release lifecycle
+## 2.2 Integration-owned resources
 
-The package lifecycle starts before installation:
+Conceptual layout:
 
 ```text
-source
-  ↓
-version
-  ↓
-test
-  ↓
-build/package
-  ↓
-release artifacts
-  ↓
-Homebrew formula
+~/.config/spotter/
+  config.toml
+  integrations/
+    codex.json
+    claude.json
 ```
 
-The project should version independently evolving contracts rather than treating the package version as sufficient:
+An `IntegrationManifest` records exactly which agent config fragments Spotter added, removed, or migrated.
+
+## 2.3 Runtime-owned resources
+
+Conceptual:
 
 ```text
-spotter_version
-ipc_protocol_version
-config_schema_version
-journal_schema_version
-label_schema_version
-experiment_schema_version
-integration_manifest_version
+runtime socket
+service registration metadata
+runtime protocol/version metadata
+connection state
 ```
 
-This is necessary because upgrades can temporarily produce combinations such as a new CLI talking to an older running daemon or a new reader opening old journals.
+A PID file may be useful for bookkeeping but should not be the liveness source of truth. A real IPC/socket handshake should be.
 
-### Required implementation
+## 2.4 User data
 
-- release automation for supported macOS/Linux artifacts
-- stable package-manager paths for `spotter`, `spotterd`, and `spotter-hook`
-- protocol/version handshakes
-- explicit reader compatibility ranges
-- schema migration rules
-- refusal rather than guessing when a newer incompatible schema is encountered
+Logical data categories:
 
-Do not embed Homebrew Cellar version paths in hooks or service definitions. Use stable `bin`/`opt` paths so upgrades do not leave dead integrations.
+```text
+session journals
+labels
+experiments
+reviewer spend ledger
+logs
+repository registry
+```
 
-## 3. Installation
+The current prototype stores much of this under `~/.spotter`; migration must preserve or explicitly migrate it.
 
-Target primary installation:
+## 2.5 Repository-owned Spotter resources
+
+Spotter can leave resources outside its home directory:
+
+```text
+refs/spotter/...
+Spotter-created detached worktrees
+snapshot/fork lineage
+```
+
+That is why a true `purge --all` needs a repository registry and Git-aware cleanup.
+
+---
+
+# 3. Install: package only
+
+Target command:
 
 ```bash
 brew install spotter
 ```
 
-Installation should place the Spotter binaries/runtime on the machine but should not silently mutate Codex, Claude Code, or other agent configuration.
+### Preconditions
 
-Installation and integration setup are intentionally separate operations:
+- supported OS/architecture;
+- supported package manager;
+- no requirement that Codex is already installed.
 
-```text
-brew install spotter     = package operation
-spotter setup codex      = integration operation
+### Actions
+
+1. Install `spotter`.
+2. Install `spotterd`.
+3. Install `spotter-hook` if the target build still requires it.
+4. Install package/version metadata.
+
+### Must not happen during package install
+
+Do **not** silently:
+
+- mutate Codex configuration;
+- register Hooks;
+- register a background service;
+- start a Codex App Server;
+- delete or migrate user data.
+
+Package installation and agent integration are separate transactions.
+
+### Success check
+
+```bash
+spotter version
+spotter status
 ```
 
-This separation keeps both upgrade and uninstall behavior predictable.
-
-Target installed entry points:
+Expected state:
 
 ```text
-spotter       user CLI / control plane
-spotterd      long-lived supervision runtime
-spotter-hook  minimal synchronous hook bridge, if still required
+Spotter:      installed 0.x.y
+Daemon:       not configured
+Codex:        detected or not detected
+Integration:  not configured
 ```
 
-The current Python package remains the implementation substrate during the migration; a native hook client is an optimization, not a prerequisite.
+### Implementation required
 
-## 4. First-time agent setup
+- Homebrew formula and release artifacts;
+- stable executable paths;
+- package provenance detection (`homebrew`, source, standalone, etc.);
+- `spotter version`;
+- package-vs-running-daemon version comparison.
 
-Target command:
+---
+
+# 4. `spotter setup codex`
+
+`setup` is the **integration installer**.
 
 ```bash
 spotter setup codex
 ```
 
-Setup is the integration installer. It should be idempotent and transactional.
+It must be **idempotent** and **transactional**.
 
-Recommended flow:
-
-```text
-inspect
-  ↓
-plan
-  ↓
-backup
-  ↓
-apply
-  ↓
-verify
-  ↓
-commit integration manifest
-```
-
-A partial failure must not leave duplicate hooks, broken Codex configuration, or a service definition that points at missing binaries.
-
-### Setup responsibilities
-
-1. Detect OS, Spotter version, Codex path/version/install type.
-2. Detect current and legacy Spotter integrations.
-3. Probe required Codex capabilities instead of relying only on a minimum version number.
-4. Choose the verified App Server integration strategy.
-5. Install/register the Spotter user runtime if the selected mode requires it.
-6. Install only the minimum hook surface that remains necessary.
-7. Preserve user configuration and create recoverable backups where appropriate.
-8. Run an end-to-end synthetic health check.
-9. Persist an integration manifest describing exactly what Spotter changed.
-
-### Integration manifest
-
-Spotter needs durable knowledge of its own mutations. Conceptually:
+## 4.1 Transaction stages
 
 ```text
-~/.config/spotter/integrations/codex.json
+INSPECT
+   ↓
+PLAN
+   ↓
+BACKUP
+   ↓
+APPLY
+   ↓
+START / CONNECT
+   ↓
+VERIFY
+   ↓
+COMMIT MANIFEST
 ```
 
-The manifest should record at least:
+## 4.2 INSPECT
+
+Collect enough information to make a deterministic plan:
+
+```text
+OS / architecture
+Spotter package version and install method
+Codex binary path
+Codex version
+Codex install method
+CODEX_HOME
+existing App Server state
+existing Codex Hook configuration
+legacy Spotter plugin/integration
+existing Spotter integration manifest
+existing Spotter data/schema versions
+```
+
+Probe capabilities rather than relying on one version check:
+
+```text
+thread lifecycle events
+user-message events
+tool start/completion
+tool result/exit status
+diff/file-change events
+token usage
+turn/steer
+turn/interrupt
+PreToolUse veto
+```
+
+## 4.3 PLAN
+
+Build an internal mutation plan before writing anything.
+
+Example:
+
+```text
+Plan
+  App Server strategy: codex-managed-external
+  Runtime mode: managed/login-scoped
+  Hooks:
+    add PreToolUse
+    remove legacy PostToolUse
+    remove legacy UserPromptSubmit
+  Legacy plugin: migrate
+  Existing data: preserve
+  Agent config backup/fingerprint: required
+```
+
+A future dry-run surface is useful:
+
+```bash
+spotter setup codex --dry-run
+```
+
+## 4.4 BACKUP
+
+Before modifying an agent-owned file:
+
+- record a content fingerprint;
+- preserve the specific original fragment Spotter will replace;
+- create a recoverable backup when the mutation API cannot be safely inverted.
+
+Do **not** plan teardown as “restore the entire old file”. The user may legitimately edit the file after Spotter setup.
+
+## 4.5 APPLY
+
+The exact changes depend on the P0-selected App Server strategy. Conceptually:
+
+1. register/prepare the Spotter runtime service if managed mode requires it;
+2. ensure the external App Server path or attach strategy;
+3. prepare Spotter's App Server client connection;
+4. register only the minimum required Hook surface;
+5. remove legacy duplicate Spotter Hooks/plugin wiring;
+6. create/update config/state directories with correct permissions.
+
+## 4.6 START / CONNECT
+
+Bring required runtime components to a testable state:
+
+```text
+spotterd ready
+App Server reachable
+Spotter ↔ App Server initialized
+Hook IPC reachable
+```
+
+## 4.7 VERIFY
+
+A synthetic E2E verification should check at least:
+
+```text
+spotterd handshake succeeds
+App Server initialize succeeds
+Spotter can subscribe/read required event surface
+Hook round-trip succeeds
+journal path is writable and private
+protocol versions are compatible
+schemas are readable
+```
+
+Once live steering is implemented, also verify the control capability without mutating user work unexpectedly.
+
+## 4.8 COMMIT MANIFEST
+
+Only after verification succeeds should the integration become `READY`.
+
+Example manifest:
 
 ```json
 {
   "schema": 1,
-  "setup_by": "0.x.y",
   "agent": "codex",
-  "agent_path": "...",
+  "setup_by": "0.6.0",
+  "agent_path": "/opt/homebrew/bin/codex",
   "agent_version": "...",
-  "app_server_strategy": "...",
+  "app_server_strategy": "codex-managed-external",
+  "runtime_mode": "managed",
   "hooks_added": ["PreToolUse"],
-  "service_installed": true,
-  "previous_config_fingerprint": "..."
+  "legacy_hooks_removed": ["PostToolUse"],
+  "config_fingerprint_before": "...",
+  "created_at": "..."
 }
 ```
 
-This is what makes `setup`, `repair`, and `teardown` safe and idempotent.
+## 4.9 Failure / rollback
 
-## 5. The App Server prerequisite
+| Failure stage | Expected behavior |
+| --- | --- |
+| INSPECT | no mutation |
+| PLAN | no mutation |
+| BACKUP | no mutation |
+| APPLY | roll back Spotter-owned mutations already applied |
+| START/CONNECT | either roll back or leave an explicit incomplete/degraded manifest |
+| VERIFY | do not report READY; preserve actionable diagnostics |
 
-The target Codex architecture requires Spotter to observe and control the **same App Server** used by the user's TUI session.
+A second `spotter setup codex` must reconcile safely from any interrupted setup state.
 
-A plain Codex TUI can use an embedded App Server when no reusable external daemon is available. Once that choice has been made, waking Spotter later at the first tool hook is too late to retroactively create an attachable control plane.
+---
 
-Therefore the first architecture PoC in #66 must choose and validate a canonical external App Server strategy.
+# 5. App Server lifecycle
 
-Candidate paths:
+This is the largest open lifecycle dependency in the target design.
 
-### A. Reuse Codex-managed App Server daemon
+## 5.1 Why startup order matters
+
+Plain `codex` may choose an embedded App Server when no reusable external daemon is present:
 
 ```text
-Codex App Server daemon already/automatically available
-        ↓
-plain `codex` attaches
-        ↓
-Spotter attaches as a second client
+codex starts
+   │
+   ├─ reusable external/default daemon?
+   │      ├─ yes → attach
+   │      └─ no
+   │
+   └─ Embedded App Server
 ```
 
-### B. Spotter ensures an external App Server process
+If Codex has already selected an embedded server, waking Spotter later at the first `PreToolUse` is too late to create an external sidecar observation/control plane for that turn.
+
+## 5.2 Candidate canonical strategies
+
+### Strategy A — Codex-managed daemon
 
 ```text
-Spotter runtime
-    ↓
-external App Server ready
-    ↓
-Codex TUI and Spotter both attach
+ensure Codex App Server daemon
+      ↓
+plain `codex` reuses default daemon
+      ↓
+Spotter attaches as client B
 ```
 
-### C. Embedded/degraded mode
+Advantages:
 
-If Spotter cannot acquire the observation/control channel, it must expose that state explicitly instead of looking merely quiet:
+- follows Codex's own lifecycle tooling;
+- plain `codex` can remain unchanged if default-daemon reuse works reliably.
+
+Risks:
+
+- daemon lifecycle is currently experimental;
+- some CLI/config overrides may disable daemon reuse;
+- Spotter must not assume exclusive ownership.
+
+### Strategy B — Spotter-managed App Server process
 
 ```text
-Observation:       unavailable/limited
+Spotter starts external `codex app-server`
+      ↓
+TUI attaches to explicit/shared endpoint
+      ↓
+Spotter attaches to same endpoint
+```
+
+Advantages:
+
+- lifecycle can be isolated behind `CodexAppServerManager`.
+
+Risks:
+
+- preserving plain `codex` UX may require wrapper/config/service work;
+- version mismatch and process ownership become Spotter concerns.
+
+### Strategy C — Embedded/degraded mode
+
+If no external attachable server can be guaranteed, Spotter must explicitly report reduced capability:
+
+```text
+Observation:       limited/unavailable
 Live NUDGE:        unavailable
 INTERRUPT:         unavailable
-PreToolUse gate:   available or unavailable independently
+PreToolUse gate:   independently available/unavailable
 ```
 
-### Ownership rule
+Silence must never mean both “nothing to report” and “Spotter is disconnected”.
 
-An App Server may be shared by consumers other than Spotter.
+## 5.3 Ownership rule
+
+App Server may be shared with non-Spotter clients.
 
 ```text
 pre-existing App Server
-    → attach
-    → never stop it merely because Spotter stops
+  → attach
+  → never stop merely because Spotter exits
 
-App Server started during Spotter ensure
-    → record provenance
-    → do not automatically couple its lifetime to spotterd exit
-    → stop only under an explicit, safe cleanup policy
+App Server started while Spotter ensures availability
+  → record provenance
+  → do not automatically couple lifetime to spotterd exit
+  → stop only through an explicit safe cleanup policy
 ```
 
-`spotter daemon stop` means “stop Spotter”, not “kill Codex infrastructure”.
+Therefore:
 
-## 6. User-login / background-service lifecycle
+```bash
+spotter daemon stop
+```
 
-The original daemon idea was fully lazy: start at the first hook and exit when idle. That conflicts with the target full Codex mode if an external App Server must exist **before** the user types `codex`.
+means “stop Spotter”, **not** “kill shared Codex infrastructure”.
 
-The requirement should be stated independently of mechanism:
+---
 
-> In managed mode, whatever runtime is required for full Spotter observation/control must be ready before an ordinary `codex` invocation chooses its App Server target.
+# 6. Managed runtime startup
 
-If the App Server PoC confirms that requirement, the likely default is a login-scoped lightweight service:
+The original daemon idea was fully lazy: start on the first Hook, exit when idle. That is attractive operationally but may be incompatible with full Codex App Server observation.
+
+The requirement is mechanism-independent:
+
+> **In managed mode, whatever runtime is required for full observation/control must be ready before ordinary `codex` chooses its App Server target.**
+
+If P0 confirms that an external App Server must already exist, a likely default is a login-scoped user service:
 
 ```text
 user login
    ↓
-spotterd ready
+spotterd starts / becomes available
    ↓
 ensure external App Server path
    ↓
@@ -298,338 +591,407 @@ user runs `codex` at any later time
 
 Possible implementations:
 
-- macOS: `launchd`
-- Linux: `systemd --user`
+- macOS: `launchd`;
+- Linux: `systemd --user`.
 
-A portable mode may intentionally trade capability for zero persistent service installation:
+Do not hard-code these mechanisms into Spotter core. Hide them behind a `ServiceManager` abstraction.
+
+A portable mode may trade capability for zero persistent service registration:
 
 ```bash
 spotter setup codex --portable
 ```
 
-Portable mode must report the capabilities it cannot guarantee.
+Portable mode must display exactly which guarantees are lost.
 
-## 7. Normal runtime lifecycle
+---
 
-The hot path should be App Server-driven, not hook-driven:
+# 7. Normal runtime
+
+## 7.1 Codex launch
+
+Target managed flow:
 
 ```text
-Codex App Server event
+external App Server already reachable
+        │
+user runs `codex`
         │
         ▼
-     spotterd
+TUI attaches to server
         │
-        ├─ normalize to Trace IR
-        ├─ update live state
-        ├─ append durable journal
-        └─ run cheap signals
-                  │
-             suspicious?
-             ├─ no
-             └─ yes
-                  ↓
-            Reviewer Job
+Spotter sees/attaches same thread
+        │
+        ▼
+RuntimeAttachment becomes ACTIVE
 ```
 
-The journal becomes the durable history and recovery source. It should not be reparsed on every event merely to reconstruct state that the daemon already owns in memory.
+## 7.2 Thread initialization
 
-### Primary App Server observations
+For a newly observed thread, Spotter should create live state and a durable provenance header.
 
-Where available, Spotter should prefer App Server data for:
+Suggested provenance:
 
-- thread / turn lifecycle
-- user messages
-- plan updates
-- reasoning summaries exposed by the runtime
-- command execution start/completion
-- tool results and exit status
-- file changes / diffs
-- MCP calls
-- web search
-- token usage
+```text
+Spotter version
+agent binary/version
+App Server version/capabilities
+repository/worktree
+config fingerprint
+reviewer model/config
+runtime attachment id
+start timestamp
+```
 
-The current 10% observed-outcome ceiling was measured on hook-collected data and must be re-measured after the App Server migration.
+## 7.3 Event processing
 
-## 8. Minimal synchronous hook lifecycle
+```text
+App Server event
+      ↓
+normalize to Trace IR
+      ↓
+update ThreadState
+      ├─ append durable journal
+      └─ evaluate cheap signals
+                 │
+            candidate?
+            ├─ no
+            └─ yes → ReviewerJob
+```
 
-Codex currently still benefits from one hook class: an execution-before-commit boundary for deterministic policy.
+## 7.4 Deterministic gate
 
-Target steady state:
+Only the bounded synchronous path uses Hook IPC:
 
 ```text
 PreToolUse
-    │
-    ▼
+  ↓
 spotter-hook
-    │ IPC
-    ▼
-spotterd
-    │
-Gate Engine
-    ├─ ALLOW
-    └─ DENY
-```
-
-Only bounded deterministic checks belong here:
-
-- destructive command policy
-- forbidden paths
-- dependency policy
-- workspace escape
-- similarly auditable rules
-
-Do not put semantic LLM review, large journal replay, full-state reconstruction, or metrics calculations on this synchronous path.
-
-Target hook reduction:
-
-| Hook | Target |
-| --- | --- |
-| `SessionStart` | replace with App Server lifecycle if coverage is sufficient |
-| `UserPromptSubmit` | replace with App Server user-message events |
-| `PreToolUse` | retain for atomic deterministic blocking |
-| `PostToolUse` | replace with App Server result/diff events |
-
-If Codex later exposes a reliable atomic veto primitive through the App Server, a zero-hook integration becomes worth reconsidering.
-
-## 9. Thread, turn, and attachment lifecycle
-
-“Session” is too overloaded for the target runtime. Spotter should distinguish at least:
-
-```text
-Agent Thread
-  └─ Turn
-       └─ Events
-
-Runtime Attachment
-  = one client/runtime attachment to that thread
-```
-
-A thread may continue across multiple TUI launches:
-
-```text
-Thread A
-├─ attachment #1
-│  ├─ turn 1
-│  └─ turn 2
-└─ attachment #2 after resume
-   ├─ turn 3
-   └─ turn 4
-```
-
-Audit state naturally belongs primarily to the thread. Some operational metrics belong to an attachment/run.
-
-The internal identity model should therefore preserve:
-
-```text
-agent_thread_id
-spotter_thread_id (if needed)
-runtime_attachment_id
-turn_id
-```
-
-At first attachment Spotter should journal provenance such as Spotter version, agent/App Server versions, repository, config fingerprint, reviewer configuration, and observed capabilities.
-
-## 10. Semantic review and intervention lifecycle
-
-Semantic supervision runs asynchronously. Main should continue while Spotter thinks.
-
-```text
-signal
   ↓
-Reviewer Job
+spotterd GateEngine
   ↓
-QUEUED → RUNNING → DECIDED
-                    │
-                    ├─ DELIVERED
-                    ├─ STALE
-                    ├─ CANCELLED
-                    └─ FAILED
+ALLOW / DENY
 ```
 
-Every reviewer job is bound to the thread/turn that motivated it.
+No LLM call, broad repository scan, or journal replay belongs here.
 
-If the target turn is still active when the verdict arrives:
+## 7.5 Async reviewer
 
 ```text
-VERIFY / NUDGE → turn/steer
-critical case  → later turn/interrupt policy
+Candidate at turn U7
+  ↓
+ReviewerJob QUEUED → RUNNING
+  ↓
+Main continues
+  ↓
+DECIDED
+  ↓
+U7 still active?
+  ├─ yes → deliver VERIFY/NUDGE
+  └─ no  → stale/defer/discard policy
 ```
 
-If the target turn has already ended, the verdict must pass an explicit stale policy rather than being blindly injected into a different turn.
+Every delivery decision is journaled.
 
-Track at least:
+## 7.6 Turn completion
 
-- signal time/step
-- reviewer start/end time
-- target thread/turn
-- delivery attempt
-- delivered/stale/discarded state
-- intervention latency
+On `turn/completed`:
 
-This makes stale rate and actual supervision latency measurable.
+- clear/update active-turn state;
+- finalize per-turn counters;
+- finalize validation state;
+- re-evaluate jobs targeting that turn;
+- mark late jobs stale if policy requires.
 
-## 11. Turn completion, TUI exit, and resume
+The Thread remains durable.
 
-### Turn completion
+## 7.7 TUI exit
 
-On turn completion:
-
-- clear/update active-turn state
-- finalize turn metrics
-- update validation state
-- mark late reviewer jobs stale or defer them according to policy
-
-The thread remains alive.
-
-### TUI exit
-
-TUI exit closes an attachment, not the durable thread model:
+TUI exit closes a runtime attachment, not the underlying durable thread:
 
 ```text
 attachment closed
       ↓
 thread becomes dormant
       ↓
-journal/audit state remains
+Spotter journal/audit state remains
 ```
 
-### Resume
+---
 
-On resume:
+# 8. Resume, fork, and experiment
+
+## 8.1 Resume
 
 ```text
-existing agent thread
+Codex resumes agent thread T1
       ↓
-find Spotter durable history
+Spotter identifies durable T1 history
       ↓
-hydrate live state
+hydrate missing live state from journal
       ↓
-reconcile with App Server thread state
+reconcile with App Server current state
       ↓
-continue
+create new RuntimeAttachment
 ```
 
-Journal replay belongs at recovery/resume boundaries, not on every event.
+Journal replay is correct here because this is a recovery/reconstruction boundary.
 
-## 12. Fork and experiment lifecycle
+## 8.2 Fork
 
-Spotter already uses detached Git worktrees and forked continuations for counterfactual experiments. In the target runtime these remain first-class managed resources.
+A fork creates explicit lineage:
 
-Conceptual lifecycle:
+```text
+parent_thread
+branch point (turn/step/tool)
+snapshot
+forked rollout/thread
+worktree
+```
+
+Forked worktree lifecycle:
 
 ```text
 CREATED
   ↓
-RUNNING
+RUNNING / PREPARED
   ↓
 COMPLETE / FAILED
   ↓
 CLEANED
 ```
 
-Lineage should remain explicit:
+Cleanup must use Git-aware operations.
+
+## 8.3 Counterfactual experiment
+
+Each experiment pair should record:
 
 ```text
-parent_thread
-branch_step / branch_turn
-snapshot
-control/guidance arm
 experiment_id
+shared prefix
+control prompt/guidance
+intervention prompt/guidance
+check command
+model/config provenance
+result
+cost/timing
 ```
 
-Cleanup must use Git-aware worktree/ref operations rather than deleting directories blindly.
+Do not treat experiment machinery as evidence of positive intervention advantage until enough mechanically scored runs exist.
 
-## 13. Crash and degraded-mode lifecycle
+---
 
-### spotterd crash
+# 9. Status, doctor, and repair
 
-In managed mode the service manager should be able to restart the runtime:
+## 9.1 `spotter status`
 
-```text
-spotterd crash
-    ↓
-service restart
-    ↓
-reconnect App Server
-    ↓
-list/reconcile active threads
-    ↓
-hydrate from journal where needed
-    ↓
-READY
-```
+Designed for a quick operational answer.
 
-During daemon unavailability the synchronous gate must retain the project's fail-open posture unless an explicit stronger policy is introduced later.
-
-### App Server disconnect/crash
-
-Observation/control has its own state machine:
-
-```text
-CONNECTED
-   ↓
-DEGRADED
-   ↓
-RECONNECTING
-   ↓
-CONNECTED or UNAVAILABLE
-```
-
-A healthy `spotterd` with no App Server control plane must not be reported as fully healthy.
-
-Example status:
-
-```text
-Spotter daemon:       running
-Codex App Server:     unavailable
-Observation:          unavailable
-Live intervention:    unavailable
-PreToolUse gate:      active
-```
-
-## 14. Status, doctor, and repair
-
-`spotter status` is the concise runtime view. `spotter doctor` is the diagnostic view.
-
-Target doctor surface:
+Example:
 
 ```text
 Spotter
-  ✓ binary/version
-  ✓ config
-  ✓ storage permissions
-  ✓ daemon/service
-  ✓ IPC
+  package:        0.6.0
+  daemon:         running
+  IPC:            healthy
 
 Codex
-  ✓ installed
-  ✓ capability-compatible
-  ✓ external App Server path
-  ✓ Spotter attached
-  ✓ event stream
-  ✓ turn/steer
-  ✓ turn/interrupt (when required)
-  ✓ PreToolUse gate
+  integration:    ready
+  App Server:     external/shared, connected
+  observation:    healthy
+  live steer:     available
+  PreToolUse:     active
 
-Data
-  ✓ journal writable
-  ✓ schemas supported
-  ✓ repository/snapshot state
-
-Integration
-  ✓ manifest consistent
-  ✓ no duplicate hooks
-  ✓ stable executable paths
+Sessions
+  active:         2
+  dormant:        7
 ```
 
-A future `spotter doctor --repair` can repair safe, well-understood drift. Destructive repair should require explicit user intent.
+## 9.2 `spotter doctor`
 
-## 15. Configuration lifecycle
+Doctor should be diagnostic and synthetic, not just configuration inspection.
 
-A reasonable target precedence is:
+Checks:
 
 ```text
-runtime override
+Spotter
+  binary/package provenance
+  config parse/schema
+  state directory permissions
+  daemon/service registration
+  IPC handshake
+
+Codex
+  binary/version
+  integration manifest consistency
+  App Server reachability
+  capability negotiation
+  same-thread observation path
+  Hook registration
+  synthetic PreToolUse round-trip
+
+Data
+  journal writable
+  supported schema versions
+  repository registry consistency
+  snapshot/worktree sanity
+```
+
+## 9.3 Repair
+
+A future:
+
+```bash
+spotter doctor --repair
+```
+
+may repair safe drift, such as:
+
+- missing Spotter-owned Hook fragment;
+- stale service path after a known package-manager migration;
+- missing owner-only permissions;
+- stale runtime socket after confirmed dead daemon.
+
+Destructive repair requires explicit confirmation or a separate command.
+
+---
+
+# 10. Failure recovery
+
+## 10.1 `spotterd` crash
+
+In managed mode:
+
+```text
+spotterd crashes
+  ↓
+service manager restarts it
+  ↓
+App Server reconnect
+  ↓
+list loaded/active threads
+  ↓
+reconcile current runtime state
+  ↓
+hydrate durable state where needed
+  ↓
+READY
+```
+
+During daemon downtime, the Hook gate remains fail-open unless a future opt-in fail-closed mode is designed separately.
+
+## 10.2 App Server disconnect/crash
+
+Connection state:
+
+```text
+CONNECTED
+  ↓
+DEGRADED
+  ↓
+RECONNECTING
+  ├─ CONNECTED
+  └─ UNAVAILABLE
+```
+
+A running daemon without its observation/control plane is not fully healthy.
+
+## 10.3 Journal write failure
+
+Policy must distinguish:
+
+- inability to persist telemetry/history;
+- inability to answer an atomic safety rule.
+
+A journal failure should surface loudly in status/logs, but should not imply a deny if the gate policy itself can still safely return.
+
+## 10.4 Reviewer/provider failure
+
+```text
+reviewer timeout / model error
+  → ReviewerJob FAILED
+  → no live intervention
+  → Main continues
+  → record error and spend if known
+```
+
+---
+
+# 11. Codex upgrade
+
+Codex and Spotter release independently.
+
+After an upgrade, do capability negotiation rather than assuming compatibility from version strings alone.
+
+Probe at least:
+
+```text
+thread/turn events
+tool start/result events
+diff visibility
+token usage
+turn/steer
+turn/interrupt
+PreToolUse veto
+```
+
+Possible outcome:
+
+```text
+Observation:        healthy
+Tool outcomes:      healthy
+Live steer:         healthy
+Interrupt:          unsupported
+PreToolUse gate:    healthy
+```
+
+This is a valid degraded state; it is better than incorrectly declaring the whole integration either compatible or broken.
+
+`doctor` should detect drift after Codex upgrade and recommend `spotter setup codex` reconciliation if integration files changed.
+
+---
+
+# 12. Spotter upgrade
+
+Target package operation:
+
+```bash
+brew upgrade spotter
+```
+
+Potential transient state:
+
+```text
+CLI binary:      0.7.0
+running spotterd: 0.6.0
+hook helper:      package path now points to 0.7.0
+```
+
+Required behavior:
+
+1. CLI performs daemon protocol/version handshake.
+2. If the running daemon is outside the supported compatibility range, request/recommend a graceful restart.
+3. Stop accepting new long operations if a migration requires exclusivity.
+4. Flush durable state.
+5. Restart daemon using stable package-manager path.
+6. Run schema migrations if needed.
+7. Reconnect App Server.
+8. Reconcile live threads.
+9. Return to READY.
+
+Never write versioned Homebrew Cellar paths into agent Hooks/service definitions. Use stable `bin`/`opt` paths.
+
+`spotter update` should not compete with Homebrew for file ownership. It may check for updates or delegate to the package-manager-supported path.
+
+---
+
+# 13. Configuration lifecycle
+
+Recommended precedence:
+
+```text
+runtime CLI override
     > repository config
     > user/global config
     > defaults
@@ -643,287 +1005,312 @@ Conceptual locations:
 CLI/runtime overrides
 ```
 
-Configuration fields should declare whether they support hot reload or require runtime/integration restart.
+Each configuration field should declare reload semantics.
 
-Examples:
+| Setting class | Likely behavior |
+| --- | --- |
+| reviewer model/budget/cadence | hot reload where safe |
+| signal thresholds | hot reload |
+| deterministic gate rules | hot reload with atomic config swap |
+| socket/runtime path | daemon restart |
+| service strategy | setup/migration required |
+| App Server integration strategy | setup/migration required |
 
-```text
-reviewer model/cadence     potentially hot-reloadable
-gate rules                 potentially hot-reloadable
-socket/service strategy    restart required
-agent integration strategy setup/migration required
-```
+Config reload must not leave half-old/half-new gate policy during a synchronous request. Parse/validate new config first, then atomically replace the active snapshot.
 
-## 16. Codex upgrade lifecycle
+---
 
-Codex and Spotter have independent release cycles. Spotter should negotiate capabilities rather than assuming one global compatible version.
+# 14. `spotter teardown codex`
 
-After a Codex upgrade, independently assess features such as:
-
-```text
-thread/turn events
-command/result visibility
-diff visibility
-turn/steer
-turn/interrupt
-hook veto support
-```
-
-This allows explicit degraded modes:
-
-```text
-Observation:  available
-Steer:        available
-Interrupt:    unsupported
-Gate:         available
-```
-
-The experimental Codex App Server daemon lifecycle must remain behind a `CodexAppServerManager` abstraction so Spotter can change strategy without rewriting the supervision runtime.
-
-## 17. Spotter upgrade lifecycle
-
-Target package update remains package-manager-owned:
-
-```bash
-brew upgrade spotter
-```
-
-A running daemon may still be the previous binary image after the package files change. The control plane therefore needs version negotiation and graceful restart:
-
-```text
-new CLI/hook installed
-      ↓
-connect old spotterd
-      ↓
-version/protocol check
-      ↓
-compatible → continue
-incompatible → graceful daemon restart
-      ↓
-schema migration if required
-      ↓
-App Server reconnect
-      ↓
-READY
-```
-
-`spotter update` should not overwrite Homebrew-owned files. It can check/report availability or delegate to the package manager.
-
-## 18. Schema migration lifecycle
-
-For journals, labels, experiments, config, and integration manifests:
-
-- prefer read-old/write-new compatibility where reasonable
-- migrations must be explicit and versioned
-- destructive migrations should follow backup → migrate → verify → replace
-- older readers encountering unknown newer formats should refuse rather than silently reinterpret them
-- mixed-version durable data needs tests
-
-## 19. Teardown, uninstall, purge, and reinstall
-
-These are intentionally separate operations.
-
-### Agent teardown
+Teardown removes the integration while preserving the Spotter installation and user data.
 
 ```bash
 spotter teardown codex
 ```
 
-Teardown should:
+### Preconditions
 
-- read the integration manifest
-- detach Spotter from Codex observation/control
-- remove only hooks/config changes that Spotter owns
-- restore preserved agent configuration when appropriate
-- remove the integration manifest
-- leave Spotter itself installed
-- not stop a shared Codex App Server merely because Spotter detached
+- package may be installed;
+- integration manifest may be present, missing, or partially drifted.
 
-Rule:
+### Actions
 
-> Never delete configuration Spotter did not create or explicitly own.
+1. Read/reconcile the integration manifest.
+2. Detach Spotter from active Codex observation/control if necessary.
+3. Remove only Spotter-owned Hook/config fragments.
+4. Remove legacy Spotter plugin wiring if it was part of the migrated integration.
+5. Disable/remove Spotter's service integration if no remaining agent needs it.
+6. Preserve session journals, labels, experiments, snapshots unless explicitly requested otherwise.
+7. Remove/mark integration manifest as torn down.
 
-### Package uninstall
+### Critical rule
 
-```bash
-brew uninstall spotter
+> **Do not delete configuration Spotter did not create.**
+
+Do not blindly restore an entire old Codex config file.
+
+### App Server rule
+
+```text
+teardown codex
+  ≠ codex app-server stop
 ```
 
-Uninstall removes binaries/package state. It should not silently delete durable user research/history data.
+A shared App Server may still be used by Codex or other clients.
 
-The integration must be resilient even if the user uninstalls without running `teardown` first: a dangling Spotter hook must fail open rather than breaking Codex.
+---
 
-### Purge
+# 15. `brew uninstall spotter`
 
-An explicit purge handles durable Spotter-owned data/resources:
+Users may uninstall without running teardown first. Codex must not become unusable because a Spotter Hook points at a missing binary.
+
+Desired safety property:
+
+```text
+Spotter helper exists
+  → normal Hook IPC
+
+Spotter helper missing/unavailable
+  → Hook path fails open / no-op
+  → Codex continues
+```
+
+Package uninstall removes package files only.
+
+It should not remove:
+
+- journals;
+- labels;
+- experiments;
+- Git snapshot refs;
+- detached worktree metadata;
+- user configuration unless explicitly owned by package manager.
+
+If package-manager uninstall cannot run lifecycle cleanup reliably, `spotter teardown --all` remains the recommended clean path but not a correctness requirement for Codex availability.
+
+---
+
+# 16. Purge
+
+Purge is the destructive data-cleanup operation.
+
+Examples:
 
 ```bash
 spotter purge --data
 spotter purge --snapshots
+spotter purge --logs
 spotter purge --all
 ```
 
-Purge may need to clean resources outside `~/.spotter`, including:
+`--all` may need to clean resources in repositories, not only `~/.spotter`/state directories.
 
-- `refs/spotter/*`
-- detached fork worktrees / Git worktree metadata
-- repository-specific state
-
-This implies a repository registry or equivalent provenance store that records which repositories Spotter has touched.
-
-### Reinstall
-
-On reinstall/setup:
+Safe order:
 
 ```text
-existing Spotter data found
-       ↓
-schema compatible?
-  ├─ yes → reuse
-  └─ no  → migrate or clearly refuse
+1. identify registered repositories/resources
+2. clean Spotter-created detached worktrees through Git
+3. clean Spotter-owned refs according to explicit policy
+4. remove journals/labels/experiments/logs
+5. remove integration/runtime metadata if requested
+6. remove repository registry last
 ```
 
-Setup must remain idempotent and repairable.
+Purge must support dry-run for repository-affecting cleanup:
 
-## 20. Legacy plugin migration
+```bash
+spotter purge --all --dry-run
+```
 
-The current plugin installation is a real migration path, not a hypothetical one.
+Never remove non-Spotter refs/worktrees based on path guessing.
 
-Target transition:
+---
+
+# 17. Reinstall
+
+A normal reinstall may encounter durable data from an earlier Spotter version.
 
 ```text
-old
-Codex plugin hooks
+brew install spotter
+      ↓
+existing Spotter data found
+      ↓
+schema compatible?
+  ├─ yes → reuse
+  └─ no  → migrate or refuse with actionable error
+```
+
+Then:
+
+```bash
+spotter setup codex
+```
+
+must be safe and idempotent even if old integration fragments remain.
+
+Desired behavior:
+
+- detect prior integration manifest;
+- reconcile rather than duplicate Hooks;
+- preserve journal/label/experiment history;
+- migrate schema explicitly;
+- re-run synthetic doctor checks.
+
+---
+
+# 18. Legacy plugin migration
+
+Current users may already have the hook/plugin integration:
+
+```text
+Legacy
+Codex plugin
 ├─ SessionStart
 ├─ UserPromptSubmit
 ├─ PreToolUse
 └─ PostToolUse
-
-        ↓ spotter setup codex
-
-new
-External App Server ↔ spotterd
-PreToolUse only (while atomic blocking still needs it)
 ```
 
-Migration must detect and remove/replace the legacy integration without double-recording events. Existing `~/.spotter` journals, labels, and experiment data should remain usable whenever their schemas are supported.
-
-## 21. Required components
-
-The lifecycle implies a concrete component set:
-
-| Component | Responsibility |
-| --- | --- |
-| `spotter` | user CLI / control plane |
-| `spotterd` | long-lived supervision runtime |
-| `spotter-hook` | minimal synchronous `PreToolUse` bridge |
-| `ServiceManager` | login/user service lifecycle |
-| `CodexIntegration` | setup/teardown/capability negotiation |
-| `CodexAppServerManager` | discover/ensure/attach App Server strategy |
-| `AppServerClient` | event stream + steer/interrupt control |
-| `SessionManager` | thread/turn/attachment lifecycle |
-| `GateEngine` | synchronous deterministic policy |
-| `SignalEngine` | cheap event-driven candidates |
-| `ReviewerScheduler` | asynchronous semantic review |
-| `InterventionController` | freshness, steer, interrupt policy |
-| `JournalStore` | durable event log |
-| `MigrationManager` | config/schema/integration migration |
-| `IntegrationManifest` | record what Spotter owns/changed |
-| `Doctor` | diagnose and safely repair drift |
-| `RepositoryRegistry` | track repos with Spotter resources |
-| `RetentionManager` | journals, snapshots, forks, logs |
-
-These are responsibility boundaries, not a requirement to create one module/class per row immediately.
-
-## 22. Measurements required across the lifecycle
-
-Architecture migration must be measured, not only described:
-
-- App Server event coverage
-- observable tool-result rate
-- hook invocations per session
-- hook latency p50/p95/p99
-- daemon CPU/memory while idle and active
-- journal write overhead
-- reviewer dispatch latency
-- intervention latency
-- stale intervention rate
-- reconnect/recovery latency
-- upgrade/migration failure rate in fixtures
-- storage growth and retention behavior
-
-## 23. Implementation sequence
-
-The lifecycle suggests this order:
-
-### P0 — App Server lifecycle PoC
+Target migration:
 
 ```text
-external App Server
-→ plain codex auto-attach
-→ Spotter second client
-→ event stream
-→ active turn identity
-→ turn/steer
+spotter setup codex
+      ↓
+detect legacy plugin/hooks
+      ↓
+preserve current data/config
+      ↓
+install standalone runtime integration
+      ↓
+remove observation hooks replaced by App Server
+      ↓
+retain only required PreToolUse gate
 ```
 
-If this fails, revisit the architecture before building more runtime semantics.
+Migration rules:
 
-### P1 — Runtime foundation
+- never register duplicate Spotter Hooks;
+- preserve existing `~/.spotter` data;
+- record which legacy mutations were removed;
+- keep rollback information until verification succeeds;
+- show the migration plan before destructive config changes when ambiguity exists.
 
-- `spotterd`
-- service/lifecycle abstraction
-- App Server manager/client
-- session/thread/turn model
-- IPC
+---
 
-### P2 — Product lifecycle
+# 19. Versioned contracts and schema migration
 
-- package/distribution path
-- `setup` / integration manifest
-- `doctor` / `status`
-- `teardown`
-- migration framework
+Do not overload the package version as the only compatibility identifier.
 
-### P3 — Move existing capabilities into the runtime
+Version independently:
 
-- journal
-- audit state
-- deterministic gates
-- snapshots/forks
-- reviewer
-- metrics/labels/experiment
+```text
+spotter_version
+ipc_protocol_version
+config_schema_version
+journal_schema_version
+label_schema_version
+experiment_schema_version
+integration_manifest_version
+```
 
-### P4 — Make App Server primary and minimize hooks
+Prefer:
 
-- migrate observation to App Server
-- re-measure observability
-- remove `SessionStart`
-- remove `UserPromptSubmit`
-- remove `PostToolUse`
-- keep only bounded `PreToolUse` enforcement if required
+```text
+read old
+write current
+```
 
-### P5 — Complete asynchronous supervision
+where practical.
 
-- event-driven signals
-- asynchronous reviewer scheduling
-- intervention freshness/staleness
-- `turn/steer`
-- later `turn/interrupt`
+For destructive migration:
 
-### P6 — Operational hardening
+```text
+backup
+  ↓
+migrate to temporary/new representation
+  ↓
+validate
+  ↓
+commit/replace
+```
 
-- crash/reconnect recovery
-- upgrade/schema migration
-- retention/purge
-- reinstall
-- multi-agent integration lifecycle
+When a newer incompatible schema is encountered, refuse rather than guessing.
 
-## 24. Non-goals for the first migration
+---
 
-- rewriting the whole runtime in Rust/Go
-- requiring a native hook client before the daemon design is validated
-- Windows support in the first App Server/daemon integration
-- solving compensating rollback for arbitrary external effects
-- implementing full automatic `RESTART` as part of the architecture migration
-- claiming positive intervention value before the evaluation task set and experiments produce evidence
+# 20. Release lifecycle
+
+The user lifecycle starts with a release pipeline:
+
+```text
+source
+  ↓
+tests
+  ↓
+version/tag
+  ↓
+build artifacts
+  ↓
+checksums/signing as applicable
+  ↓
+GitHub Release
+  ↓
+Homebrew formula update
+```
+
+Release verification should include fixtures for:
+
+- clean install;
+- setup;
+- idempotent setup;
+- upgrade with running daemon;
+- schema migration;
+- teardown;
+- uninstall without teardown;
+- reinstall with retained data.
+
+---
+
+# 21. Required implementation components
+
+The lifecycle implies concrete components rather than one monolithic CLI.
+
+| Component | Lifecycle responsibility |
+| --- | --- |
+| `PackageInfo` | detect Spotter install/version/provenance |
+| `IntegrationManager` | setup/teardown/reconcile agent integrations |
+| `IntegrationManifest` | record Spotter-owned mutations |
+| `ServiceManager` | launchd/systemd-user or selected runtime startup mechanism |
+| `CodexAppServerManager` | ensure/discover/attach App Server without assuming ownership |
+| `CapabilityProbe` | determine supported observation/control/enforcement surfaces |
+| `DaemonClient` | CLI ↔ spotterd control protocol |
+| `Doctor` | synthetic health diagnostics |
+| `MigrationManager` | config/journal/label/etc. schema migration |
+| `RepositoryRegistry` | track repositories containing Spotter refs/worktrees |
+| `RetentionManager` | journal/snapshot/log lifecycle |
+| `PurgeManager` | safe destructive cleanup with dry-run |
+
+---
+
+# 22. Lifecycle acceptance checklist
+
+The target lifecycle is not complete until all of these work end-to-end:
+
+- [ ] clean package install does not modify Codex;
+- [ ] `spotter setup codex` is idempotent;
+- [ ] interrupted setup can be resumed/reconciled;
+- [ ] ordinary `codex` requires no manual Spotter/App Server startup in managed mode;
+- [ ] `status` distinguishes daemon, observation, control, enforcement, storage health;
+- [ ] `doctor` performs a real synthetic round-trip;
+- [ ] multiple concurrent threads/sessions remain isolated;
+- [ ] daemon crash recovers without corrupting journal/live state;
+- [ ] Codex upgrade degrades by capability rather than silently breaking;
+- [ ] Spotter upgrade handles a running old daemon and schema migration;
+- [ ] `teardown codex` removes only Spotter-owned integration changes;
+- [ ] uninstall without teardown does not break Codex;
+- [ ] user data survives normal uninstall;
+- [ ] purge can enumerate and safely clean repository resources;
+- [ ] reinstall can reuse/migrate retained data;
+- [ ] legacy plugin users migrate without duplicate events.
+
+For runtime component boundaries, see [Architecture](architecture.md). For implementation sequencing, see [Roadmap](roadmap.md). For current implementation state, see [Status](status.md).

--- a/docs/research.md
+++ b/docs/research.md
@@ -1,487 +1,676 @@
 # Research
 
-Spotter is not based on a single paper. It combines ideas from recent work on runtime supervision, process-level evaluation, online auditing, restart/recovery, verifiable reasoning, claim/evidence tracking, and harness diagnosis.
+> **Purpose:** track the research ideas Spotter borrows, map them to concrete mechanisms, and keep **design inspiration**, **implemented code**, and **measured evidence** separate.
 
-This document has two purposes:
+Spotter is not based on one paper. It combines ideas from runtime supervision, process-level evaluation, online auditing, restart/recovery, verifier-first reasoning, claim/evidence tracking, and harness diagnosis.
 
-1. track the ideas Spotter borrows from prior work;
-2. keep a clear boundary between **design inspiration**, **implemented mechanisms**, and **measured evidence**.
+The central Spotter claim remains unproven:
 
-That distinction matters. Spotter already implements several mechanisms, but its central causal claim—**that runtime intervention improves coding-agent outcomes more than it harms them**—is not yet established.
+> **Runtime intervention improves coding-agent outcomes more than it harms them, at an acceptable cost.**
 
-The standalone-runtime direction in [#66](https://github.com/Bogyie/spotter/issues/66) does not change the research hypothesis. It changes the observation/control substrate so the hypothesis can be tested with better state, timing, and intervention primitives.
-
-## Current evidence posture
-
-Before the literature survey, an honest status summary:
-
-| Claim / mechanism | Status |
-| --- | --- |
-| hook-level trajectory collection | implemented |
-| deterministic pre-action gates | implemented, default-safe/shadow posture |
-| Git snapshot/fork/replay machinery | implemented |
-| model-backed reviewer judgment | implemented in shadow mode |
-| claim/evidence ledger | implemented for observable outcomes |
-| counterfactual experiment machinery | implemented |
-| ground-truth task set and enough executed experiments | **missing** |
-| positive intervention advantage | **not established** |
-| live NUDGE/VERIFY delivery | **not implemented** |
-| event-driven signal → reviewer path | **not implemented** |
-| INTERRUPT / RESTART | **not implemented** |
-| App Server-based observation/control | **target architecture, not implemented** |
-
-The current hook-collected corpus also exposed an observation limitation: only a small fraction of real tool results carried directly usable outcomes for the audit ledger. The target App Server migration should re-measure that ceiling rather than assume it is permanent.
+The standalone-runtime direction in [#66](https://github.com/Bogyie/spotter/issues/66) changes the observation/control substrate used to test that claim. It does not count as evidence for the claim by itself.
 
 ---
 
-## 1. Wink — asynchronous course correction for coding agents
+## 30-second research map
+
+| Work | Main idea Spotter borrows | Spotter mechanism | Current status |
+| --- | --- | --- | --- |
+| **Wink** | async course correction during coding trajectories | shadow reviewer → future live steer | reviewer implemented; live delivery missing |
+| **SWE-PRM** | process-level failure taxonomy | structured candidates/verdicts | partially reflected in reviewer taxonomy |
+| **AgentForesight** | early prefix-only auditing | detection timing / first-deviation metrics | measurement design, not fully executed |
+| **FailFast-RestartSmart** | stop/restart bad trajectories | `INTERRUPT` / `RESTART` | target only |
+| **Calibration Is Not Control** | intervention value matters more than risk score | same-prefix counterfactual experiment | harness implemented; evidence missing |
+| **interwhen** | verify deterministic facts outside LLM | deterministic gate / verifier-first design | implemented for selected policies |
+| **Grounded Continuation** | claim/evidence invalidation | audit ledger + stale propagation | implemented, observation-limited |
+| **AgentProcessBench** | neutral exploration ≠ error | candidates are not verdicts; conservative reviewer | design principle |
+| **HarnessFix** | normalize traces; diagnose harness | Trace IR / adapter boundary | partial implementation / target expansion |
+| **Refute-or-Promote** | falsification beats consensus | evidence-first VERIFY / empirical probes | design principle |
+
+---
+
+## Current evidence posture
+
+Legend: ✅ implemented · 🟡 partial/shadow · 🧪 needs experiment · ❌ missing
+
+| Claim / mechanism | Status | What the evidence actually says |
+| --- | --- | --- |
+| real trajectory collection | ✅ | Spotter records real Codex Hook trajectories |
+| deterministic pre-action policy | ✅ | implemented and hardened with real false-positive cases |
+| snapshot/fork/replay | ✅ | machinery exists and can branch from recorded prefixes |
+| model-backed semantic judgment | ✅ shadow | reviewer produces plausible structured verdicts but does not affect Main |
+| claim/evidence ledger | 🟡 | works only where the observation surface exposes usable outcomes |
+| counterfactual experiment framework | ✅ | machinery exists; not enough executed ground-truth runs |
+| ground-truth task set | ❌ | major current evaluation blocker |
+| positive intervention advantage | ❌ | not established |
+| event-driven reviewer dispatch | ❌ | current reviewer trigger is cadence-based |
+| live `VERIFY / NUDGE` delivery | ❌ | target: `turn/steer` |
+| `INTERRUPT / RESTART` | ❌ | target only |
+| App Server observation/control | 🧪 | P0 architecture PoC required |
+
+The hook-collected corpus exposed a concrete observation limit for the audit ledger: directly usable outcomes were present in only a small fraction of real tool results. The App Server migration must **re-measure** that ceiling instead of assuming it is permanent.
+
+---
+
+## What evidence would change a design decision?
+
+This project should use research questions to make engineering decisions, not just accumulate papers.
+
+| Decision | Evidence required |
+| --- | --- |
+| Replace periodic review with signal-triggered review | similar/better detection with fewer reviewer calls and acceptable miss rate |
+| Enable live NUDGE by default | positive intervention advantage, bounded harm, wrong-nudge resistance |
+| Keep deterministic BLOCK active | near-deterministic precision with measured blind spots and low latency |
+| Add INTERRUPT | high precision in shadow mode + evidence that steer is insufficient for targeted cases |
+| Add automatic RESTART | restart advantage over continue/interrupt + side-effect-safe recovery model |
+| Use a different reviewer model/family | measured reduction in correlated failures after controlling for model strength |
+| Keep App Server architecture | richer observation/control and lower hot-path cost justify lifecycle complexity |
+
+---
+
+# 1. Wink — asynchronous course correction for coding agents
 
 **Wink: Recovering from Misbehaviors in Coding Agents**  
 Rahul Nanda et al., 2026  
 https://arxiv.org/abs/2602.17037
 
-### Why it matters
+## Why it matters
 
-Wink is the closest direct precedent for Spotter's core product idea: observe a coding agent while it works and inject a targeted course correction when its trajectory begins to misbehave.
+Wink is the closest direct precedent to Spotter's product idea: observe a coding agent while it works and inject targeted guidance when the execution trajectory begins to misbehave.
 
-Its framing is important for Spotter because it treats many coding-agent failures as **process failures**, not merely bad final diffs.
+The useful framing is not “another reviewer model.” It is **asynchronous runtime course correction**.
 
-### What Spotter borrows
+## What Spotter borrows
 
-- persistent online observation rather than post-hoc-only review
-- asynchronous course correction during an active coding trajectory
-- a compact taxonomy of coding-agent misbehavior
-- the principle that the observer should normally stay out of Main's way
+- persistent online observation instead of post-hoc-only review;
+- semantic review running mostly outside the main execution path;
+- compact coding-agent failure categories;
+- targeted guidance rather than a full competing implementation;
+- the principle that the observer should usually stay silent.
 
-### Where Spotter intends to differ
+## Where Spotter differs or extends
 
-| Extension | Spotter status |
+| Extension | Status |
 | --- | --- |
-| deterministic pre-action blocking | implemented in the prototype |
-| independent claim/evidence state | implemented, limited by observation coverage |
-| stronger interruption/restart | not implemented |
-| action-conditioned intervention choice | not implemented as a complete policy |
+| deterministic pre-action blocking | implemented in prototype |
+| independent claim/evidence state | implemented, observation-limited |
+| same-prefix causal evaluation | experiment harness implemented |
+| event-driven cheap signal layer | not implemented |
+| live steer delivery | not implemented |
+| interrupt/restart | not implemented |
 | explicit external side-effect handling | not implemented |
 
-The project should not present the unimplemented rows as delivered differentiators.
+## Architecture consequence
 
-### Architecture implication
+Semantic supervision should stay asynchronous. In the target architecture:
 
-Wink reinforces the decision that semantic supervision should be asynchronous. In the target architecture, App Server events feed `spotterd`; the reviewer runs in parallel; soft guidance is delivered only when ready and still relevant.
+```text
+App Server event
+  ↓
+spotterd signal
+  ↓
+reviewer in parallel
+  ↓
+verdict still relevant?
+  ├─ yes → live steer
+  └─ no  → stale/discard
+```
+
+This is one reason to move semantic supervision out of per-hook processes.
 
 ---
 
-## 2. SWE-PRM — process reward models for SWE trajectory correction
+# 2. SWE-PRM — process reward models for SWE trajectory correction
 
 **When Agents go Astray: Course-Correcting SWE Agents with PRMs**  
 Shubham Gandhi et al., 2025  
 https://arxiv.org/abs/2509.02360
 
-### Why it matters
+## Why it matters
 
-SWE-PRM treats software-engineering failures as trajectory-level problems and applies inference-time process supervision to redundant exploration, loops, premature stopping, and related inefficiencies.
+SWE-PRM treats software-engineering agent failures as **trajectory-level process problems**, including redundant exploration, loops, premature stopping, and other execution inefficiencies.
 
-### What Spotter borrows
+## What Spotter borrows
 
-- process-level failure categories
-- inference-time correction without retraining Main
-- interpretable feedback rather than a full competing implementation
-- evaluation of trajectory efficiency as well as final success
+- failure categories attached to execution process rather than final artifact only;
+- inference-time correction without retraining Main;
+- compact interpretable feedback;
+- evaluation of efficiency as well as final success.
 
-### Design lesson
+## Design consequence
 
-Taxonomy-guided feedback is more testable than unconstrained reviewer chatter. Spotter should keep reviewer outputs structured around explicit candidate failures, targets, probes, and control actions.
+Reviewer output should remain structured and testable.
+
+Prefer:
+
+```json
+{
+  "candidate": "POSSIBLE_SPEC_DRIFT",
+  "decision": "VERIFY",
+  "target": "constraint:C2",
+  "reason": "The current edit changes files outside the requested scope.",
+  "probe": "Re-read the explicit scope constraint before continuing."
+}
+```
+
+rather than unrestricted reviewer prose.
+
+Structured categories make it possible to measure precision, misses, harm, latency, and intervention advantage by failure/action class.
 
 ---
 
-## 3. AgentForesight — online auditing and early failure prediction
+# 3. AgentForesight — online auditing and early failure prediction
 
 **AgentForesight: Online Auditing for Early Failure Prediction in Multi-Agent Systems**  
 Boxuan Zhang et al., 2026  
 https://arxiv.org/abs/2605.08715
 
-### Why it matters
+## Why it matters
 
-AgentForesight frames auditing as a prefix-only problem: decide from the trajectory so far whether a meaningful failure has become visible, without relying on future hindsight.
+AgentForesight emphasizes **prefix-only** judgment. A runtime auditor cannot rely on knowing what happens later; it must decide from the trajectory that is visible now.
 
-### What Spotter borrows
+## What Spotter borrows
 
-- prefix-only judgment
-- timing as a first-class objective
-- the distinction between eventually detecting a failure and detecting it early enough to matter
+- evaluate from the current prefix, not hindsight;
+- separate “eventually detected” from “detected early enough to matter”;
+- measure the first point where intervention becomes warranted/possible.
 
-### Design lesson
+## Metrics implied by this work
 
-Spotter should report **regret / wasted actions before intervention** and intervention latency. A detector that is always correct twenty steps too late is not necessarily useful.
+Spotter should measure:
 
-The daemon/App Server architecture improves the ability to measure real wall-clock timing because events and intervention delivery can carry explicit timestamps instead of only journal order.
+```text
+first warranted intervention point
+first observable intervention point
+actual detection point
+reviewer decision point
+actual delivery point
+```
+
+From those timestamps/steps we can derive:
+
+- detection delay;
+- reviewer latency;
+- delivery latency;
+- wasted tool calls/actions;
+- stale intervention rate.
+
+A reviewer that is correct twenty actions late may be useless as a controller.
 
 ---
 
-## 4. FailFast-RestartSmart — stop bad trajectories and restart cleanly
+# 4. FailFast-RestartSmart — stop bad trajectories and restart cleanly
 
 **Fail-Fast, Restart-Smart: Early Failure Prediction and Restart for SWE Agentic Tasks**  
 Chenyu Wang et al., 2026  
 https://arxiv.org/abs/2608.03222
 
-### Why it matters
+## Why it matters
 
-This line of work asks whether a trajectory can become bad enough that continuing inside the same reasoning context is less useful than starting a fresh rollout while deliberately preserving useful external state.
+This line of work motivates a control primitive stronger than guidance: sometimes continuing inside the same reasoning context is worse than abandoning it and starting again from selected state.
 
-### What Spotter borrows
+## What Spotter borrows
 
-- `RESTART` as a primitive distinct from `NUDGE`
-- the possibility that reasoning context becomes contaminated
-- preservation of useful repository state without blindly preserving the whole failed trajectory
-- stricter false-positive budgets for stronger control
+- `RESTART` is distinct from `NUDGE`;
+- reasoning context can become contaminated by stale assumptions;
+- useful repository state can be preserved without preserving the failed reasoning history;
+- strong actions require stricter false-positive budgets.
 
-### Design lesson
+## Preconditions before Spotter can implement RESTART responsibly
 
-Restart is not “send another message to the same context.” It is a state-selection problem.
+```text
+verified-state representation
+last-sound-state / branch-point model
+snapshot/checkpoint lineage
+explicit retained artifacts
+external side-effect ledger
+fresh continuation mechanism
+```
 
-Before Spotter implements it, the runtime needs:
+The daemon architecture makes these boundaries easier to represent, but does not solve them automatically.
 
-- verified-state representation
-- checkpoint lineage
-- explicit retained artifacts
-- external side-effect accounting
+## Evaluation requirement
 
-The target long-lived runtime makes those state boundaries more explicit, but does not solve them automatically.
+Compare from the same prefix:
+
+```text
+continue
+vs
+NUDGE
+vs
+INTERRUPT + replan
+vs
+RESTART from verified state
+```
+
+RESTART should not exist simply because it is technically possible.
 
 ---
 
-## 5. Calibration Is Not Control — intervention advantage
+# 5. Calibration Is Not Control — intervention advantage
 
 **Calibration Is Not Control: Why LLM-Agent Oversight Needs Intervention**  
 Chubin Zhang et al., 2026  
 https://arxiv.org/abs/2606.21399
 
-### Why it matters
+## Why it matters
 
-Failure probability is not the same thing as control value. Two prefixes can look equally risky while only one benefits from intervention.
+Predicting “this trajectory is likely to fail” is not the same as knowing that an intervention will help.
 
-The relevant question is closer to:
+Two prefixes with similar failure probability can have very different control value:
 
-> What is the expected outcome if we intervene now compared with letting this exact prefix continue?
+```text
+Prefix A
+  high risk, but one focused VERIFY may recover it
 
-### What Spotter borrows
+Prefix B
+  high risk, but an intervention may only distract Main
+```
 
-- optimize for useful intervention, not maximum alarm rate
-- condition the decision on the available action (`continue`, `verify`, `nudge`, `interrupt`, ...)
-- use same-prefix branching to estimate intervention advantage
+## Spotter consequence
 
-### Current Spotter status
+The decision target should be closer to:
 
-The repository already has machinery for same-prefix counterfactual pairs, but the project still lacks a ground-truth task set and enough executed runs to make a causal claim.
+> **Expected outcome if we take action X now minus expected outcome if we continue.**
 
-This is one of the most important current evidence gaps.
+That leads to action-conditioned evaluation:
+
+```text
+Advantage(VERIFY | prefix)
+Advantage(NUDGE  | prefix)
+Advantage(BLOCK  | proposal)
+Advantage(INTERRUPT | prefix)
+```
+
+## Current status
+
+Spotter already has same-prefix counterfactual experiment machinery. The missing pieces are:
+
+- mechanically scored tasks;
+- enough executed pairs;
+- replay/fork fidelity measurement;
+- cost/timing accounting;
+- harm classification.
+
+This is one of the largest gaps between “implemented system” and “proven product value.”
 
 ---
 
-## 6. interwhen — verifier-first runtime supervision
+# 6. interwhen — verifier-first runtime supervision
 
 **interwhen: A Generalizable Framework for Verifiable Reasoning with Test-time Monitors**  
 Vishak K. Bhat et al., 2026  
 https://arxiv.org/abs/2602.11202  
 Code: https://github.com/microsoft/interwhen
 
-### Why it matters
+## Why it matters
 
-interwhen separates verifiable properties from broad free-form reasoning and uses monitors only where they add information.
+Some properties can be verified directly; they do not need broad model judgment.
 
-### What Spotter borrows
+## What Spotter borrows
 
-- turn deterministic properties into executable checks
-- use external/verifiable evidence before semantic debate
-- avoid forcing all reasoning into a rigid schema
-- call the semantic reviewer only for what code cannot decide cheaply
+- extract deterministic properties into executable checks;
+- prefer external/verifiable evidence over debate;
+- keep semantic model calls selective;
+- do not force all reasoning into a rigid formal schema.
 
-### Architecture implication
-
-This supports Spotter's split between:
+## Architecture mapping
 
 ```text
 PreToolUse synchronous gate
-  = narrow, deterministic, bounded
+  deterministic
+  bounded
+  no model call
 
-Async reviewer
-  = semantic, selective, parallel to Main
+Async semantic reviewer
+  ambiguity
+  context-sensitive
+  only when cheap signals justify it
 ```
+
+## Product implication
+
+One useful metric is **semantic-review avoidance**: what fraction of useful supervision decisions can be resolved without an LLM call?
+
+That directly affects latency and cost.
 
 ---
 
-## 7. Grounded Continuation — claim/evidence dependency tracking
+# 7. Grounded Continuation — claim/evidence dependency tracking
 
 **Grounded Continuation: A Linear-Time Runtime Verifier for LLM Conversations**  
 Qisong He, Yi Dong, Xiaowei Huang, 2026  
 https://arxiv.org/abs/2605.14175
 
-### Why it matters
+## Why it matters
 
-Grounded Continuation maintains explicit relationships between claims and evidence. When evidence is retracted, conclusions that depended on it can become stale.
+The core mechanism maps naturally to coding trajectories: hypotheses depend on evidence, and when evidence is retracted, downstream conclusions should become stale.
 
-### What Spotter borrows
-
-- evidence-backed hypotheses instead of copying Main's conclusions as truth
-- explicit stale-premise detection
-- transitive invalidation
-
-### Coding example
+## Coding example
 
 ```text
-E1: timeout appears under high concurrency
-        ↓
-H1: Redis pool exhaustion is the cause
-        ↓
-P1: modify Redis pool configuration
+E1: timeout correlates with high concurrency
+        ↓ supports
+H1: Redis pool exhaustion causes timeout
+        ↓ motivates
+P1: change Redis pool configuration
 
-new evidence:
+new evidence
 E2: stack trace points to upstream HTTP client
 
-→ H1 becomes stale
+→ H1 stale
 → P1 requires revalidation
 ```
 
-### Current Spotter status
+## Current Spotter status
 
-The prototype implements a typed audit ledger and stale propagation. Its practical reach is bounded by the observable event surface. Moving to richer App Server events is therefore not only an architecture cleanup; it is an experiment in whether the evidence graph becomes materially more useful.
+The prototype implements a typed claim/evidence audit ledger with transitive stale propagation for observable outcomes.
+
+The practical limitation is observation coverage. If the runtime does not expose reliable outcomes, the ledger correctly remains silent rather than inventing pass/fail.
+
+## App Server hypothesis
+
+The App Server migration creates a measurable question:
+
+> Does richer event/result visibility materially increase the fraction of useful claims that can be grounded and invalidated mechanically?
+
+That must be measured after P4.
 
 ---
 
-## 8. AgentProcessBench — neutral exploration is not failure
+# 8. AgentProcessBench — neutral exploration is not failure
 
 **AgentProcessBench: Diagnosing Step-Level Process Quality in Tool-Using Agents**  
 Shengda Fan et al., 2026  
 https://arxiv.org/abs/2603.14465  
 Code/data: https://github.com/RUCBM/AgentProcessBench
 
-### Why it matters
+## Why it matters
 
-Real tool-using trajectories contain actions that are not obviously useful but are also not errors. Current models can struggle to distinguish neutral exploration from genuine failure.
+Real tool-use contains steps that are neither clearly useful nor clearly wrong. Exploration may look inefficient from a short window but still be justified.
 
-### What Spotter borrows
+## What Spotter borrows
 
-- uncertainty/neutrality must exist in the reviewer worldview
-- repeated reads are not automatically a loop
-- early intervention should be conservative around ambiguous exploration
+- neutral/uncertain behavior must exist in the reviewer worldview;
+- repetition is a signal, not an automatic verdict;
+- early intervention should be conservative around ambiguous exploration.
 
-### Design lesson
+## Signal-engine consequence
 
-> “The agent is taking a while” is not itself a failure signal.
+Bad:
 
-This is especially relevant for the planned cheap Signal Engine: signals must produce candidates, not verdicts.
+```text
+same file read three times
+→ EXPLORATION_LOOP
+→ NUDGE
+```
+
+Better:
+
+```text
+same semantic read repeated
++ no frontier expansion
++ no new evidence recorded
+→ POSSIBLE_EXPLORATION_LOOP
+→ reviewer decides whether intervention is warranted
+```
+
+This is why P5 separates cheap signal generation from semantic verdicts.
 
 ---
 
-## 9. HarnessFix — normalize traces and diagnose the harness too
+# 9. HarnessFix — normalize traces and diagnose the harness too
 
 **From Failed Trajectories to Reliable LLM Agents: Diagnosing and Repairing Harness Flaws**  
 Mengzhuo Chen et al., 2026  
 https://arxiv.org/abs/2606.06324
 
-### Why it matters
+## Why it matters
 
-HarnessFix compiles raw execution traces into a harness-aware intermediate representation and reasons about failures across both agent behavior and harness structure.
+Runtime failures can come from Main, but also from the harness/observer itself. A normalized representation helps reason across both.
 
-### What Spotter borrows
+## What Spotter borrows
 
-- normalize raw runtime streams into a backend-independent Trace IR
-- keep provenance between normalized state and runtime events
-- distinguish Main failure from Spotter/harness failure
+- normalize backend-specific runtime streams into Trace IR;
+- preserve provenance from normalized records back to raw events;
+- distinguish Main failure from Spotter/harness failure;
+- eventually diagnose recurring harness problems rather than endlessly nudging Main.
 
-### Architecture implication
+## Architecture consequence
 
-The move from hooks to App Server should not leak Codex event shapes throughout Spotter core. The adapter should normalize events so the runtime, reviewer, metrics, and replay machinery remain transport-independent.
+The App Server migration must not replace one coupling with another.
 
-A repeated Spotter diagnosis may eventually imply that the right fix is a harness change rather than another intervention.
+Bad:
+
+```text
+Codex App Server JSON fields
+  scattered through GateEngine / Reviewer / Metrics / Replay
+```
+
+Target:
+
+```text
+Codex raw events
+  ↓
+CodexAdapter
+  ↓
+Trace IR
+  ↓
+Spotter core
+```
+
+This keeps another coding-agent adapter possible later.
 
 ---
 
-## 10. Refute-or-Promote — falsification and empirical gates
+# 10. Refute-or-Promote — falsification and empirical gates
 
 **Refute-or-Promote: An Adversarial Stage-Gated Multi-Agent Review Methodology for High-Precision LLM-Assisted Defect Discovery**  
 Abhinav Agarwal, 2026  
 https://arxiv.org/abs/2604.19049
 
-### Why it matters
+## Why it matters
 
-This work emphasizes killing candidate findings before promoting them and illustrates the danger of correlated model agreement without empirical evidence.
+Multiple models can agree on a wrong claim. Empirical evidence can eliminate the claim cheaply.
 
-### What Spotter borrows
+## What Spotter borrows
 
-- try to falsify a consequential Main hypothesis rather than produce a competing solution
-- treat cross-model diversity as a possible way to reduce correlated blind spots
-- rank empirical verification above model consensus
+- try to falsify consequential hypotheses;
+- use a different reviewer/model context as a source of independent challenge, not truth;
+- promote intervention only after sufficient evidence;
+- prefer one decisive test over model consensus.
 
-### Design lesson
+## Product consequence
 
-Ten models agreeing can still be weaker evidence than one decisive test.
+A useful `VERIFY` message should propose the smallest discriminating probe.
+
+```text
+Weak:
+"I think the Redis hypothesis may be wrong."
+
+Better:
+"Before editing Redis settings, inspect the timeout stack trace; no observed result currently ties the timeout to Redis."
+```
 
 ---
 
-# Synthesis
-
-Spotter sits at the intersection of these ideas:
+# Synthesis: how the pieces fit together
 
 ```text
 Wink
-  asynchronous coding-agent observer
-          +
+  async coding-agent supervision
+        +
 SWE-PRM
-  trajectory failure taxonomy
-          +
+  process failure taxonomy
+        +
 AgentForesight
-  early prefix-only auditing
-          +
+  early prefix-only detection
+        +
 FailFast-RestartSmart
-  interrupt + clean restart
-          +
+  interrupt / restart
+        +
 Calibration Is Not Control
-  intervention-value decision policy
-          +
+  intervention advantage
+        +
 interwhen
-  deterministic verifier-first design
-          +
+  verifier-first deterministic checks
+        +
 Grounded Continuation
-  claim/evidence dependency state
-          +
+  claim/evidence invalidation
+        +
 AgentProcessBench
   neutral exploration awareness
-          +
+        +
 HarnessFix
-  normalized Trace IR / harness attribution
-          +
+  Trace IR and harness attribution
+        +
 Refute-or-Promote
-  falsification + empirical gates
+  falsification before promotion
 ```
 
-The target runtime architecture adds an engineering hypothesis underneath that synthesis:
+Spotter adds an engineering hypothesis underneath this research synthesis:
 
 ```text
 rich observation/control stream
-          +
+        +
 long-lived independent state
-          +
-selective async review
-          +
+        +
+selective async semantic review
+        +
 bounded synchronous enforcement
 ```
 
-should be a better substrate for studying runtime supervision than rebuilding state inside independent hook processes.
+may be a better substrate than reconstructing state inside independent Hook processes.
 
-That engineering hypothesis must also be measured: richer infrastructure is not automatically better if its operational cost or fragility outweighs the supervision benefit.
+That engineering hypothesis must be measured too. A richer runtime is a regression if it adds more operational cost/fragility than the supervision benefit it enables.
 
 ---
 
 # Research questions
 
-## RQ1 — Intervention timing
+## RQ1 — Observation surface
 
-How early should a coding-agent trajectory be reviewed?
+How much does moving from Hook-collected events to App Server events change:
 
-Compare:
+- directly visible tool outcomes;
+- goal/constraint availability;
+- failure observability ceiling;
+- event provenance;
+- timing precision;
+- missing/duplicated events?
 
-- periodic asynchronous review
-- event-triggered review
-- synchronous deterministic gate
+**Decision affected:** whether App Server should remain the primary observation plane.
 
-Measure not only detection but wasted actions and wall-clock time before intervention.
+## RQ2 — Intervention timing
 
-## RQ2 — Intervention policy
-
-When is `VERIFY` better than `NUDGE`? When does `INTERRUPT` help? When is `RESTART` better than continuing inside the same reasoning context?
-
-The action should be chosen for expected intervention value, not only failure severity.
-
-## RQ3 — Model diversity
-
-Does a different reviewer model/family reduce correlated failures compared with same-model isolated-context review?
+How early can/will Spotter identify a warranted intervention?
 
 Compare:
 
-- same model / isolated context
-- different model / isolated context
-- smaller specialized reviewer
+- periodic review;
+- event-triggered review;
+- deterministic pre-action gate.
 
-Do not conflate “different family” with “stronger model”.
+Measure wasted actions, not only final detection correctness.
 
-## RQ4 — Reviewer harm and sycophancy
+## RQ3 — Event-driven triggering
 
-How often does Spotter degrade a trajectory that would have succeeded on its own?
-
-Related failure direction: how often does Main comply with a deliberately wrong but plausible Spotter nudge instead of refuting it with evidence?
-
-Both should gate live injection policy.
-
-## RQ5 — Deterministic vs semantic supervision
-
-What fraction of useful supervision can be triggered or resolved by cheap executable checks before an LLM reviewer is needed?
-
-This directly affects latency and cost.
-
-## RQ6 — Observation surface
-
-How much does the move from hook-collected events to App Server events change:
-
-- visible tool outcomes
-- failure observability ceiling
-- goal/constraint availability
-- timing precision
-- trace fidelity
-
-A better reviewer cannot compensate for missing evidence.
-
-## RQ7 — Event-driven triggering
-
-Can cheap candidate signals reduce reviewer calls without reducing useful detection?
+Can cheap signals reduce reviewer calls without materially increasing misses?
 
 Sweep:
 
-- signal thresholds
-- fallback cadence
-- reviewer calls/session
-- detection latency
-- precision/miss rate
-- token cost
+```text
+signal threshold
+fallback cadence
+reviewer calls/session
+detection delay
+precision
+sampled miss rate
+reviewer tokens
+```
+
+**Decision affected:** P5 signal policy.
+
+## RQ4 — Intervention policy
+
+When is `VERIFY` better than `NUDGE`? When does `INTERRUPT` outperform soft steering? When does `RESTART` outperform continuation?
+
+**Decision affected:** intervention ladder thresholds.
+
+## RQ5 — Reviewer harm and wrong-nudge susceptibility
+
+Two directions matter:
+
+1. Spotter interrupts a trajectory that would have succeeded.
+2. Main obeys plausible but wrong Spotter guidance instead of refuting it with evidence.
+
+Both should gate live injection.
+
+## RQ6 — Model diversity
+
+Does a different reviewer family reduce correlated blind spots after controlling for model capability?
+
+Compare:
+
+```text
+same model + isolated context
+different model + isolated context
+smaller specialized reviewer
+```
+
+Do not confuse “different” with “weaker” or “stronger”.
+
+## RQ7 — Deterministic vs semantic supervision
+
+What fraction of useful supervision can be resolved by executable checks before an LLM is required?
+
+**Decision affected:** cost/latency budget and which policies belong in GateEngine.
 
 ## RQ8 — Runtime overhead
 
-Does the standalone runtime reduce hot-path cost enough to justify its operational complexity?
+Does the standalone runtime reduce hot-path cost enough to justify lifecycle complexity?
 
 Measure:
 
-- hook p50/p95/p99 before/after
-- App Server processing overhead
-- idle/active daemon CPU and memory
-- reconnect/recovery latency
-- additional failure modes introduced by the runtime
+```text
+Hook p50/p95/p99 before/after
+reviewer dispatch latency
+App Server processing overhead
+idle/active daemon CPU/memory
+reconnect/recovery latency
+additional failure modes
+```
 
 ## RQ9 — Replay/fork fidelity
 
-How similar is a forked continuation to what the original prefix would have produced without intervention?
+How noisy is the counterfactual instrument itself?
 
-Before causal claims rely on forks, establish:
+Measure:
 
-- identical-arm noise floor
-- continuation similarity
-- environmental failure rate
+- identical-arm noise floor;
+- repeated continuation similarity;
+- environmental failure rate;
+- detached-worktree effects.
 
-## RQ10 — User experience of supervision
+Intervention deltas smaller than the instrument noise floor should not be overinterpreted.
 
-Correct but annoying supervision can still be a product failure.
+## RQ10 — User experience
 
-Measure or collect:
+Correct supervision can still be a bad product if it is confusing or annoying.
 
-- dismiss/disagree signals
-- blocks users override
-- interventions perceived as useful vs disruptive
-- whether the user can understand when Spotter is active, degraded, or disconnected
+Collect/measure:
+
+- dismiss/disagree signals;
+- overridden blocks;
+- perceived usefulness vs disruption;
+- whether users can tell healthy silence from disconnected silence;
+- whether setup/daemon lifecycle becomes operationally burdensome.
 
 ---
 
 # Evaluation matrix
 
-The eventual comparison should include at least:
+Eventually compare at least:
 
 ```text
 A. Vanilla coding agent
@@ -490,7 +679,7 @@ B. Periodic async reviewer
    fixed cadence, soft guidance
 
 C. Event-driven Spotter
-   cheap signals + semantic reviewer
+   cheap candidates + semantic reviewer
 
 D. Spotter + deterministic gate
    event-driven + PreToolUse enforcement
@@ -499,97 +688,63 @@ E. Full Spotter
    gate + steer + stronger interrupt/recovery primitives
 ```
 
-The runtime substrate should be held constant where possible when comparing supervision policy, otherwise architecture changes become a confound.
-
-## Primary metrics
-
-### Outcome
-
-- task resolution
-- regression rate
-
-### Efficiency
-
-- main-agent tokens
-- reviewer tokens
-- tool-call count
-- repeated-action count
-- elapsed/tool time
-- Spotter CPU/memory
-
-### Observation quality
-
-- event coverage
-- observable outcome rate
-- failure observability ceiling
-- missing goal/constraint rate
-- liveness / disconnect rate
-
-### Intervention quality
-
-- intervention precision
-- sampled miss rate / recall estimate
-- intervention advantage
-- harm rate
-- recovery rate
-- ignored-intervention rate
-
-### Timing
-
-- wasted actions before intervention
-- reviewer latency
-- delivery latency
-- stale intervention rate
-
-### Recovery
-
-- success after nudge
-- success after interrupt
-- success after restart
-- useful work retained
-- external state left unreverted
+Hold the runtime substrate constant where possible when comparing supervision policy, otherwise architecture changes become a confound.
 
 ---
 
-# Evidence gates for stronger behavior
+# Primary metrics
 
-The project should continue using an “earn the right to intervene” progression:
+| Dimension | Metrics |
+| --- | --- |
+| Outcome | task resolution, regression rate |
+| Main efficiency | main tokens, tool calls, repeated actions, elapsed/tool time |
+| Spotter cost | reviewer tokens/calls, CPU/memory, storage growth |
+| Observation | event coverage, observable outcome rate, missing goal/constraint rate, disconnect rate |
+| Detection | precision, FP rate, sampled miss rate/recall, abstention/blind spots |
+| Intervention | advantage, harm rate, recovery rate, ignored rate |
+| Timing | detection delay, reviewer latency, delivery latency, stale rate, wasted actions |
+| Recovery | success after nudge/interrupt/restart, useful work retained, external effects unreverted |
+| Operations | Hook latency, reconnect/recovery time, upgrade/migration failure rate |
+
+---
+
+# Evidence gates
+
+Strong mechanisms should not become default behavior merely because they exist.
 
 ```text
-observe
-  ↓
-measure detector/reviewer quality
-  ↓
-run counterfactuals
-  ↓
-soft intervention
-  ↓
-measure harm/recovery
-  ↓
-stronger intervention
+VERIFY
+  lowest semantic intervention cost
+  can tolerate uncertainty if it requests concrete evidence
+
+NUDGE
+  require conservative precision + positive harm/advantage evidence
+
+BLOCK
+  deterministic / near-deterministic only
+  measure blind spots separately from FP
+
+INTERRUPT
+  shadow first
+  very high precision/harm threshold
+
+RESTART
+  strongest control
+  requires restart advantage + side-effect-safe state model
 ```
-
-A feature being implemented is not a reason to enable it by default.
-
-Examples:
-
-- deterministic gate: measure per-rule false positives and misses
-- NUDGE/VERIFY: require reviewer quality + intervention-advantage evidence + wrong-nudge behavior
-- INTERRUPT: require substantially stricter precision/harm budget
-- RESTART: require recovery-state/side-effect correctness in addition to reviewer confidence
 
 ---
 
-# Notes on research status
+# Current top evidence gaps
 
-This is a fast-moving area. Several sources above are recent preprints rather than established production standards.
+1. **No ground-truth task set** large enough to run meaningful counterfactual experiments.
+2. **No measured positive intervention advantage** for Spotter guidance.
+3. **No sampled miss-rate/recall estimate** for semantic detector behavior.
+4. **No App Server observability measurement** yet.
+5. **No replay/fork noise-floor measurement** supporting causal interpretation.
+6. **No live wrong-nudge/sycophancy evaluation** before injection.
+7. **No full runtime overhead measurement** for the target architecture.
 
-Spotter should treat them as:
+These gaps should be treated as first-class roadmap items, not post-launch research cleanup.
 
-- design evidence
-- experimental hypotheses
-- useful benchmark ideas
-
-not as proof that every mechanism transfers to Codex, every repository, or every model generation.
-
-The architecture should remain modular enough to remove mechanisms that do not survive measurement. A negative result—such as no measurable intervention advantage, excessive stale interventions, or negligible benefit from model diversity—is a useful project result, not something to hide behind additional complexity.
+For current implementation state, see [Status](status.md). For implementation sequence, see [Roadmap](roadmap.md). For runtime details, see [Architecture](architecture.md).

--- a/docs/research.md
+++ b/docs/research.md
@@ -1,8 +1,38 @@
 # Research
 
-Spotter is not based on a single paper. It combines ideas from several recent lines of work on runtime supervision, process-level evaluation, online auditing, restart/recovery, verifiable reasoning, and harness diagnosis.
+Spotter is not based on a single paper. It combines ideas from recent work on runtime supervision, process-level evaluation, online auditing, restart/recovery, verifiable reasoning, claim/evidence tracking, and harness diagnosis.
 
-This document tracks the most relevant prior work and the concrete ideas Spotter intends to borrow.
+This document has two purposes:
+
+1. track the ideas Spotter borrows from prior work;
+2. keep a clear boundary between **design inspiration**, **implemented mechanisms**, and **measured evidence**.
+
+That distinction matters. Spotter already implements several mechanisms, but its central causal claim—**that runtime intervention improves coding-agent outcomes more than it harms them**—is not yet established.
+
+The standalone-runtime direction in [#66](https://github.com/Bogyie/spotter/issues/66) does not change the research hypothesis. It changes the observation/control substrate so the hypothesis can be tested with better state, timing, and intervention primitives.
+
+## Current evidence posture
+
+Before the literature survey, an honest status summary:
+
+| Claim / mechanism | Status |
+| --- | --- |
+| hook-level trajectory collection | implemented |
+| deterministic pre-action gates | implemented, default-safe/shadow posture |
+| Git snapshot/fork/replay machinery | implemented |
+| model-backed reviewer judgment | implemented in shadow mode |
+| claim/evidence ledger | implemented for observable outcomes |
+| counterfactual experiment machinery | implemented |
+| ground-truth task set and enough executed experiments | **missing** |
+| positive intervention advantage | **not established** |
+| live NUDGE/VERIFY delivery | **not implemented** |
+| event-driven signal → reviewer path | **not implemented** |
+| INTERRUPT / RESTART | **not implemented** |
+| App Server-based observation/control | **target architecture, not implemented** |
+
+The current hook-collected corpus also exposed an observation limitation: only a small fraction of real tool results carried directly usable outcomes for the audit ledger. The target App Server migration should re-measure that ceiling rather than assume it is permanent.
+
+---
 
 ## 1. Wink — asynchronous course correction for coding agents
 
@@ -12,32 +42,32 @@ https://arxiv.org/abs/2602.17037
 
 ### Why it matters
 
-Wink is the closest direct precedent for Spotter's core product idea.
+Wink is the closest direct precedent for Spotter's core product idea: observe a coding agent while it works and inject a targeted course correction when its trajectory begins to misbehave.
 
-It studies production coding-agent trajectories and identifies three broad misbehavior classes:
-
-- specification drift
-- reasoning problems
-- tool-call failures
-
-The paper reports that these misbehaviors appear in roughly 30% of observed production trajectories. Wink adds a lightweight asynchronous observer that watches the coding agent and injects targeted course-correction guidance when it detects a problem. The evaluation covers more than 10,000 real-world trajectories; the paper reports that about 90% of misbehaviors requiring a single intervention were recovered.
+Its framing is important for Spotter because it treats many coding-agent failures as **process failures**, not merely bad final diffs.
 
 ### What Spotter borrows
 
-- persistent online observation rather than post-hoc review
-- course correction during the active coding trajectory
-- a concrete taxonomy of coding-agent misbehavior
-- the principle that the observer should be lightweight and mostly asynchronous
+- persistent online observation rather than post-hoc-only review
+- asynchronous course correction during an active coding trajectory
+- a compact taxonomy of coding-agent misbehavior
+- the principle that the observer should normally stay out of Main's way
 
-### Where Spotter extends it
+### Where Spotter intends to differ
 
-Wink primarily nudges after observing trajectory steps. Spotter additionally explores:
+| Extension | Spotter status |
+| --- | --- |
+| deterministic pre-action blocking | implemented in the prototype |
+| independent claim/evidence state | implemented, limited by observation coverage |
+| stronger interruption/restart | not implemented |
+| action-conditioned intervention choice | not implemented as a complete policy |
+| explicit external side-effect handling | not implemented |
 
-- pre-action blocking for deterministic violations
-- stronger interruption/restart actions
-- independent claim/evidence state
-- action-conditioned intervention choice
-- explicit handling of external side effects
+The project should not present the unimplemented rows as delivered differentiators.
+
+### Architecture implication
+
+Wink reinforces the decision that semantic supervision should be asynchronous. In the target architecture, App Server events feed `spotterd`; the reviewer runs in parallel; soft guidance is delivered only when ready and still relevant.
 
 ---
 
@@ -49,24 +79,22 @@ https://arxiv.org/abs/2509.02360
 
 ### Why it matters
 
-SWE-PRM treats software-engineering agent failures as trajectory-level problems rather than only bad final outputs. It uses inference-time process supervision to detect redundant exploration, loops, premature stopping, and other execution inefficiencies, then feeds interpretable feedback back into the running agent.
-
-On SWE-bench Verified, the paper reports an improvement from 40.0% to 50.6% resolution for its strongest closed-source PRM configuration.
+SWE-PRM treats software-engineering failures as trajectory-level problems and applies inference-time process supervision to redundant exploration, loops, premature stopping, and related inefficiencies.
 
 ### What Spotter borrows
 
-- process-level failure taxonomy
-- inference-time correction without modifying the main model policy
-- lightweight, interpretable feedback rather than verbose alternate solutions
+- process-level failure categories
+- inference-time correction without retraining Main
+- interpretable feedback rather than a full competing implementation
 - evaluation of trajectory efficiency as well as final success
 
 ### Design lesson
 
-Taxonomy-guided feedback performs better than unconstrained reviewer chatter. Spotter's reviewer output should therefore be structured around a small set of failure hypotheses and control actions.
+Taxonomy-guided feedback is more testable than unconstrained reviewer chatter. Spotter should keep reviewer outputs structured around explicit candidate failures, targets, probes, and control actions.
 
 ---
 
-## 3. AgentForesight — alarm at the earliest decisive error
+## 3. AgentForesight — online auditing and early failure prediction
 
 **AgentForesight: Online Auditing for Early Failure Prediction in Multi-Agent Systems**  
 Boxuan Zhang et al., 2026  
@@ -74,23 +102,23 @@ https://arxiv.org/abs/2605.08715
 
 ### Why it matters
 
-AgentForesight reframes failure attribution as **online auditing**. At each step, the auditor sees only the current trajectory prefix and must decide whether to continue or alarm at the earliest decisive error, without access to future steps.
-
-Its benchmark includes coding, math, and general agentic trajectories.
+AgentForesight frames auditing as a prefix-only problem: decide from the trajectory so far whether a meaningful failure has become visible, without relying on future hindsight.
 
 ### What Spotter borrows
 
-- prefix-only judgment: the reviewer must not depend on hindsight
-- first-error localization as a separate objective
-- the distinction between detecting failure eventually and detecting it early enough to intervene
+- prefix-only judgment
+- timing as a first-class objective
+- the distinction between eventually detecting a failure and detecting it early enough to matter
 
 ### Design lesson
 
-A useful Spotter should measure **time-to-intervention** and **wasted actions before intervention**, not only whether it eventually spotted a problem.
+Spotter should report **regret / wasted actions before intervention** and intervention latency. A detector that is always correct twenty steps too late is not necessarily useful.
+
+The daemon/App Server architecture improves the ability to measure real wall-clock timing because events and intervention delivery can carry explicit timestamps instead of only journal order.
 
 ---
 
-## 4. FailFast-RestartSmart — abort bad trajectories and restart cleanly
+## 4. FailFast-RestartSmart — stop bad trajectories and restart cleanly
 
 **Fail-Fast, Restart-Smart: Early Failure Prediction and Restart for SWE Agentic Tasks**  
 Chenyu Wang et al., 2026  
@@ -98,24 +126,31 @@ https://arxiv.org/abs/2608.03222
 
 ### Why it matters
 
-FailFast-RestartSmart uses a small monitor to predict failure from observable trajectory prefixes. When risk becomes high enough, it terminates the current run and starts a fresh rollout without the old prompt history, while optionally preserving useful repository edits as an overlay.
-
-The paper reports 14.6%–20.4% execution-token savings at a 5% false-positive target across transferred policies, and a resolution increase from 66.6% to 71.8% for one studied policy under a more aggressive restart setting.
+This line of work asks whether a trajectory can become bad enough that continuing inside the same reasoning context is less useful than starting a fresh rollout while deliberately preserving useful external state.
 
 ### What Spotter borrows
 
-- `RESTART` as a control primitive distinct from a nudge
-- recognition that a reasoning context can become contaminated
-- preservation of useful code state without preserving the entire failed reasoning history
-- explicit false-positive budgets for strong intervention
+- `RESTART` as a primitive distinct from `NUDGE`
+- the possibility that reasoning context becomes contaminated
+- preservation of useful repository state without blindly preserving the whole failed trajectory
+- stricter false-positive budgets for stronger control
 
 ### Design lesson
 
-Sometimes telling an agent to "try again" inside the same context is weaker than discarding the trajectory and starting from verified state.
+Restart is not “send another message to the same context.” It is a state-selection problem.
+
+Before Spotter implements it, the runtime needs:
+
+- verified-state representation
+- checkpoint lineage
+- explicit retained artifacts
+- external side-effect accounting
+
+The target long-lived runtime makes those state boundaries more explicit, but does not solve them automatically.
 
 ---
 
-## 5. Calibration Is Not Control — predict the value of intervention
+## 5. Calibration Is Not Control — intervention advantage
 
 **Calibration Is Not Control: Why LLM-Agent Oversight Needs Intervention**  
 Chubin Zhang et al., 2026  
@@ -123,27 +158,27 @@ https://arxiv.org/abs/2606.21399
 
 ### Why it matters
 
-The paper argues that scalar failure probability is the wrong control target for runtime oversight.
+Failure probability is not the same thing as control value. Two prefixes can look equally risky while only one benefits from intervention.
 
-Two trajectory prefixes can have the same estimated chance of failure while requiring different actions: one may be highly recoverable through intervention, while another may not benefit from intervention at all.
+The relevant question is closer to:
 
-It proposes **intervention advantage** — the expected utility difference between intervening and continuing — as the relevant decision quantity, and uses same-prefix counterfactual branching to evaluate it.
+> What is the expected outcome if we intervene now compared with letting this exact prefix continue?
 
 ### What Spotter borrows
 
-- ask "will intervention help?" rather than only "is this risky?"
-- intervention should be action-conditioned (`continue`, `nudge`, `interrupt`, etc.)
-- same-prefix branching as an evaluation technique for intervention policy
+- optimize for useful intervention, not maximum alarm rate
+- condition the decision on the available action (`continue`, `verify`, `nudge`, `interrupt`, ...)
+- use same-prefix branching to estimate intervention advantage
 
-### Design lesson
+### Current Spotter status
 
-A reviewer that accurately predicts failure can still be a bad controller.
+The repository already has machinery for same-prefix counterfactual pairs, but the project still lacks a ground-truth task set and enough executed runs to make a causal claim.
 
-Spotter should optimize for **useful intervention**, not maximum detection rate.
+This is one of the most important current evidence gaps.
 
 ---
 
-## 6. interwhen — verifier-first runtime reasoning supervision
+## 6. interwhen — verifier-first runtime supervision
 
 **interwhen: A Generalizable Framework for Verifiable Reasoning with Test-time Monitors**  
 Vishak K. Bhat et al., 2026  
@@ -152,18 +187,26 @@ Code: https://github.com/microsoft/interwhen
 
 ### Why it matters
 
-interwhen verifies partial reasoning during generation rather than only testing the final answer. It separates verifiable properties from general free-form reasoning and checks them with external or self-verifiers only when needed.
+interwhen separates verifiable properties from broad free-form reasoning and uses monitors only where they add information.
 
 ### What Spotter borrows
 
-- identify which runtime properties can be made executable
-- verify deterministic constraints outside the reviewer LLM
-- avoid forcing the whole reasoning process into a rigid step schema
-- steer only when a verifiable invariant is actually violated
+- turn deterministic properties into executable checks
+- use external/verifiable evidence before semantic debate
+- avoid forcing all reasoning into a rigid schema
+- call the semantic reviewer only for what code cannot decide cheaply
 
-### Design lesson
+### Architecture implication
 
-Do not spend an expensive semantic reviewer call on facts that can be checked by code.
+This supports Spotter's split between:
+
+```text
+PreToolUse synchronous gate
+  = narrow, deterministic, bounded
+
+Async reviewer
+  = semantic, selective, parallel to Main
+```
 
 ---
 
@@ -175,15 +218,13 @@ https://arxiv.org/abs/2605.14175
 
 ### Why it matters
 
-Grounded Continuation maintains an explicit graph that records which claims depend on which evidence. When evidence is retracted, invalidation propagates to conclusions that depended on it.
-
-The original work targets long conversations, but the mechanism maps naturally to coding-agent trajectories.
+Grounded Continuation maintains explicit relationships between claims and evidence. When evidence is retracted, conclusions that depended on it can become stale.
 
 ### What Spotter borrows
 
 - evidence-backed hypotheses instead of copying Main's conclusions as truth
 - explicit stale-premise detection
-- transitive invalidation of dependent plans/actions
+- transitive invalidation
 
 ### Coding example
 
@@ -201,6 +242,10 @@ E2: stack trace points to upstream HTTP client
 → P1 requires revalidation
 ```
 
+### Current Spotter status
+
+The prototype implements a typed audit ledger and stale propagation. Its practical reach is bounded by the observable event surface. Moving to richer App Server events is therefore not only an architecture cleanup; it is an experiment in whether the evidence graph becomes materially more useful.
+
 ---
 
 ## 8. AgentProcessBench — neutral exploration is not failure
@@ -212,19 +257,19 @@ Code/data: https://github.com/RUCBM/AgentProcessBench
 
 ### Why it matters
 
-AgentProcessBench provides human-labeled step-level annotations for realistic tool-using trajectories and explicitly uses a ternary label scheme to distinguish useful, neutral/exploratory, and erroneous behavior.
-
-A key finding is that current models struggle to distinguish neutral exploration from actual error.
+Real tool-using trajectories contain actions that are not obviously useful but are also not errors. Current models can struggle to distinguish neutral exploration from genuine failure.
 
 ### What Spotter borrows
 
-- `NEUTRAL` / uncertainty must exist in the reviewer worldview
-- repeated reads or exploration are not automatically loops
-- early intervention policy must be conservative around ambiguous exploratory steps
+- uncertainty/neutrality must exist in the reviewer worldview
+- repeated reads are not automatically a loop
+- early intervention should be conservative around ambiguous exploration
 
 ### Design lesson
 
-"The agent is taking a while" is not itself a failure signal.
+> “The agent is taking a while” is not itself a failure signal.
+
+This is especially relevant for the planned cheap Signal Engine: signals must produce candidates, not verdicts.
 
 ---
 
@@ -236,17 +281,19 @@ https://arxiv.org/abs/2606.06324
 
 ### Why it matters
 
-HarnessFix compiles raw execution traces and harness code into a Harness-aware Trace Intermediate Representation (HTIR), then attributes recurring failures to specific trajectory steps and harness layers.
+HarnessFix compiles raw execution traces into a harness-aware intermediate representation and reasons about failures across both agent behavior and harness structure.
 
 ### What Spotter borrows
 
 - normalize raw runtime streams into a backend-independent Trace IR
-- track provenance between runtime behavior and harness configuration
+- keep provenance between normalized state and runtime events
 - distinguish Main failure from Spotter/harness failure
 
-### Future direction
+### Architecture implication
 
-Repeated Spotter diagnoses may eventually reveal that the right fix is not another runtime intervention, but a change to the agent harness itself.
+The move from hooks to App Server should not leak Codex event shapes throughout Spotter core. The adapter should normalize events so the runtime, reviewer, metrics, and replay machinery remain transport-independent.
+
+A repeated Spotter diagnosis may eventually imply that the right fix is a harness change rather than another intervention.
 
 ---
 
@@ -258,23 +305,23 @@ https://arxiv.org/abs/2604.19049
 
 ### Why it matters
 
-This work uses adversarial reviewers to try to kill candidate findings before they are promoted. It highlights correlated reviewer errors and reports an instructive case where multiple reviewers agreed on a nonexistent vulnerability that was eliminated by a single empirical test.
+This work emphasizes killing candidate findings before promoting them and illustrates the danger of correlated model agreement without empirical evidence.
 
 ### What Spotter borrows
 
-- Spotter should try to **falsify** a consequential Main hypothesis rather than produce a competing full solution
-- cross-model review may reduce correlated blind spots
-- empirical evidence outranks model consensus
+- try to falsify a consequential Main hypothesis rather than produce a competing solution
+- treat cross-model diversity as a possible way to reduce correlated blind spots
+- rank empirical verification above model consensus
 
 ### Design lesson
 
-Ten models agreeing is weaker evidence than one decisive test.
+Ten models agreeing can still be weaker evidence than one decisive test.
 
 ---
 
-## Synthesis
+# Synthesis
 
-The core Spotter design can be seen as the intersection of these ideas:
+Spotter sits at the intersection of these ideas:
 
 ```text
 Wink
@@ -284,7 +331,7 @@ SWE-PRM
   trajectory failure taxonomy
           +
 AgentForesight
-  earliest-error online auditing
+  early prefix-only auditing
           +
 FailFast-RestartSmart
   interrupt + clean restart
@@ -302,15 +349,33 @@ AgentProcessBench
   neutral exploration awareness
           +
 HarnessFix
-  Trace IR / harness attribution
+  normalized Trace IR / harness attribution
           +
 Refute-or-Promote
   falsification + empirical gates
 ```
 
-## Research questions for Spotter
+The target runtime architecture adds an engineering hypothesis underneath that synthesis:
 
-### RQ1 — Intervention timing
+```text
+rich observation/control stream
+          +
+long-lived independent state
+          +
+selective async review
+          +
+bounded synchronous enforcement
+```
+
+should be a better substrate for studying runtime supervision than rebuilding state inside independent hook processes.
+
+That engineering hypothesis must also be measured: richer infrastructure is not automatically better if its operational cost or fragility outweighs the supervision benefit.
+
+---
+
+# Research questions
+
+## RQ1 — Intervention timing
 
 How early should a coding-agent trajectory be reviewed?
 
@@ -318,61 +383,213 @@ Compare:
 
 - periodic asynchronous review
 - event-triggered review
-- synchronous pre-action gate
+- synchronous deterministic gate
 
-### RQ2 — Intervention policy
+Measure not only detection but wasted actions and wall-clock time before intervention.
 
-When is a `NUDGE` better than `INTERRUPT`? When is `RESTART` better than continuing inside the same context?
+## RQ2 — Intervention policy
 
-### RQ3 — Model diversity
+When is `VERIFY` better than `NUDGE`? When does `INTERRUPT` help? When is `RESTART` better than continuing inside the same reasoning context?
 
-Does a different reviewer model reduce correlated failures compared with same-model review?
+The action should be chosen for expected intervention value, not only failure severity.
+
+## RQ3 — Model diversity
+
+Does a different reviewer model/family reduce correlated failures compared with same-model isolated-context review?
 
 Compare:
 
 - same model / isolated context
 - different model / isolated context
-- small specialized reviewer
+- smaller specialized reviewer
 
-### RQ4 — Reviewer harm
+Do not conflate “different family” with “stronger model”.
 
-How often does Spotter interrupt a trajectory that would have succeeded on its own?
+## RQ4 — Reviewer harm and sycophancy
 
-This should be treated as a first-class metric, not a footnote.
+How often does Spotter degrade a trajectory that would have succeeded on its own?
 
-### RQ5 — Deterministic vs semantic supervision
+Related failure direction: how often does Main comply with a deliberately wrong but plausible Spotter nudge instead of refuting it with evidence?
 
-What fraction of useful interventions can be triggered by cheap executable checks before an LLM reviewer is needed?
+Both should gate live injection policy.
 
-## Evaluation metrics
+## RQ5 — Deterministic vs semantic supervision
 
-Spotter should report more than final task success:
+What fraction of useful supervision can be triggered or resolved by cheap executable checks before an LLM reviewer is needed?
 
-- task resolution rate
-- token usage
-- tool-call count
-- wall-clock latency
-- interventions per run
-- intervention precision
-- intervention harm rate
-- recovery rate after intervention
-- time-to-intervention
-- wasted actions before intervention
-- ignored-intervention rate
-- restart recovery rate
+This directly affects latency and cost.
 
-The core benchmark comparison should eventually include:
+## RQ6 — Observation surface
+
+How much does the move from hook-collected events to App Server events change:
+
+- visible tool outcomes
+- failure observability ceiling
+- goal/constraint availability
+- timing precision
+- trace fidelity
+
+A better reviewer cannot compensate for missing evidence.
+
+## RQ7 — Event-driven triggering
+
+Can cheap candidate signals reduce reviewer calls without reducing useful detection?
+
+Sweep:
+
+- signal thresholds
+- fallback cadence
+- reviewer calls/session
+- detection latency
+- precision/miss rate
+- token cost
+
+## RQ8 — Runtime overhead
+
+Does the standalone runtime reduce hot-path cost enough to justify its operational complexity?
+
+Measure:
+
+- hook p50/p95/p99 before/after
+- App Server processing overhead
+- idle/active daemon CPU and memory
+- reconnect/recovery latency
+- additional failure modes introduced by the runtime
+
+## RQ9 — Replay/fork fidelity
+
+How similar is a forked continuation to what the original prefix would have produced without intervention?
+
+Before causal claims rely on forks, establish:
+
+- identical-arm noise floor
+- continuation similarity
+- environmental failure rate
+
+## RQ10 — User experience of supervision
+
+Correct but annoying supervision can still be a product failure.
+
+Measure or collect:
+
+- dismiss/disagree signals
+- blocks users override
+- interventions perceived as useful vs disruptive
+- whether the user can understand when Spotter is active, degraded, or disconnected
+
+---
+
+# Evaluation matrix
+
+The eventual comparison should include at least:
 
 ```text
 A. Vanilla coding agent
-B. Periodic async reviewer (Wink-style)
-C. Event-triggered Spotter
-D. Spotter + pre-action deterministic gates
-E. Spotter + interrupt/restart
+
+B. Periodic async reviewer
+   fixed cadence, soft guidance
+
+C. Event-driven Spotter
+   cheap signals + semantic reviewer
+
+D. Spotter + deterministic gate
+   event-driven + PreToolUse enforcement
+
+E. Full Spotter
+   gate + steer + stronger interrupt/recovery primitives
 ```
 
-## Notes on research status
+The runtime substrate should be held constant where possible when comparing supervision policy, otherwise architecture changes become a confound.
 
-This is a fast-moving area. Several papers listed here are 2026 preprints rather than established production standards. Spotter should treat them as design evidence and experimental hypotheses, not as proof that every mechanism will generalize to Codex or every repository/task class.
+## Primary metrics
 
-The project should therefore keep its architecture modular enough to remove mechanisms that do not survive empirical evaluation.
+### Outcome
+
+- task resolution
+- regression rate
+
+### Efficiency
+
+- main-agent tokens
+- reviewer tokens
+- tool-call count
+- repeated-action count
+- elapsed/tool time
+- Spotter CPU/memory
+
+### Observation quality
+
+- event coverage
+- observable outcome rate
+- failure observability ceiling
+- missing goal/constraint rate
+- liveness / disconnect rate
+
+### Intervention quality
+
+- intervention precision
+- sampled miss rate / recall estimate
+- intervention advantage
+- harm rate
+- recovery rate
+- ignored-intervention rate
+
+### Timing
+
+- wasted actions before intervention
+- reviewer latency
+- delivery latency
+- stale intervention rate
+
+### Recovery
+
+- success after nudge
+- success after interrupt
+- success after restart
+- useful work retained
+- external state left unreverted
+
+---
+
+# Evidence gates for stronger behavior
+
+The project should continue using an “earn the right to intervene” progression:
+
+```text
+observe
+  ↓
+measure detector/reviewer quality
+  ↓
+run counterfactuals
+  ↓
+soft intervention
+  ↓
+measure harm/recovery
+  ↓
+stronger intervention
+```
+
+A feature being implemented is not a reason to enable it by default.
+
+Examples:
+
+- deterministic gate: measure per-rule false positives and misses
+- NUDGE/VERIFY: require reviewer quality + intervention-advantage evidence + wrong-nudge behavior
+- INTERRUPT: require substantially stricter precision/harm budget
+- RESTART: require recovery-state/side-effect correctness in addition to reviewer confidence
+
+---
+
+# Notes on research status
+
+This is a fast-moving area. Several sources above are recent preprints rather than established production standards.
+
+Spotter should treat them as:
+
+- design evidence
+- experimental hypotheses
+- useful benchmark ideas
+
+not as proof that every mechanism transfers to Codex, every repository, or every model generation.
+
+The architecture should remain modular enough to remove mechanisms that do not survive measurement. A negative result—such as no measurable intervention advantage, excessive stale interventions, or negligible benefit from model diversity—is a useful project result, not something to hide behind additional complexity.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,246 +1,428 @@
 # Roadmap
 
-> **Status:** roadmap reset around the standalone runtime direction in [#66](https://github.com/Bogyie/spotter/issues/66).
-
-Spotter should still earn complexity through evaluation, but the implementation order needs to change.
-
-The hook/plugin prototype already proved enough of the idea to expose a structural problem: the next features—event-driven detection, live steering, richer audit state, interruption, multi-session supervision—want a long-lived runtime and a richer observation/control channel. Building them deeply into the current per-hook-process model would create work that must immediately be migrated again.
-
-The roadmap therefore splits into two tracks that must advance together:
-
-```text
-Runtime/Product track
-  build the architecture that can supervise reliably
-
-Evaluation track
-  prove that the supervision actually helps
-```
-
-Neither substitutes for the other.
-
-## Current baseline
-
-### Implemented in the prototype
-
-- Codex lifecycle/tool hook ingestion
-- deterministic pre-action gates
-- shell-aware handling for several destructive command classes
-- crash-tolerant step journals
-- Git-backed snapshots and detached restore
-- snapshot dedup/pruning
-- Codex continuation fork/replay machinery
-- shadow-mode model-backed reviewer
-- periodic/detached reviewer execution
-- typed claim/evidence ledger with stale propagation where outcomes are observable
-- labels and coverage-aware metrics
-- same-prefix counterfactual experiment harness
-- Codex and Claude Code plugin packaging
-
-### Still missing or unproven
-
-- standalone runtime distribution and lifecycle
-- `spotterd` live state ownership
-- App Server as Codex's primary observation/control plane
-- event-driven signal layer
-- live `VERIFY` / `NUDGE` delivery
-- `INTERRUPT` / `RESTART`
-- complete side-effect/reversibility handling
-- a ground-truth task corpus and enough executed experiments to estimate intervention advantage
-- recall/miss-rate evidence for detectors
-- full efficiency/cost accounting
-
-This means the project is **implementation-rich but evidence-poor**: the measurement machinery exists, but the central claim that Spotter improves outcomes is not yet established.
+> **Status:** reset around the standalone-runtime direction in [#66](https://github.com/Bogyie/spotter/issues/66).  
+> This roadmap separates **runtime/product work** from **evaluation work**. Shipping more mechanisms does not substitute for proving that intervention helps.
 
 ---
 
-# Runtime / product roadmap
+## 30-second summary
 
-## P0 — App Server lifecycle and attach PoC
+### Now
 
-**Priority: first.**
+**P0 — App Server lifecycle / attach PoC**
 
-Before building the daemon migration, validate the premise that makes the target Codex architecture possible.
+Prove that ordinary `codex` and Spotter can share the same external App Server, observe the same thread/turn, and that `turn/steer` reaches the actual user session.
 
-### Goal
-
-Prove that the user's ordinary Codex TUI and Spotter can share the same externally reachable App Server, and that Spotter can observe and steer the real active turn.
-
-### Experiments
-
-#### A. Codex-managed daemon
+### Next
 
 ```text
-external App Server daemon
-        ↓
-plain `codex` attaches
-        ↓
-Spotter attaches as second client
-        ↓
-receive same thread/turn events
-        ↓
-turn/steer reaches the user session
+P1  standalone runtime foundation
+ ↓
+P2  product lifecycle: package/setup/status/doctor/teardown
+ ↓
+P3  move existing capabilities behind spotterd
+ ↓
+P4  App Server primary observation + Hook minimization
 ```
 
-#### B. Spotter-managed external App Server
+### Then
 
-Test whether Spotter can safely ensure the external App Server when relying on Codex's experimental daemon lifecycle is undesirable.
+```text
+P5  cheap signals → event-driven reviewer
+ ↓
+P6  live VERIFY / NUDGE
+ ↓
+P7  INTERRUPT / RESTART / side-effect-aware recovery
+ ↓
+P8  operational hardening
+ ↓
+P9  adaptation / learned policy only after evidence is strong enough
+```
 
-#### C. Embedded/degraded baseline
+The corresponding evaluation path is:
 
-Document exactly what Spotter can and cannot do when Codex chooses an embedded App Server that Spotter cannot attach to.
+```text
+E0  observability ceiling
+ ↓
+E1  mechanically scored task set
+ ↓
+E2  replay/fork fidelity
+ ↓
+E3  precision + miss rate
+ ↓
+E4  intervention advantage / harm
+ ↓
+E5  real-session operational A/B
+```
+
+---
+
+## Quick phase table
+
+| Phase | Outcome | Hard dependency | Done when... |
+| --- | --- | --- | --- |
+| **P0** | App Server strategy selected | none | same real Codex turn can be observed and steered |
+| **P1** | long-lived runtime boundary | P0 | `spotterd` owns live multi-thread state and reconnects |
+| **P2** | product lifecycle | P1 | clean install → setup → `codex` → teardown works |
+| **P3** | current features moved behind daemon | P1 | journal/gate/audit/reviewer/snapshot no longer depend on per-hook state rebuild |
+| **P4** | App Server primary observation | P0–P3 | observation hooks removed where coverage is proven |
+| **P5** | event-driven review | P4 | reviewer is triggered mainly by cheap candidate signals |
+| **P6** | live soft intervention | P5 + E3/E4 evidence | `VERIFY/NUDGE` can reach correct active turn safely |
+| **P7** | strong control/recovery | P6 + strong evidence | interrupt/restart operate with side-effect awareness |
+| **P8** | operational hardening | P1–P7 | upgrades/crashes/purge/reinstall are boring and diagnosable |
+| **P9** | adaptation | E4/E5 mature | learned policy can be evaluated for regressions |
+
+---
+
+# Baseline: what already exists
+
+## Implemented in the current prototype
+
+- Codex lifecycle/tool Hook ingestion;
+- deterministic pre-action gates;
+- shell-aware handling of several destructive command classes;
+- crash-tolerant step journals;
+- Git-backed snapshots and detached restore;
+- snapshot deduplication and pruning;
+- Codex continuation fork/replay machinery;
+- model-backed reviewer in shadow mode;
+- periodic/detached reviewer execution;
+- typed claim/evidence ledger with stale propagation where outcomes are observable;
+- human labels and coverage-aware metrics;
+- same-prefix counterfactual experiment harness;
+- Codex and Claude Code plugin packaging.
+
+## Missing or unproven
+
+- standalone runtime distribution/lifecycle;
+- `spotterd` live-state ownership;
+- App Server as primary Codex observation/control plane;
+- event-driven signal layer;
+- live `VERIFY / NUDGE` delivery;
+- `INTERRUPT / RESTART`;
+- complete side-effect/reversibility handling;
+- a mechanically scored task corpus with enough executed experiments;
+- detector miss-rate/recall evidence;
+- positive intervention advantage;
+- full runtime/operational cost accounting.
+
+The project is therefore **implementation-rich but evidence-poor**: substantial machinery exists, but the central causal claim is still open.
+
+---
+
+# Runtime / product track
+
+## P0 — App Server lifecycle / attach PoC
+
+**Priority:** first.  
+**Why:** every later App Server/daemon decision depends on this.
+
+### Entry criteria
+
+- current Codex version exposes App Server client/control surfaces worth testing;
+- Spotter can run local integration experiments without changing production policy.
+
+### Questions to answer
+
+1. Does plain `codex` reuse a pre-existing default external App Server daemon?
+2. Can Spotter attach as a second client to the exact same server?
+3. Do TUI and Spotter observe the same thread id and active turn id?
+4. Does `turn/steer` affect the actual user-visible turn?
+5. What happens with multiple simultaneous TUI sessions?
+6. Which CLI/config overrides disable daemon reuse?
+7. What can Spotter still do when Codex chooses an embedded server?
+8. What lifecycle/ownership guarantees does Codex's experimental daemon actually provide?
+
+### Experiment A — Codex-managed daemon
+
+```text
+ensure Codex App Server daemon
+        ↓
+plain `codex`
+        ↓
+TUI reuses external daemon
+        ↓
+Spotter attaches as client B
+        ↓
+observe same thread/turn
+        ↓
+turn/steer reaches user session
+```
+
+Record:
+
+- daemon endpoint/path;
+- Codex CLI/version/config;
+- thread ids seen by both clients;
+- turn ids over several actions;
+- event duplication/order;
+- steer latency and visible result;
+- disconnect/reconnect behavior.
+
+### Experiment B — Spotter-managed App Server
+
+```text
+Spotter starts external `codex app-server`
+        ↓
+TUI attaches same endpoint
+        ↓
+Spotter attaches same endpoint
+```
+
+Answer whether a normal plain-`codex` UX can still be preserved without relying on Codex's managed-daemon lifecycle.
+
+### Experiment C — embedded baseline
+
+Run ordinary Codex without an attachable external server and write down the real capability matrix:
+
+```text
+thread observation:    ?
+tool result visibility:?
+live steer:            ?
+interrupt:             ?
+PreToolUse gate:       ?
+```
+
+### Non-goals
+
+- no daemon rewrite;
+- no new reviewer policy;
+- no Homebrew packaging;
+- no Hook migration yet.
 
 ### Exit criteria
 
-- canonical App Server ownership/attach strategy chosen
-- ordinary `codex` UX remains possible
-- Spotter receives live events for the user's real thread
-- active turn identity is reliable
-- `turn/steer` works end to end
-- multi-client/multi-session behavior is understood
-- degraded mode is explicit
+- one canonical App Server strategy selected;
+- ordinary `codex` UX remains acceptable;
+- same-thread/same-turn observation is proven;
+- real `turn/steer` delivery is proven;
+- concurrent sessions are understood;
+- degraded/embedded mode is documented;
+- ownership and reconnect rules are known.
 
-If this phase fails, revisit the target architecture before continuing.
+**If a core property fails, stop and revise #66 before P1.**
+
+---
 
 ## P1 — Standalone runtime foundation
 
 ### Goal
 
-Create the smallest long-lived runtime boundary without yet rewriting every supervision feature.
+Create the smallest long-lived runtime boundary that can own state and connections.
 
-### Scope
+### Entry criteria
 
-- `spotterd` process/runtime
-- user-service/lifecycle abstraction where required
-- Unix-domain-socket IPC for the remaining synchronous hook bridge
-- App Server manager/client
-- capability negotiation
-- thread / turn / runtime-attachment identity model
-- live state container
-- connection/reconnect state machine
-- protocol/version handshake
+- P0 selected an App Server integration strategy.
 
-### Design constraint
+### Deliverables
 
-Do not rewrite the whole project in Rust/Go. The current Python implementation is sufficient to validate the runtime boundary. A native `spotter-hook` is a later optimization if cold-start measurements justify it.
+#### `spotterd`
+
+- per-user daemon process;
+- CLI control RPC;
+- graceful start/stop/restart;
+- explicit protocol version.
+
+#### Runtime state
+
+- `ThreadState` registry;
+- `TurnState` / active-turn identity;
+- `RuntimeAttachment` identity;
+- capability/connection state;
+- multi-thread isolation.
+
+#### App Server client
+
+- connect/initialize;
+- capability probe;
+- event subscription;
+- reconnect state machine;
+- list/reconcile loaded threads.
+
+#### Hook IPC
+
+- Unix-domain-socket request/reply for `PreToolUse`;
+- bounded timeout;
+- fail-open when unavailable;
+- startup/protocol handshake.
+
+#### Service abstraction
+
+- `ServiceManager` interface;
+- managed-vs-portable runtime mode;
+- defer exact launchd/systemd behavior until P0 result requires it.
+
+### Non-goals
+
+- no native hook rewrite unless measurements demand it;
+- no event-driven reviewer yet;
+- no live steering policy beyond a PoC control request.
 
 ### Exit criteria
 
-- daemon can own more than one concurrent session/thread state
-- App Server event stream updates live memory
-- daemon restart can reconnect/reconcile state
-- current coding session does not fail when Spotter is unavailable
+- one `spotterd` handles multiple concurrent thread states;
+- App Server events update memory without journal reconstruction;
+- CLI can query daemon health/state;
+- daemon restart reconnects and reconciles active threads;
+- a dead daemon does not break the coding session.
+
+---
 
 ## P2 — Product lifecycle
 
 ### Goal
 
-Make the runtime installable, diagnosable, upgradable, and removable as a product rather than a development harness.
+Make Spotter installable and removable as a product, not merely runnable from a checkout.
 
-### Scope
+### Entry criteria
 
-Target distribution/control plane:
+- P1 runtime exists locally.
+
+### Deliverables
 
 ```text
 brew install spotter
 spotter setup codex
-spotter doctor
 spotter status
+spotter doctor
 spotter teardown codex
 ```
 
-Implementation areas:
+Implementation:
 
-- Homebrew/release packaging
-- `setup` transaction
-- integration manifest
-- legacy plugin migration
-- service registration if managed mode requires it
-- `doctor` and `status`
-- `teardown`
-- stable executable paths across package upgrades
-- config/schema versioning foundation
+- release artifacts/Homebrew formula;
+- package provenance/version detection;
+- transactional setup (`INSPECT → PLAN → BACKUP → APPLY → VERIFY → COMMIT`);
+- `IntegrationManifest`;
+- legacy plugin detection/migration;
+- service registration if required;
+- App Server strategy installation/reconciliation;
+- minimal Hook installation;
+- synthetic `doctor` checks;
+- teardown and interrupted-setup recovery;
+- stable executable paths across upgrades.
+
+### Fixtures/tests
+
+- clean machine fixture;
+- existing Codex config fixture;
+- existing legacy Spotter plugin fixture;
+- interrupted setup at each transaction stage;
+- repeated setup three times;
+- uninstall without teardown.
 
 ### Exit criteria
 
-- clean install → setup → ordinary `codex` → teardown round trip works
-- setup is idempotent
-- partial setup failure is recoverable
-- uninstall without teardown cannot break Codex through a dangling Spotter hook
+- clean install → setup → plain `codex` → teardown works;
+- setup is idempotent;
+- interrupted setup can be reconciled;
+- Spotter removes only its own config changes;
+- uninstall without teardown cannot make Codex unusable.
 
-See [Lifecycle](lifecycle.md) for the complete target lifecycle.
+Detailed contract: [Lifecycle](lifecycle.md).
+
+---
 
 ## P3 — Move existing capabilities behind the runtime boundary
 
 ### Goal
 
-Preserve the useful prototype mechanisms while changing who owns their live state.
+Preserve useful prototype behavior while changing who owns live state.
 
-### Move/refactor
+### Migrate/refactor
 
-- journal writer
-- Trace IR/state updates
-- audit ledger
-- gate engine
-- snapshot manager
-- replay/fork manager
-- reviewer scheduler
-- labels/metrics integration
-- experiment harness
+- journal writer;
+- Trace IR normalization;
+- audit ledger;
+- deterministic gate;
+- snapshot manager;
+- fork/replay manager;
+- reviewer scheduler;
+- labels/metrics integration;
+- experiment harness.
 
-### Key change
+### Required architecture change
 
 ```text
-before:
+BEFORE
 hook → journal → rebuild state
 
-after:
+AFTER
 event → live state → policy
-                  └→ durable journal
+                  └→ journal append
+```
+
+### Specific work
+
+- daemon becomes primary journal writer where possible;
+- audit ledger updates incrementally from Trace IR;
+- reviewer context is read from live state + bounded durable data, not full journal rebuild;
+- snapshot calls become managed resources linked to thread/turn identity;
+- existing commands continue to work against durable history.
+
+### Exit criteria
+
+- current safety tests remain valid;
+- current session analysis/fork/metrics workflows still work;
+- normal event handling does not reconstruct full state from disk;
+- daemon restart/resume is the explicit reconstruction boundary.
+
+---
+
+## P4 — App Server primary observation + Hook minimization
+
+### Goal
+
+Move broad observation off Hooks and prove no critical signal is lost.
+
+### Migration matrix
+
+| Hook | Target |
+| --- | --- |
+| `SessionStart` | remove if App Server thread lifecycle covers it |
+| `UserPromptSubmit` | remove if App Server user-message events cover it |
+| `PreToolUse` | retain only for bounded deterministic enforcement |
+| `PostToolUse` | remove in favor of App Server tool/result/diff events |
+
+### Deliverables
+
+- App Server event → Trace IR adapter;
+- lifecycle/user-message/tool/result/diff/token coverage map;
+- event ordering/idempotency handling;
+- provenance from Trace IR back to App Server item/turn;
+- reduced Hook configuration;
+- Hook latency and invocation count measurement;
+- re-measured observable-outcome ceiling.
+
+### Measurement
+
+Compare before/after:
+
+```text
+hook invocations / session
+hook p50 / p95 / p99
+observable tool-result rate
+missing goal/constraint rate
+App Server event loss/duplication
+CPU/memory overhead
 ```
 
 ### Exit criteria
 
-- current tests/guarantees remain meaningful
-- journal becomes durable history/recovery, not the hot-path state database
-- reviewer does not rebuild whole state from disk on every invocation
+- App Server is the primary trajectory source;
+- no required observation silently disappears;
+- the old 10% hook-era outcome figure is replaced with a measured App Server-era result;
+- the remaining Hook path is small, bounded, and deterministic.
 
-## P4 — Make App Server primary and minimize hooks
+---
 
-### Goal
-
-Move broad observation away from hooks.
-
-### Target migration
-
-| Hook | Target state |
-| --- | --- |
-| `SessionStart` | remove if App Server lifecycle covers it |
-| `UserPromptSubmit` | remove if App Server user-message events cover it |
-| `PreToolUse` | retain only for bounded deterministic blocking |
-| `PostToolUse` | remove in favor of App Server results/diffs |
-
-### Scope
-
-- App Server → Trace IR normalization
-- thread/turn lifecycle handling
-- command/result/diff coverage
-- reasoning/plan signals where exposed
-- token/cost observation where exposed
-- re-measure observability ceiling
-- measure hook latency/invocation reduction
-
-### Exit criteria
-
-- App Server is the primary trajectory source
-- no required observation silently disappears when hooks are removed
-- existing 10% hook-era outcome observability figure is replaced with a measured App Server-era figure
-- synchronous hook path is small and bounded
-
-## P5 — Event-driven semantic supervision
+## P5 — Event-driven semantic review
 
 ### Goal
 
-Replace fixed periodic review with cheap candidate signals followed by semantic review only when warranted.
+Replace fixed periodic model calls with cheap candidate detection.
+
+### Target flow
 
 ```text
 runtime event
@@ -248,313 +430,371 @@ runtime event
 cheap signal / verifier
     ↓
 possible issue?
-    ├─ no → continue
+    ├─ no → done
     └─ yes
          ↓
-     Pair Reviewer
+     ReviewerJob
 ```
 
-Candidate signals:
+### Initial candidate signals
 
-- repeated equivalent actions
-- failure streaks
-- stagnant exploration frontier
-- touched-scope growth
-- edits without validation
-- stale premise reuse
-- block circumvention
-- budget anomalies
+- repeated equivalent tool calls;
+- failure streaks;
+- repeated reads with no frontier expansion;
+- sudden touched-scope growth;
+- edits accumulating without validation;
+- stale hypothesis reuse;
+- repeated behavior after a deterministic block;
+- tool/token/time budget anomalies.
 
-Signals produce candidates, not verdicts.
+### Data contract
+
+Candidate example:
+
+```json
+{
+  "candidate": "POSSIBLE_EXPLORATION_LOOP",
+  "thread_id": "T1",
+  "turn_id": "U8",
+  "evidence": ["same search pattern repeated 4 times"],
+  "signal_version": 1
+}
+```
+
+A signal is not a verdict.
 
 ### Exit criteria
 
-- candidate signals are journaled and labelable
-- reviewer dispatch is primarily event-driven
-- calls/session and detection behavior are measured before/after the change
+- candidate signals are journaled and labelable;
+- reviewer calls/session decrease or become more targeted;
+- detection latency/precision/miss rate are measured before and after;
+- cadence, if retained, is an explicit fallback rather than the primary trigger.
+
+---
 
 ## P6 — Live soft intervention
 
 ### Goal
 
-Deliver useful reviewer decisions without blocking Main while the reviewer thinks.
+Deliver `VERIFY / NUDGE` while Main continues in parallel.
 
-### Runtime actions
+### Entry criteria
 
-- `CONTINUE`
-- `VERIFY`
-- `NUDGE`
+- P5 produces reviewer jobs;
+- E3 has enough precision/miss-rate evidence to set a conservative live policy;
+- E4 has at least initial intervention-harm evidence.
 
-### Flow
+### Deliverables
+
+#### Reviewer job lifecycle
 
 ```text
-signal at turn T
-    ↓
-reviewer runs asynchronously
-    ↓
-Main continues
-    ↓
-verdict ready
-    ↓
-T still active?
-  ├─ yes → turn/steer
-  └─ no  → stale/defer/discard policy
+QUEUED → RUNNING → DECIDED
+                    ├─ DELIVERED
+                    ├─ STALE
+                    ├─ DISCARDED
+                    └─ FAILED
 ```
 
-### Required support
+#### Freshness
 
-- reviewer job state machine
-- target turn identity
-- intervention freshness policy
-- delivery journaling
-- ignored/stale intervention metrics
-- pair-runtime contract for Main
+- every job anchors to `thread_id` + `target_turn_id`;
+- only the intended active turn receives the verdict;
+- late decisions follow explicit stale/defer policy.
+
+#### Delivery
+
+```text
+VERIFY → concise evidence request via turn/steer
+NUDGE  → concise course correction via turn/steer
+```
+
+#### Measurement
+
+- reviewer latency;
+- delivery latency;
+- stale rate;
+- ignored intervention rate;
+- duplicate delivery prevention;
+- user-visible supervision provenance.
 
 ### Exit criteria
 
-- a shadow-earned reviewer decision can reach the active real Codex turn
-- repeat delivery is impossible
-- stale decisions do not leak into unrelated later turns
-- intervention latency and stale rate are measurable
+- live decision reaches the correct real active Codex turn;
+- the same decision cannot be delivered twice;
+- stale decisions do not leak into unrelated turns;
+- Main can distinguish Spotter supervision from user intent;
+- live intervention remains off by default until measurement gates are met.
+
+---
 
 ## P7 — Strong control and recovery
 
 ### Goal
 
-Add high-cost actions only after soft intervention has evidence.
+Add higher-cost actions only after soft intervention is understood.
 
-### Runtime actions
-
-- `BLOCK` — already deterministic, but re-measured in new runtime
-- `INTERRUPT`
-- `RESTART`
-
-### Required support
-
-- high precision budgets per action
-- last-sound-state representation
-- checkpoint metadata
-- side-effect/reversibility ledger
-- explicit retained-state selection
-- restart lineage
-
-### Restart payload
-
-A fresh continuation should receive only what is deliberately retained:
-
-- user goal
-- explicit constraints
-- verified evidence
-- current repository state
-- intentionally preserved artifacts
-
-Do not imply that a reasoning restart undoes external state.
-
-## P8 — Operational hardening
-
-### Scope
-
-- daemon/App Server reconnect recovery
-- Codex upgrade capability negotiation
-- Spotter upgrade and graceful daemon restart
-- config/journal/label/experiment schema migration
-- retention policies
-- repository registry
-- purge
-- reinstall
-- multi-agent integration lifecycle
-
-### Goal
-
-A Spotter installation should remain understandable after months of normal upgrades, crashes, resumes, and repository churn.
-
-## P9 — Experience and adaptation
-
-Only after intervention quality is measurable should Spotter learn from prior runs.
-
-Possible directions:
-
-- model-specific failure profiles
-- repository-specific signal thresholds
-- retrieval of previous useful/harmful interventions
-- offline learning of intervention policy
-
-Do not introduce adaptive behavior without an evaluation harness capable of detecting regressions.
-
----
-
-# Evaluation roadmap
-
-The runtime migration does not relax the project's measurement discipline. It makes better measurement possible.
-
-## E0 — Observability ceiling
-
-Re-measure what failures are visible before they compound after App Server becomes the observation surface.
-
-Questions:
-
-- what fraction of failed/degraded sessions were observable early enough?
-- what fraction of tool outcomes are directly observable?
-- which failure classes remain invisible?
-
-A smarter reviewer cannot beat an observation surface that never exposes the relevant evidence.
-
-## E1 — Ground-truth task set
-
-Create a small reproducible task corpus with mechanical checks so counterfactual experiments can actually run.
+### `INTERRUPT`
 
 Requirements:
 
-- fixture repository/task
-- prompt
-- objective `--check`
-- provenance
-- cost budget
+- high precision threshold;
+- shadow “would interrupt” mode first;
+- `turn/interrupt` control path;
+- clear post-interrupt replanning contract.
 
-The first measured intervention result should be recorded even if negative or inconclusive.
+### `RESTART`
+
+Requirements:
+
+```text
+last sound state
+verified evidence set
+checkpoint/snapshot lineage
+explicit retained artifacts
+external side-effect ledger
+fresh continuation payload
+```
+
+Restart payload should be deliberately minimal:
+
+```text
+user goal
+explicit constraints
+verified evidence
+current repository state
+retained artifacts
+```
+
+Do not imply that external writes were rolled back.
+
+### Exit criteria
+
+- strong actions have explicit precision/harm budgets;
+- shadow evidence precedes active control;
+- external side effects remain visible in recovery UX;
+- restart lineage is reproducible and auditable.
+
+---
+
+## P8 — Operational hardening
+
+### Goal
+
+Make months of use boring.
+
+### Scope
+
+- daemon/App Server reconnect;
+- crash recovery;
+- Codex upgrade capability negotiation;
+- Spotter upgrade with running old daemon;
+- config/journal/label/experiment schema migration;
+- repository registry;
+- retention policy;
+- worktree/snapshot cleanup;
+- `purge --dry-run`;
+- uninstall/reinstall fixtures;
+- multi-agent integration lifecycle;
+- logs/diagnostic bundle if useful.
+
+### Exit criteria
+
+- upgrade and reinstall fixtures pass across supported schema ranges;
+- stale resources are discoverable and cleanable;
+- `status`/`doctor` explain partial failures;
+- package uninstall and integration teardown have separate, predictable ownership.
+
+---
+
+## P9 — Experience and adaptation
+
+Do not build learned/adaptive intervention policy until the evaluation harness can detect regressions.
+
+Possible later directions:
+
+- model-specific failure profiles;
+- repository-specific signal thresholds;
+- retrieval of prior useful/harmful interventions;
+- offline policy learning;
+- personalized intervention tolerance.
+
+Entry gate:
+
+- E4/E5 produce enough repeatable evidence to compare policy versions.
+
+---
+
+# Evaluation track
+
+The evaluation track advances alongside runtime work.
+
+## E0 — Observability ceiling
+
+### Question
+
+What fraction of important failures are visible **early enough to act** on the chosen observation surface?
+
+Measure:
+
+- directly observable tool outcomes;
+- visible goal/constraint context;
+- failure classes that are structurally invisible;
+- earliest step/turn where a warranted intervention becomes observable.
+
+Re-measure after App Server migration.
+
+---
+
+## E1 — Ground-truth task set
+
+Build a small reproducible corpus where success is mechanically decidable.
+
+Each task needs:
+
+```text
+repository/fixture version
+user prompt
+known initial failing state
+objective check command
+provenance
+cost budget
+```
+
+Possible source: a carefully selected SWE-bench Verified subset or equivalent local fixtures.
+
+Exit criterion: `spotter experiment --run --check ...` completes across enough tasks to produce real control/guidance outcomes.
+
+---
 
 ## E2 — Replay/fork fidelity
 
-Before causal claims rely on fork pairs, measure the instrument itself:
+Before using forks for causal claims, measure the instrument.
 
-- identical-arm noise floor
-- continuation similarity
-- environmental failure rate
-- effect of detached worktree differences
+Experiments:
 
-Any claimed intervention effect should be interpreted relative to this noise floor.
+- identical control vs identical control;
+- repeated continuations from the same prefix;
+- worktree/environment failure rate;
+- model nondeterminism distribution.
+
+Report a noise floor before interpreting intervention deltas.
+
+---
 
 ## E3 — Precision and miss rate
 
-Positive-only labeling is insufficient.
+Positive labels alone are insufficient.
 
-Measure both:
+Measure:
 
-- precision / false-positive rate on flags and reviewer findings
-- sampled miss rate / recall estimate on unflagged trajectories or proposals
+- precision / false-positive rate on emitted candidates/verdicts;
+- sampled miss rate / recall estimate on unflagged trajectories;
+- coverage per failure class;
+- abstention/blind-spot rate separately from incorrect verdicts.
 
 A detector that never fires should not appear perfect.
 
+---
+
 ## E4 — Intervention advantage and harm
 
-Use same-prefix counterfactuals to ask:
+For a shared prefix:
 
-> Did this intervention improve the outcome compared with continuing from the same prefix?
+```text
+control: continue
+vs
+intervention: VERIFY / NUDGE / later stronger action
+```
 
-Report at least:
+Classify outcomes:
 
-- guidance better
-- control better (harm)
-- tied
-- incomplete/failed
+```text
+intervention better
+control better (harm)
+tied
+incomplete / infrastructure failure
+```
 
-Do not enable live injection by default before useful intervention advantage and wrong-nudge/sycophancy behavior are measured.
+Report sample size and coverage. Do not enable live intervention by default from anecdotal success.
 
-## E5 — Operational effect
+Also test **wrong-nudge susceptibility**: Main should be able to reject plausible but incorrect Spotter advice when evidence contradicts it.
 
-Eventually compare real-session configurations:
+---
+
+## E5 — Real-session operational A/B
+
+Eventually compare full runtime configurations:
 
 ```text
 A. Vanilla Codex
 B. Periodic async reviewer
 C. Event-driven Spotter
 D. Event-driven Spotter + deterministic gate
-E. Full Spotter with stronger control
+E. Full Spotter with stronger recovery/control
 ```
 
-This answers a different question from fork pairs: whether running Spotter at all improves real work across a population of sessions.
+This answers a population-level question different from same-prefix forks: **does running Spotter in real work improve outcomes enough to justify its cost?**
 
 ---
 
 # Primary metrics
 
-## Outcome
-
-- task success / resolution
-- regression rate
-
-## Efficiency
-
-- main-agent tokens
-- reviewer tokens
-- tool calls
-- repeated-action count
-- elapsed/tool-execution time
-- Spotter CPU/memory overhead
-
-## Observation quality
-
-- observable outcome rate
-- event coverage
-- missing-goal/constraint rate
-- supervision liveness
-
-## Intervention quality
-
-- interventions per run
-- precision
-- miss rate / sampled recall
-- intervention advantage
-- harm rate
-- recovery rate
-- ignored-intervention rate
-
-## Timing
-
-- steps from warranted intervention range to verdict
-- wasted actions before intervention
-- reviewer latency
-- delivery latency
-- stale intervention rate
-
-## Recovery
-
-- success after nudge
-- success after interrupt
-- success after restart
-- useful work retained across restart
-- external effects left unreverted
-
-## Operations
-
-- hook p50/p95/p99
-- App Server reconnect latency
-- daemon restart/recovery latency
-- storage growth
-- migration/upgrade failures in fixtures
+| Dimension | Metrics |
+| --- | --- |
+| Outcome | task success/resolution, regression rate |
+| Main efficiency | main tokens, tool calls, repeated actions, elapsed/tool time |
+| Spotter cost | reviewer tokens, model calls, CPU/memory, journal/storage growth |
+| Observation | event coverage, observable outcome rate, missing goal/constraint rate, disconnect rate |
+| Detection | precision, FP rate, miss-rate/recall estimate, abstention/blind spots |
+| Intervention | intervention advantage, harm rate, recovery, ignored rate |
+| Timing | detection delay, reviewer latency, delivery latency, stale rate, wasted actions before intervention |
+| Recovery | success after nudge/interrupt/restart, retained useful work, unreverted external effects |
+| Operations | Hook p50/p95/p99, reconnect time, daemon recovery time, upgrade/migration failure rate |
 
 ---
 
-# False-positive budgets
+# Intervention evidence budgets
 
-Strong interventions need increasingly strict evidence.
-
-Initial philosophy:
-
-- `VERIFY`: can tolerate uncertainty because it requests evidence
-- `NUDGE`: conservative
-- `BLOCK`: near-deterministic
-- `INTERRUPT`: very high confidence
-- `RESTART`: extremely rare and likely user-visible/confirmable
-
-Exact thresholds should be learned from evaluation rather than chosen once from intuition.
-
----
-
-# Revised MVP definition
-
-A useful public Spotter does not need a graph database, learned policy, or automatic rollback engine.
-
-It needs to demonstrate this loop reliably **on the standalone runtime boundary**:
+The stronger the action, the stronger the evidence requirement.
 
 ```text
-1. Observe an active coding-agent trajectory through a reliable runtime surface.
+VERIFY
+  can tolerate uncertainty because it asks for evidence
+
+NUDGE
+  conservative semantic intervention
+
+BLOCK
+  near-deterministic policy only
+
+INTERRUPT
+  very high precision + shadow evidence first
+
+RESTART
+  extremely rare, auditable, likely user-visible/confirmable initially
+```
+
+Exact thresholds should come from evaluation, not intuition.
+
+---
+
+# Revised MVP
+
+A useful public Spotter does **not** require a graph database, learned policy, or automatic rollback engine.
+
+It must prove this loop on the standalone runtime boundary:
+
+```text
+1. Observe the real active coding-agent trajectory.
 2. Maintain independent live state for goal, constraints, hypotheses, evidence, and progress.
-3. Detect a small set of trajectory problems with cheap signals/verifiers.
-4. Ask an independently configured reviewer to verify ambiguous candidates.
-5. Intervene with async VERIFY/NUDGE or deterministic BLOCK.
-6. Record timing, cost, delivery, and outcome.
-7. Measure whether intervention helped more than it harmed.
+3. Generate a small set of cheap candidate failure signals.
+4. Use an independent reviewer only for ambiguous candidates.
+5. Deliver async VERIFY/NUDGE to the correct active turn or deterministic BLOCK before execution.
+6. Record timing, cost, freshness, delivery, and outcome.
+7. Demonstrate that intervention helps more than it harms.
 ```
 
 The architecture is successful only if it enables this experiment without itself becoming a major source of latency, fragility, or operational burden.
+
+For current status, see [Status](status.md). For concrete runtime contracts, see [Architecture](architecture.md). For product lifecycle, see [Lifecycle](lifecycle.md).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,113 +1,246 @@
 # Roadmap
 
-Spotter should start narrow and earn complexity through evaluation.
+> **Status:** roadmap reset around the standalone runtime direction in [#66](https://github.com/Bogyie/spotter/issues/66).
 
-The first objective is not to build a complete self-healing agent runtime. It is to prove that a separate observer can improve coding-agent trajectories **without becoming a noisy source of latency and false positives**.
+Spotter should still earn complexity through evaluation, but the implementation order needs to change.
 
-## Phase 0 — Research baseline
+The hook/plugin prototype already proved enough of the idea to expose a structural problem: the next features—event-driven detection, live steering, richer audit state, interruption, multi-session supervision—want a long-lived runtime and a richer observation/control channel. Building them deeply into the current per-hook-process model would create work that must immediately be migrated again.
 
-Status: **current**
+The roadmap therefore splits into two tracks that must advance together:
 
-Deliverables:
+```text
+Runtime/Product track
+  build the architecture that can supervise reliably
 
-- project concept and terminology
-- Codex runtime capability inventory
-- related-work map
-- intervention taxonomy
-- initial evaluation design
+Evaluation track
+  prove that the supervision actually helps
+```
 
-Exit criterion:
+Neither substitutes for the other.
 
-- a stable, testable definition of Spotter's MVP
+## Current baseline
 
-## Phase 1 — Passive Spotter
+### Implemented in the prototype
 
-Build observation without intervention.
+- Codex lifecycle/tool hook ingestion
+- deterministic pre-action gates
+- shell-aware handling for several destructive command classes
+- crash-tolerant step journals
+- Git-backed snapshots and detached restore
+- snapshot dedup/pruning
+- Codex continuation fork/replay machinery
+- shadow-mode model-backed reviewer
+- periodic/detached reviewer execution
+- typed claim/evidence ledger with stale propagation where outcomes are observable
+- labels and coverage-aware metrics
+- same-prefix counterfactual experiment harness
+- Codex and Claude Code plugin packaging
+
+### Still missing or unproven
+
+- standalone runtime distribution and lifecycle
+- `spotterd` live state ownership
+- App Server as Codex's primary observation/control plane
+- event-driven signal layer
+- live `VERIFY` / `NUDGE` delivery
+- `INTERRUPT` / `RESTART`
+- complete side-effect/reversibility handling
+- a ground-truth task corpus and enough executed experiments to estimate intervention advantage
+- recall/miss-rate evidence for detectors
+- full efficiency/cost accounting
+
+This means the project is **implementation-rich but evidence-poor**: the measurement machinery exists, but the central claim that Spotter improves outcomes is not yet established.
+
+---
+
+# Runtime / product roadmap
+
+## P0 — App Server lifecycle and attach PoC
+
+**Priority: first.**
+
+Before building the daemon migration, validate the premise that makes the target Codex architecture possible.
+
+### Goal
+
+Prove that the user's ordinary Codex TUI and Spotter can share the same externally reachable App Server, and that Spotter can observe and steer the real active turn.
+
+### Experiments
+
+#### A. Codex-managed daemon
+
+```text
+external App Server daemon
+        ↓
+plain `codex` attaches
+        ↓
+Spotter attaches as second client
+        ↓
+receive same thread/turn events
+        ↓
+turn/steer reaches the user session
+```
+
+#### B. Spotter-managed external App Server
+
+Test whether Spotter can safely ensure the external App Server when relying on Codex's experimental daemon lifecycle is undesirable.
+
+#### C. Embedded/degraded baseline
+
+Document exactly what Spotter can and cannot do when Codex chooses an embedded App Server that Spotter cannot attach to.
+
+### Exit criteria
+
+- canonical App Server ownership/attach strategy chosen
+- ordinary `codex` UX remains possible
+- Spotter receives live events for the user's real thread
+- active turn identity is reliable
+- `turn/steer` works end to end
+- multi-client/multi-session behavior is understood
+- degraded mode is explicit
+
+If this phase fails, revisit the target architecture before continuing.
+
+## P1 — Standalone runtime foundation
+
+### Goal
+
+Create the smallest long-lived runtime boundary without yet rewriting every supervision feature.
 
 ### Scope
 
-- connect to Codex runtime events
-- normalize events into a simple Trace IR
-- run a separately configured reviewer model
-- record candidate trajectory problems
-- never modify Main behavior
+- `spotterd` process/runtime
+- user-service/lifecycle abstraction where required
+- Unix-domain-socket IPC for the remaining synchronous hook bridge
+- App Server manager/client
+- capability negotiation
+- thread / turn / runtime-attachment identity model
+- live state container
+- connection/reconnect state machine
+- protocol/version handshake
 
-### Initial failure classes
+### Design constraint
 
-Start with a small set that is both useful and observable:
+Do not rewrite the whole project in Rust/Go. The current Python implementation is sufficient to validate the runtime boundary. A native `spotter-hook` is a later optimization if cold-start measurements justify it.
 
-1. specification / scope drift
-2. repeated low-information exploration
-3. repeated tool-failure loop
-4. consequential unverified assumption
-5. validation missing after meaningful edits
+### Exit criteria
 
-### Output
+- daemon can own more than one concurrent session/thread state
+- App Server event stream updates live memory
+- daemon restart can reconnect/reconcile state
+- current coding session does not fail when Spotter is unavailable
 
-For each detected event, record:
+## P2 — Product lifecycle
+
+### Goal
+
+Make the runtime installable, diagnosable, upgradable, and removable as a product rather than a development harness.
+
+### Scope
+
+Target distribution/control plane:
 
 ```text
-trajectory step
-candidate failure class
-reviewer verdict
-confidence
-proposed intervention
-supporting evidence
+brew install spotter
+spotter setup codex
+spotter doctor
+spotter status
+spotter teardown codex
 ```
 
-### Goal
+Implementation areas:
 
-Measure reviewer quality before allowing it to interfere with coding.
+- Homebrew/release packaging
+- `setup` transaction
+- integration manifest
+- legacy plugin migration
+- service registration if managed mode requires it
+- `doctor` and `status`
+- `teardown`
+- stable executable paths across package upgrades
+- config/schema versioning foundation
 
-## Phase 2 — Nudge mode
+### Exit criteria
 
-Enable only soft intervention.
+- clean install → setup → ordinary `codex` → teardown round trip works
+- setup is idempotent
+- partial setup failure is recoverable
+- uninstall without teardown cannot break Codex through a dangling Spotter hook
 
-### Runtime actions
+See [Lifecycle](lifecycle.md) for the complete target lifecycle.
 
-- `CONTINUE`
-- `VERIFY`
-- `NUDGE`
-
-### Principles
-
-- interventions are concise
-- reviewer does not provide a full alternate implementation
-- Main remains autonomous
-- disagreement should produce a verification request where possible
-
-### Metrics
-
-- recovery rate
-- ignored intervention rate
-- success-rate delta
-- added token cost
-- added wall-clock latency
-- intervention harm rate
-
-## Phase 3 — Deterministic pre-action gates
-
-Add synchronous blocking only for constraints that can be checked reliably without semantic LLM judgment.
-
-Examples:
-
-- forbidden dependency changes
-- forbidden paths
-- destructive command patterns
-- external-write boundaries
-- explicit user restrictions
-
-### Runtime action
-
-- `BLOCK`
+## P3 — Move existing capabilities behind the runtime boundary
 
 ### Goal
 
-Demonstrate that strong intervention can be both fast and high precision when backed by executable constraints.
+Preserve the useful prototype mechanisms while changing who owns their live state.
 
-## Phase 4 — Event-driven semantic review
+### Move/refactor
 
-Replace naive periodic review with a two-stage system.
+- journal writer
+- Trace IR/state updates
+- audit ledger
+- gate engine
+- snapshot manager
+- replay/fork manager
+- reviewer scheduler
+- labels/metrics integration
+- experiment harness
+
+### Key change
+
+```text
+before:
+hook → journal → rebuild state
+
+after:
+event → live state → policy
+                  └→ durable journal
+```
+
+### Exit criteria
+
+- current tests/guarantees remain meaningful
+- journal becomes durable history/recovery, not the hot-path state database
+- reviewer does not rebuild whole state from disk on every invocation
+
+## P4 — Make App Server primary and minimize hooks
+
+### Goal
+
+Move broad observation away from hooks.
+
+### Target migration
+
+| Hook | Target state |
+| --- | --- |
+| `SessionStart` | remove if App Server lifecycle covers it |
+| `UserPromptSubmit` | remove if App Server user-message events cover it |
+| `PreToolUse` | retain only for bounded deterministic blocking |
+| `PostToolUse` | remove in favor of App Server results/diffs |
+
+### Scope
+
+- App Server → Trace IR normalization
+- thread/turn lifecycle handling
+- command/result/diff coverage
+- reasoning/plan signals where exposed
+- token/cost observation where exposed
+- re-measure observability ceiling
+- measure hook latency/invocation reduction
+
+### Exit criteria
+
+- App Server is the primary trajectory source
+- no required observation silently disappears when hooks are removed
+- existing 10% hook-era outcome observability figure is replaced with a measured App Server-era figure
+- synchronous hook path is small and bounded
+
+## P5 — Event-driven semantic supervision
+
+### Goal
+
+Replace fixed periodic review with cheap candidate signals followed by semantic review only when warranted.
 
 ```text
 runtime event
@@ -118,193 +251,310 @@ possible issue?
     ├─ no → continue
     └─ yes
          ↓
-    Pair Reviewer
+     Pair Reviewer
 ```
 
-Potential signals:
+Candidate signals:
 
 - repeated equivalent actions
 - failure streaks
-- sudden scope growth
-- stale hypothesis reuse
-- prolonged edit-without-validation windows
+- stagnant exploration frontier
+- touched-scope growth
+- edits without validation
+- stale premise reuse
+- block circumvention
+- budget anomalies
 
-The signal layer generates hypotheses; it does not make semantic verdicts.
+Signals produce candidates, not verdicts.
 
-## Phase 5 — Interrupt and recovery
+### Exit criteria
 
-Add strong runtime control for high-confidence trajectory failure.
+- candidate signals are journaled and labelable
+- reviewer dispatch is primarily event-driven
+- calls/session and detection behavior are measured before/after the change
+
+## P6 — Live soft intervention
+
+### Goal
+
+Deliver useful reviewer decisions without blocking Main while the reviewer thinks.
 
 ### Runtime actions
 
+- `CONTINUE`
+- `VERIFY`
+- `NUDGE`
+
+### Flow
+
+```text
+signal at turn T
+    ↓
+reviewer runs asynchronously
+    ↓
+Main continues
+    ↓
+verdict ready
+    ↓
+T still active?
+  ├─ yes → turn/steer
+  └─ no  → stale/defer/discard policy
+```
+
+### Required support
+
+- reviewer job state machine
+- target turn identity
+- intervention freshness policy
+- delivery journaling
+- ignored/stale intervention metrics
+- pair-runtime contract for Main
+
+### Exit criteria
+
+- a shadow-earned reviewer decision can reach the active real Codex turn
+- repeat delivery is impossible
+- stale decisions do not leak into unrelated later turns
+- intervention latency and stale rate are measurable
+
+## P7 — Strong control and recovery
+
+### Goal
+
+Add high-cost actions only after soft intervention has evidence.
+
+### Runtime actions
+
+- `BLOCK` — already deterministic, but re-measured in new runtime
 - `INTERRUPT`
 - `RESTART`
 
-### Required supporting features
+### Required support
 
-- last-sound-step tracking
+- high precision budgets per action
+- last-sound-state representation
 - checkpoint metadata
-- external side-effect ledger
-- explicit retained-state selection for restart
+- side-effect/reversibility ledger
+- explicit retained-state selection
+- restart lineage
 
 ### Restart payload
 
-A fresh Main should receive only:
+A fresh continuation should receive only what is deliberately retained:
 
-- original user goal
+- user goal
 - explicit constraints
 - verified evidence
 - current repository state
-- intentionally preserved diff/artifacts
+- intentionally preserved artifacts
 
-It should not inherit the full failed reasoning history by default.
+Do not imply that a reasoning restart undoes external state.
 
-## Phase 6 — Evidence dependency state
+## P8 — Operational hardening
 
-Introduce lightweight claim/evidence relationships.
+### Scope
 
-```text
-Evidence
-   ↓ supports
-Hypothesis
-   ↓ motivates
-Plan / Action
-```
+- daemon/App Server reconnect recovery
+- Codex upgrade capability negotiation
+- Spotter upgrade and graceful daemon restart
+- config/journal/label/experiment schema migration
+- retention policies
+- repository registry
+- purge
+- reinstall
+- multi-agent integration lifecycle
 
-When evidence is invalidated, dependent hypotheses and pending plans become stale.
+### Goal
 
-This should begin as an in-memory structure, not a graph database.
+A Spotter installation should remain understandable after months of normal upgrades, crashes, resumes, and repository churn.
 
-## Phase 7 — Experience and adaptation
+## P9 — Experience and adaptation
 
-Only after intervention quality is measurable, allow Spotter to learn from previous runs.
+Only after intervention quality is measurable should Spotter learn from prior runs.
 
-Potential directions:
+Possible directions:
 
 - model-specific failure profiles
-- repository-specific intervention patterns
-- retrieval of previous productive / harmful interventions
+- repository-specific signal thresholds
+- retrieval of previous useful/harmful interventions
 - offline learning of intervention policy
 
-Do not introduce adaptive behavior until there is a reliable evaluation harness capable of detecting reviewer regressions.
+Do not introduce adaptive behavior without an evaluation harness capable of detecting regressions.
 
 ---
 
-# Evaluation plan
+# Evaluation roadmap
 
-## Baselines
+The runtime migration does not relax the project's measurement discipline. It makes better measurement possible.
 
-Compare at least:
+## E0 — Observability ceiling
+
+Re-measure what failures are visible before they compound after App Server becomes the observation surface.
+
+Questions:
+
+- what fraction of failed/degraded sessions were observable early enough?
+- what fraction of tool outcomes are directly observable?
+- which failure classes remain invisible?
+
+A smarter reviewer cannot beat an observation surface that never exposes the relevant evidence.
+
+## E1 — Ground-truth task set
+
+Create a small reproducible task corpus with mechanical checks so counterfactual experiments can actually run.
+
+Requirements:
+
+- fixture repository/task
+- prompt
+- objective `--check`
+- provenance
+- cost budget
+
+The first measured intervention result should be recorded even if negative or inconclusive.
+
+## E2 — Replay/fork fidelity
+
+Before causal claims rely on fork pairs, measure the instrument itself:
+
+- identical-arm noise floor
+- continuation similarity
+- environmental failure rate
+- effect of detached worktree differences
+
+Any claimed intervention effect should be interpreted relative to this noise floor.
+
+## E3 — Precision and miss rate
+
+Positive-only labeling is insufficient.
+
+Measure both:
+
+- precision / false-positive rate on flags and reviewer findings
+- sampled miss rate / recall estimate on unflagged trajectories or proposals
+
+A detector that never fires should not appear perfect.
+
+## E4 — Intervention advantage and harm
+
+Use same-prefix counterfactuals to ask:
+
+> Did this intervention improve the outcome compared with continuing from the same prefix?
+
+Report at least:
+
+- guidance better
+- control better (harm)
+- tied
+- incomplete/failed
+
+Do not enable live injection by default before useful intervention advantage and wrong-nudge/sycophancy behavior are measured.
+
+## E5 — Operational effect
+
+Eventually compare real-session configurations:
 
 ```text
 A. Vanilla Codex
-
-B. Periodic reviewer
-   async, fixed interval, nudge only
-
+B. Periodic async reviewer
 C. Event-driven Spotter
-   cheap trigger + semantic reviewer
-
-D. Spotter + Gate
-   event-driven + deterministic PreToolUse blocking
-
-E. Full Spotter
-   gate + nudge + interrupt/restart
+D. Event-driven Spotter + deterministic gate
+E. Full Spotter with stronger control
 ```
 
-## Model matrix
+This answers a different question from fork pairs: whether running Spotter at all improves real work across a population of sessions.
 
-One of Spotter's central hypotheses is that reviewer diversity matters.
+---
 
-Evaluate:
+# Primary metrics
 
-```text
-Main A + Reviewer A
-Main A + Reviewer B
-Main A + smaller specialized reviewer
-```
-
-Keep reviewer context isolated even in the same-model condition.
-
-## Primary metrics
-
-### Outcome
+## Outcome
 
 - task success / resolution
 - regression rate
 
-### Efficiency
+## Efficiency
 
-- total tokens
+- main-agent tokens
+- reviewer tokens
 - tool calls
-- elapsed time
 - repeated-action count
+- elapsed/tool-execution time
+- Spotter CPU/memory overhead
 
-### Intervention quality
+## Observation quality
+
+- observable outcome rate
+- event coverage
+- missing-goal/constraint rate
+- supervision liveness
+
+## Intervention quality
 
 - interventions per run
-- intervention precision
-- recovery after intervention
-- reviewer false-positive rate
-- intervention harm rate
+- precision
+- miss rate / sampled recall
+- intervention advantage
+- harm rate
+- recovery rate
+- ignored-intervention rate
 
-### Timing
+## Timing
 
-- first-error localization accuracy
-- steps between first meaningful deviation and intervention
-- wasted tool calls before intervention
+- steps from warranted intervention range to verdict
+- wasted actions before intervention
+- reviewer latency
+- delivery latency
+- stale intervention rate
 
-### Recovery
+## Recovery
 
 - success after nudge
 - success after interrupt
 - success after restart
 - useful work retained across restart
+- external effects left unreverted
 
-## Counterfactual evaluation
+## Operations
 
-Where runtime replay is practical, checkpoint a shared trajectory prefix and branch it:
-
-```text
-same prefix
-    │
-    ├─ continue normally
-    ├─ VERIFY / NUDGE
-    ├─ BLOCK
-    └─ INTERRUPT / RESTART
-```
-
-This allows measurement of whether the intervention itself improved the outcome rather than merely correlating with a later success.
-
-## False-positive budget
-
-Strong interventions should have explicit budgets.
-
-A plausible initial philosophy:
-
-- `VERIFY`: tolerate moderate uncertainty
-- `NUDGE`: conservative
-- `BLOCK`: near-deterministic only
-- `INTERRUPT`: very high confidence
-- `RESTART`: extremely rare
-
-Exact thresholds should be learned from evaluation rather than hard-coded from intuition.
+- hook p50/p95/p99
+- App Server reconnect latency
+- daemon restart/recovery latency
+- storage growth
+- migration/upgrade failures in fixtures
 
 ---
 
-# MVP definition
+# False-positive budgets
 
-A useful first public version of Spotter does **not** need rollback, learned policies, or a graph engine.
+Strong interventions need increasingly strict evidence.
 
-It needs to demonstrate this loop reliably:
+Initial philosophy:
+
+- `VERIFY`: can tolerate uncertainty because it requests evidence
+- `NUDGE`: conservative
+- `BLOCK`: near-deterministic
+- `INTERRUPT`: very high confidence
+- `RESTART`: extremely rare and likely user-visible/confirmable
+
+Exact thresholds should be learned from evaluation rather than chosen once from intuition.
+
+---
+
+# Revised MVP definition
+
+A useful public Spotter does not need a graph database, learned policy, or automatic rollback engine.
+
+It needs to demonstrate this loop reliably **on the standalone runtime boundary**:
 
 ```text
-1. Observe an active Codex task.
-2. Keep an independent compact view of goal, constraints, hypotheses, and progress.
-3. Detect one of a small set of trajectory problems.
-4. Ask a separately configured model to verify the suspected problem.
-5. Intervene with VERIFY/NUDGE or deterministic BLOCK.
-6. Measure whether the intervention helped or harmed.
+1. Observe an active coding-agent trajectory through a reliable runtime surface.
+2. Maintain independent live state for goal, constraints, hypotheses, evidence, and progress.
+3. Detect a small set of trajectory problems with cheap signals/verifiers.
+4. Ask an independently configured reviewer to verify ambiguous candidates.
+5. Intervene with async VERIFY/NUDGE or deterministic BLOCK.
+6. Record timing, cost, delivery, and outcome.
+7. Measure whether intervention helped more than it harmed.
 ```
 
-If this loop works, the more ambitious runtime-control features have a foundation worth building on.
+The architecture is successful only if it enables this experiment without itself becoming a major source of latency, fragility, or operational burden.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,62 +1,95 @@
 # Spotter Status
 
-> **목적:** 이 문서는 Spotter의 **현재 구현 상태, 목표 구조, 가장 가까운 다음 단계**를 빠르게 확인하기 위한 대시보드다.  
-> 방향성의 기준은 [#66](https://github.com/Bogyie/spotter/issues/66), 구현 순서는 [Roadmap](roadmap.md), 상세 구조는 [Architecture](architecture.md)를 따른다.
+> **Purpose:** the fastest way to answer three questions: **What works today? What architecture are we moving to? What should be built next?**  
+> Direction: [#66](https://github.com/Bogyie/spotter/issues/66) · Implementation order: [Roadmap](roadmap.md) · Runtime details: [Architecture](architecture.md)
 
-## 30초 요약
+---
 
-Spotter는 현재 **Hook 기반 research prototype**이다. 이미 trajectory journal, deterministic gate, snapshot/fork/replay, shadow reviewer, audit ledger, label/metrics, counterfactual experiment harness까지 구현돼 있다.
+## 30-second summary
 
-하지만 Spotter가 최종적으로 지향하는 형태는 다르다.
+Spotter is currently a **hook-based research prototype**. It already has real trajectory journals, deterministic gates, Git snapshots, fork/replay, a shadow reviewer, an audit ledger, labeling/metrics, and a counterfactual experiment harness.
+
+The target product is different:
 
 ```text
-현재
+CURRENT
 Codex hooks
    ↓
-각 hook마다 Spotter process 실행
+a new Spotter process per hook
    ↓
-journal / gate / snapshot / shadow review
+journal / gate / snapshot / periodic shadow review
 
-목표
+TARGET
 Codex TUI
    ↓
 External Codex App Server
    ↕ events / steer / interrupt
 spotterd
    ↓
-PreToolUse Hook (deterministic gate만)
+PreToolUse Hook only
+(deterministic synchronous enforcement)
 ```
 
-가장 먼저 검증해야 할 것은 **사용자가 평소처럼 `codex`를 실행하면서도 Codex TUI와 Spotter가 동일한 외부 App Server를 공유할 수 있는가**다. 이 PoC가 실패하면 target architecture를 다시 검토한다.
+The **immediate blocker** is not writing `spotterd`. It is proving that ordinary `codex` and Spotter can share the **same externally reachable App Server**, so Spotter can observe the real thread and steer the real active turn. If that PoC fails, the target architecture must be revisited before the daemon migration continues.
 
 ---
 
-## 지금 되는 것 / 아직 안 되는 것
+## Quick status
 
-| 영역 | 상태 | 지금 가능한 것 | 다음 단계 |
+Legend: ✅ implemented · 🟡 partial/shadow · 🧪 PoC required · 🎯 target · ❌ not implemented
+
+| Area | Status | What exists now | Next concrete step |
 | --- | --- | --- | --- |
-| Hook ingestion | ✅ 구현 | `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse` 수집 | App Server로 observation 이동 후 Hook 최소화 |
-| Deterministic gate | ✅ 구현 | destructive command/path/dependency 등 shadow/active 판정 | daemon IPC 뒤로 이동, latency 재측정 |
-| Journal | ✅ 구현 | crash-tolerant JSONL, cross-process append | live state의 hot store가 아니라 durable log로 역할 변경 |
-| Snapshot | ✅ 구현 | Git-backed snapshot, dedup, prune | runtime lifecycle/retention에 통합 |
-| Fork / replay | ✅ 구현 | 동일 prefix에서 Codex continuation fork | fidelity/noise floor 측정 |
-| Shadow reviewer | ✅ 구현 | `CONTINUE/VERIFY/NUDGE` 판단 기록 | event-driven dispatch + live delivery |
-| Audit ledger | ✅ 부분 구현 | observable outcome 기반 claim/evidence, stale propagation | App Server observability로 범위 확대 |
-| Label / metrics | ✅ 구현 | gate/reviewer precision 및 coverage | miss rate, timing, cost, harm/recovery 확장 |
-| Counterfactual experiment | ✅ 구현 | control/guidance pair 생성·실행 가능 | ground-truth task set으로 실제 실험 |
-| Standalone runtime | ❌ 미구현 | 없음 | `spotterd`, service, IPC |
-| App Server observation | ❌ 미구현 | 없음 | 최우선 lifecycle/attach PoC |
-| Event-driven signal engine | ❌ 미구현 | periodic reviewer만 존재 | cheap signal → reviewer |
-| Live VERIFY / NUDGE | ❌ 미구현 | verdict는 journal에만 기록 | `turn/steer` delivery |
-| INTERRUPT | ❌ 미구현 | 없음 | `turn/interrupt` |
-| RESTART | ❌ 미구현 | fork 실험 primitive만 존재 | verified state + side-effect ledger 기반 recovery |
-| Homebrew/setup lifecycle | ❌ 목표 | 현재 source/plugin 설치 | `brew install spotter`, `spotter setup codex` |
+| Hook ingestion | ✅ | `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse` are journaled | Replace broad observation with App Server events |
+| Deterministic gate | ✅ | Shell-aware checks for destructive commands, path/dependency constraints, fail-open ambiguity handling | Move gate behind daemon IPC and re-measure latency |
+| Journal | ✅ | Crash-tolerant JSONL, cross-process locking, fsync, torn-tail recovery | Make it durable history, not the hot state store |
+| Snapshot | ✅ | Git-backed snapshots, deduplication, pruning, detached restore | Integrate into runtime resource lifecycle |
+| Fork / replay | ✅ | Continue Codex from a shared prefix in a detached worktree | Measure replay fidelity/noise floor |
+| Shadow reviewer | ✅ | Produces `CONTINUE`, `VERIFY`, `NUDGE`; verdicts are recorded only | Trigger from signals, then deliver live |
+| Audit ledger | 🟡 | Claim/evidence state and stale propagation where outcomes are observable | Rebuild around richer App Server observations |
+| Labels / metrics | ✅ | Coverage-aware labeling and precision/FP metrics | Add miss-rate, timing, cost, harm/recovery metrics |
+| Counterfactual experiment harness | ✅ | Control/guidance same-prefix pairs can be prepared/run | Add a mechanically scored task set and execute real experiments |
+| Standalone runtime | ❌ | No long-lived owner of live supervision state | Implement `spotterd`, IPC, service abstraction |
+| App Server primary observation | 🧪 | Design only | Complete P0 lifecycle/attach PoC |
+| Event-driven signal engine | ❌ | Reviewer is still cadence-based | Cheap signal → reviewer dispatch |
+| Live `VERIFY` / `NUDGE` | ❌ | Reviewer decisions stop at the journal | Deliver via `turn/steer` |
+| `INTERRUPT` | ❌ | No control path | Add `turn/interrupt` after evidence gate |
+| `RESTART` | ❌ | Fork/replay is research machinery, not live recovery | Define verified-state + side-effect-aware recovery |
+| Homebrew / setup lifecycle | 🎯 | Current paths are source/plugin installs | `brew install spotter`, `spotter setup codex`, `doctor`, `teardown` |
 
 ---
 
-## 현재 사용자 경로
+## The one thing to build first
 
-현재 prototype은 source 또는 plugin 방식으로 사용한다.
+### P0 — Codex App Server lifecycle / attach PoC
+
+The question is intentionally narrow:
+
+> **Can a user run ordinary `codex`, while the Codex TUI and Spotter use the same external App Server, and can Spotter steer that exact active turn?**
+
+Test three paths:
+
+1. **Codex-managed daemon** — start/ensure the Codex App Server daemon, then verify plain `codex` reuses it and Spotter can attach as a second client.
+2. **Spotter-managed App Server** — Spotter starts/owns the external `codex app-server` process while preserving a normal `codex` UX.
+3. **Embedded baseline** — document exactly which Spotter capabilities remain when Codex chooses an embedded App Server that Spotter cannot attach to.
+
+PoC exit criteria:
+
+- TUI and Spotter observe the same thread id.
+- Spotter receives live events for the same active turn.
+- Active `turn_id` tracking remains correct across multiple tool calls.
+- `turn/steer` changes the actual user-visible Codex turn.
+- Multiple concurrent Codex sessions are distinguishable.
+- Reconnect behavior is understood.
+- `status` / `doctor` can distinguish healthy, degraded, and disconnected states.
+
+**Do not proceed to the daemon migration if these properties are not proven.**
+
+---
+
+## Current user path
+
+The current prototype can still be used from source:
 
 ```bash
 git clone https://github.com/Bogyie/spotter.git
@@ -66,14 +99,14 @@ source .venv/bin/activate
 python -m pip install -e .
 ```
 
-또는 현재 plugin compatibility path:
+Current Codex plugin compatibility path:
 
 ```bash
 codex plugin marketplace add bogyie/spotter
 codex plugin add spotter@spotter
 ```
 
-현재 세션을 확인·평가하는 명령:
+Useful current commands:
 
 ```bash
 spotter analyze
@@ -86,20 +119,20 @@ spotter experiment --session <id> --step <n> --guidance "..." --check "..."
 
 ---
 
-## 목표 사용자 경로
+## Target user path
 
-구현 후 목표 UX:
+After the standalone runtime migration, ordinary setup should look like this:
 
 ```bash
 brew install spotter
 spotter setup codex
 spotter doctor
 
-# 이후 평소처럼
+# normal use afterwards
 codex
 ```
 
-운영/디버깅용:
+Operational/debug commands remain available, but should not be required for normal use:
 
 ```bash
 spotter status
@@ -110,7 +143,7 @@ spotter doctor
 spotter teardown codex
 ```
 
-사용자가 매번 아래를 직접 실행하게 만들지 않는다.
+The user should **not** need to run either command before every Codex session:
 
 ```bash
 spotter daemon start
@@ -119,47 +152,20 @@ codex app-server daemon start
 
 ---
 
-## 가장 중요한 현재 blocker
-
-### P0 — Codex App Server lifecycle / attach PoC
-
-확인할 질문은 단순하다.
-
-> **plain `codex`를 실행했을 때, 사용자 TUI와 Spotter가 동일한 외부 App Server를 공유하고 Spotter가 그 active turn에 `turn/steer`를 보낼 수 있는가?**
-
-검증할 세 경로:
-
-1. Codex managed App Server daemon을 미리 띄우고 plain `codex`가 자동 attach하는 경로
-2. Spotter가 외부 `codex app-server` lifecycle을 관리하는 경로
-3. 외부 App Server를 확보하지 못했을 때 embedded/degraded mode의 실제 capability
-
-PoC exit criteria:
-
-- TUI와 Spotter가 같은 thread/turn을 본다.
-- Spotter가 App Server event stream을 실시간 수신한다.
-- active `turn_id`를 신뢰성 있게 추적한다.
-- `turn/steer`가 실제 사용자 세션에 전달된다.
-- concurrent Codex session을 구분한다.
-- 실패 시 `doctor/status`에서 degraded 상태가 명확하게 보인다.
-
-이 조건을 만족하지 못하면 P1 daemon migration으로 넘어가지 않는다.
-
----
-
-## 구현 순서
+## Implementation sequence
 
 ```text
 P0  App Server lifecycle / attach PoC
  ↓
-P1  spotterd + App Server client + IPC + session identity
+P1  spotterd + App Server client + IPC + thread/turn identity
  ↓
-P2  install/setup/doctor/status/teardown/package lifecycle
+P2  install/setup/status/doctor/teardown/package lifecycle
  ↓
-P3  기존 journal/gate/audit/reviewer/snapshot 기능을 runtime 뒤로 이관
+P3  move journal/gate/audit/reviewer/snapshot behind the runtime boundary
  ↓
-P4  App Server를 primary observation으로 전환, Hook 최소화
+P4  App Server primary observation + Hook minimization
  ↓
-P5  cheap signal → event-driven reviewer
+P5  cheap signals → event-driven reviewer
  ↓
 P6  live VERIFY / NUDGE via turn/steer
  ↓
@@ -170,32 +176,46 @@ P8  upgrade/migration/retention/purge/multi-agent hardening
 P9  experience / adaptation
 ```
 
-자세한 dependency와 exit criteria는 [Roadmap](roadmap.md)을 본다.
+Each phase has explicit dependencies and exit criteria in [Roadmap](roadmap.md).
 
 ---
 
-## 문서 빠른 탐색
+## Evidence status
 
-| 알고 싶은 것 | 문서 |
+Implementation progress and research evidence are separate.
+
+| Question | Evidence today |
 | --- | --- |
-| Spotter가 무엇이고 왜 필요한가 | [Concept](concept.md) |
-| 지금 무엇이 구현됐나 | **이 문서** |
-| runtime process/data flow가 어떻게 생기나 | [Architecture](architecture.md) |
-| 설치→setup→사용→업데이트→제거가 어떻게 이어지나 | [Lifecycle](lifecycle.md) |
-| 무엇부터 구현할 것인가 | [Roadmap](roadmap.md) |
-| 어떤 연구를 근거로 삼고 무엇이 아직 미검증인가 | [Research](research.md) |
-| 방향성 umbrella issue | [#66](https://github.com/Bogyie/spotter/issues/66) |
+| Can Spotter collect real coding-agent trajectories? | Yes |
+| Can deterministic gates catch concrete policy violations? | Yes, with measured false-positive/blind-spot work still ongoing |
+| Can Spotter produce plausible semantic reviewer verdicts? | Yes, in shadow mode |
+| Can Spotter branch a shared prefix for counterfactual experiments? | Yes |
+| Has live Spotter guidance been shown to improve task outcomes? | **No** |
+| Is intervention advantage positive on a ground-truth task set? | **Not measured yet** |
+| Is the App Server target architecture operationally viable? | **PoC required** |
+
+A mechanism being implemented does not prove it improves outcomes. Null and negative results are first-class outcomes for this project.
 
 ---
 
-## 상태 표기 규칙
+## Documentation map
 
-문서에서는 아래 의미를 구분한다.
+| If you want to know... | Read |
+| --- | --- |
+| What Spotter is and why it exists | [Concept](concept.md) |
+| What is implemented right now | **This document** |
+| Exact process/data/control boundaries | [Architecture](architecture.md) |
+| Install → setup → run → recover → upgrade → remove | [Lifecycle](lifecycle.md) |
+| What should be built in what order | [Roadmap](roadmap.md) |
+| Prior work, borrowed mechanisms, and open research questions | [Research](research.md) |
+| The umbrella design decision | [#66](https://github.com/Bogyie/spotter/issues/66) |
 
-- ✅ **Implemented** — 코드가 존재하고 최소한 테스트/실사용 증거가 있다.
-- 🟡 **Partial / shadow** — 동작 일부가 구현됐거나 의도적으로 observe-only다.
-- 🧪 **PoC required** — architecture 전제로 사용하기 전에 E2E 검증이 필요하다.
-- 🎯 **Target** — 합의된 목표 구조지만 아직 구현되지 않았다.
-- ❌ **Not implemented** — 코드 경로가 없다.
+---
 
-구현 완료와 효과 입증도 구분한다. 예를 들어 reviewer가 `NUDGE`를 생성할 수 있다는 사실은 **NUDGE가 실제로 task outcome을 개선한다는 증거가 아니다.**
+## Status terminology
+
+- ✅ **Implemented** — code exists and has at least tests or real-use evidence.
+- 🟡 **Partial / shadow** — only part of the behavior exists, or it intentionally cannot affect Main yet.
+- 🧪 **PoC required** — a design dependency that must be proven end-to-end before becoming an architectural assumption.
+- 🎯 **Target** — agreed direction, not yet implemented.
+- ❌ **Not implemented** — no production path exists yet.

--- a/docs/status.md
+++ b/docs/status.md
@@ -32,6 +32,13 @@ PreToolUse Hook only
 
 The **immediate blocker** is not writing `spotterd`. It is proving that ordinary `codex` and Spotter can share the **same externally reachable App Server**, so Spotter can observe the real thread and steer the real active turn. If that PoC fails, the target architecture must be revisited before the daemon migration continues.
 
+### Read next
+
+- Implementing runtime internals → [Architecture](architecture.md)
+- Implementing install/setup/update/remove → [Lifecycle](lifecycle.md)
+- Deciding what to build first → [Roadmap](roadmap.md)
+- Evaluating whether the idea actually works → [Research](research.md)
+
 ---
 
 ## Quick status

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,201 @@
+# Spotter Status
+
+> **목적:** 이 문서는 Spotter의 **현재 구현 상태, 목표 구조, 가장 가까운 다음 단계**를 빠르게 확인하기 위한 대시보드다.  
+> 방향성의 기준은 [#66](https://github.com/Bogyie/spotter/issues/66), 구현 순서는 [Roadmap](roadmap.md), 상세 구조는 [Architecture](architecture.md)를 따른다.
+
+## 30초 요약
+
+Spotter는 현재 **Hook 기반 research prototype**이다. 이미 trajectory journal, deterministic gate, snapshot/fork/replay, shadow reviewer, audit ledger, label/metrics, counterfactual experiment harness까지 구현돼 있다.
+
+하지만 Spotter가 최종적으로 지향하는 형태는 다르다.
+
+```text
+현재
+Codex hooks
+   ↓
+각 hook마다 Spotter process 실행
+   ↓
+journal / gate / snapshot / shadow review
+
+목표
+Codex TUI
+   ↓
+External Codex App Server
+   ↕ events / steer / interrupt
+spotterd
+   ↓
+PreToolUse Hook (deterministic gate만)
+```
+
+가장 먼저 검증해야 할 것은 **사용자가 평소처럼 `codex`를 실행하면서도 Codex TUI와 Spotter가 동일한 외부 App Server를 공유할 수 있는가**다. 이 PoC가 실패하면 target architecture를 다시 검토한다.
+
+---
+
+## 지금 되는 것 / 아직 안 되는 것
+
+| 영역 | 상태 | 지금 가능한 것 | 다음 단계 |
+| --- | --- | --- | --- |
+| Hook ingestion | ✅ 구현 | `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse` 수집 | App Server로 observation 이동 후 Hook 최소화 |
+| Deterministic gate | ✅ 구현 | destructive command/path/dependency 등 shadow/active 판정 | daemon IPC 뒤로 이동, latency 재측정 |
+| Journal | ✅ 구현 | crash-tolerant JSONL, cross-process append | live state의 hot store가 아니라 durable log로 역할 변경 |
+| Snapshot | ✅ 구현 | Git-backed snapshot, dedup, prune | runtime lifecycle/retention에 통합 |
+| Fork / replay | ✅ 구현 | 동일 prefix에서 Codex continuation fork | fidelity/noise floor 측정 |
+| Shadow reviewer | ✅ 구현 | `CONTINUE/VERIFY/NUDGE` 판단 기록 | event-driven dispatch + live delivery |
+| Audit ledger | ✅ 부분 구현 | observable outcome 기반 claim/evidence, stale propagation | App Server observability로 범위 확대 |
+| Label / metrics | ✅ 구현 | gate/reviewer precision 및 coverage | miss rate, timing, cost, harm/recovery 확장 |
+| Counterfactual experiment | ✅ 구현 | control/guidance pair 생성·실행 가능 | ground-truth task set으로 실제 실험 |
+| Standalone runtime | ❌ 미구현 | 없음 | `spotterd`, service, IPC |
+| App Server observation | ❌ 미구현 | 없음 | 최우선 lifecycle/attach PoC |
+| Event-driven signal engine | ❌ 미구현 | periodic reviewer만 존재 | cheap signal → reviewer |
+| Live VERIFY / NUDGE | ❌ 미구현 | verdict는 journal에만 기록 | `turn/steer` delivery |
+| INTERRUPT | ❌ 미구현 | 없음 | `turn/interrupt` |
+| RESTART | ❌ 미구현 | fork 실험 primitive만 존재 | verified state + side-effect ledger 기반 recovery |
+| Homebrew/setup lifecycle | ❌ 목표 | 현재 source/plugin 설치 | `brew install spotter`, `spotter setup codex` |
+
+---
+
+## 현재 사용자 경로
+
+현재 prototype은 source 또는 plugin 방식으로 사용한다.
+
+```bash
+git clone https://github.com/Bogyie/spotter.git
+cd spotter
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e .
+```
+
+또는 현재 plugin compatibility path:
+
+```bash
+codex plugin marketplace add bogyie/spotter
+codex plugin add spotter@spotter
+```
+
+현재 세션을 확인·평가하는 명령:
+
+```bash
+spotter analyze
+spotter review --session <id>
+spotter label --session <id> --step <n> --verdict fp
+spotter metrics
+spotter fork --session <id> --step <n>
+spotter experiment --session <id> --step <n> --guidance "..." --check "..."
+```
+
+---
+
+## 목표 사용자 경로
+
+구현 후 목표 UX:
+
+```bash
+brew install spotter
+spotter setup codex
+spotter doctor
+
+# 이후 평소처럼
+codex
+```
+
+운영/디버깅용:
+
+```bash
+spotter status
+spotter sessions
+spotter daemon status
+spotter daemon restart
+spotter doctor
+spotter teardown codex
+```
+
+사용자가 매번 아래를 직접 실행하게 만들지 않는다.
+
+```bash
+spotter daemon start
+codex app-server daemon start
+```
+
+---
+
+## 가장 중요한 현재 blocker
+
+### P0 — Codex App Server lifecycle / attach PoC
+
+확인할 질문은 단순하다.
+
+> **plain `codex`를 실행했을 때, 사용자 TUI와 Spotter가 동일한 외부 App Server를 공유하고 Spotter가 그 active turn에 `turn/steer`를 보낼 수 있는가?**
+
+검증할 세 경로:
+
+1. Codex managed App Server daemon을 미리 띄우고 plain `codex`가 자동 attach하는 경로
+2. Spotter가 외부 `codex app-server` lifecycle을 관리하는 경로
+3. 외부 App Server를 확보하지 못했을 때 embedded/degraded mode의 실제 capability
+
+PoC exit criteria:
+
+- TUI와 Spotter가 같은 thread/turn을 본다.
+- Spotter가 App Server event stream을 실시간 수신한다.
+- active `turn_id`를 신뢰성 있게 추적한다.
+- `turn/steer`가 실제 사용자 세션에 전달된다.
+- concurrent Codex session을 구분한다.
+- 실패 시 `doctor/status`에서 degraded 상태가 명확하게 보인다.
+
+이 조건을 만족하지 못하면 P1 daemon migration으로 넘어가지 않는다.
+
+---
+
+## 구현 순서
+
+```text
+P0  App Server lifecycle / attach PoC
+ ↓
+P1  spotterd + App Server client + IPC + session identity
+ ↓
+P2  install/setup/doctor/status/teardown/package lifecycle
+ ↓
+P3  기존 journal/gate/audit/reviewer/snapshot 기능을 runtime 뒤로 이관
+ ↓
+P4  App Server를 primary observation으로 전환, Hook 최소화
+ ↓
+P5  cheap signal → event-driven reviewer
+ ↓
+P6  live VERIFY / NUDGE via turn/steer
+ ↓
+P7  INTERRUPT / RESTART / side-effect-aware recovery
+ ↓
+P8  upgrade/migration/retention/purge/multi-agent hardening
+ ↓
+P9  experience / adaptation
+```
+
+자세한 dependency와 exit criteria는 [Roadmap](roadmap.md)을 본다.
+
+---
+
+## 문서 빠른 탐색
+
+| 알고 싶은 것 | 문서 |
+| --- | --- |
+| Spotter가 무엇이고 왜 필요한가 | [Concept](concept.md) |
+| 지금 무엇이 구현됐나 | **이 문서** |
+| runtime process/data flow가 어떻게 생기나 | [Architecture](architecture.md) |
+| 설치→setup→사용→업데이트→제거가 어떻게 이어지나 | [Lifecycle](lifecycle.md) |
+| 무엇부터 구현할 것인가 | [Roadmap](roadmap.md) |
+| 어떤 연구를 근거로 삼고 무엇이 아직 미검증인가 | [Research](research.md) |
+| 방향성 umbrella issue | [#66](https://github.com/Bogyie/spotter/issues/66) |
+
+---
+
+## 상태 표기 규칙
+
+문서에서는 아래 의미를 구분한다.
+
+- ✅ **Implemented** — 코드가 존재하고 최소한 테스트/실사용 증거가 있다.
+- 🟡 **Partial / shadow** — 동작 일부가 구현됐거나 의도적으로 observe-only다.
+- 🧪 **PoC required** — architecture 전제로 사용하기 전에 E2E 검증이 필요하다.
+- 🎯 **Target** — 합의된 목표 구조지만 아직 구현되지 않았다.
+- ❌ **Not implemented** — 코드 경로가 없다.
+
+구현 완료와 효과 입증도 구분한다. 예를 들어 reviewer가 `NUDGE`를 생성할 수 있다는 사실은 **NUDGE가 실제로 task outcome을 개선한다는 증거가 아니다.**


### PR DESCRIPTION
## Purpose

Align the repository documentation with the standalone-runtime direction tracked in [#66](https://github.com/Bogyie/spotter/issues/66).

This is a **documentation-only PR**. It does not implement `spotterd`, App Server observation, live steering, or Homebrew packaging. Instead, it makes the current prototype, target architecture, lifecycle, implementation order, and evidence gaps explicit enough to guide the next implementation PRs.

**Related to #66 — this PR does not close #66.**

## Documentation structure

The docs now have clear ownership instead of repeating the same architecture story in several places:

- `README.md` — first-page project overview, current vs target, immediate blocker, current/target usage
- `docs/README.md` — documentation landing page and recommended reading paths
- `docs/status.md` — current implementation dashboard, evidence status, P0 blocker, next sequence
- `docs/concept.md` — problem model, trajectory failures, intervention semantics, invariants
- `docs/architecture.md` — concrete component contracts, runtime flows, state/identity/IPC/failure boundaries
- `docs/lifecycle.md` — install → setup → runtime → recovery → upgrade → teardown → uninstall → purge → reinstall
- `docs/roadmap.md` — dependency-driven runtime/product phases plus a separate evaluation track
- `docs/research.md` — literature-to-mechanism map, implementation status, evidence gates, research questions

## Scan-first structure

Each long document now puts the information most people need first:

1. a **30-second summary**;
2. a quick navigation/status/decision table;
3. the immediate blocker or relevant contract;
4. detailed sections below.

The lower sections are intentionally more concrete than before. They describe process ownership, inputs/outputs, state machines, failure behavior, setup transaction stages, resource ownership, exit criteria, and the measurements required to justify the next phase.

## Core architecture direction

```text
CURRENT
Codex hooks
   ↓
per-hook Spotter processes
   ↓
journal / gate / snapshot / periodic shadow reviewer

TARGET
Codex TUI
   ↓
External Codex App Server
   ↕ events / steer / interrupt
spotterd
   ↓
PreToolUse Hook only for deterministic synchronous enforcement
```

The target remains conditional on **P0**. Before building the daemon migration, Spotter must prove that ordinary `codex` and Spotter can share the same external App Server, observe the same thread/turn, and that `turn/steer` reaches the real active user turn.

If that PoC fails, the architecture is revisited before P1.

## Runtime / product roadmap

```text
P0  App Server lifecycle / attach PoC
 ↓
P1  standalone runtime foundation
 ↓
P2  package/setup/status/doctor/teardown lifecycle
 ↓
P3  move existing capabilities behind spotterd
 ↓
P4  App Server primary observation + Hook minimization
 ↓
P5  cheap signals → event-driven reviewer
 ↓
P6  live VERIFY / NUDGE via turn/steer
 ↓
P7  INTERRUPT / RESTART / side-effect-aware recovery
 ↓
P8  operational hardening
 ↓
P9  experience / adaptation
```

A separate evaluation track now makes it explicit that architecture progress is not research evidence:

```text
E0  observability ceiling
E1  mechanically scored task set
E2  replay/fork fidelity
E3  precision + miss rate
E4  intervention advantage + harm
E5  real-session operational A/B
```

## Lifecycle detail added

`docs/lifecycle.md` is now an operational specification rather than a high-level narrative. It defines:

- package-owned vs integration-owned vs user-data resources;
- `spotter setup codex` as `INSPECT → PLAN → BACKUP → APPLY → START/CONNECT → VERIFY → COMMIT MANIFEST`;
- partial setup rollback/reconciliation;
- App Server lifecycle/ownership strategies;
- managed/login-scoped vs portable runtime considerations;
- normal thread/turn/reviewer lifecycle;
- status/doctor/repair contracts;
- daemon and App Server crash recovery;
- Codex and Spotter upgrade behavior;
- schema/protocol/version compatibility;
- teardown semantics;
- uninstall-without-teardown safety;
- repository-aware purge and reinstall;
- legacy plugin migration.

## Architecture detail added

`docs/architecture.md` now specifies component contracts for the intended runtime, including responsibilities, inputs, outputs, owned state, and failure posture for:

- `spotterd`
- CLI/control plane
- App Server client
- thread/session manager
- Trace IR normalization
- audit state
- signal engine
- reviewer scheduler
- intervention controller
- deterministic gate
- journal/snapshot managers
- integration manager

It also defines the thread / turn / runtime-attachment / reviewer-job identity model and explicit degraded-mode reporting.

## Current implementation vs target behavior

The docs preserve the distinction between what already exists and what is planned.

Implemented today includes:

- Hook ingestion
- deterministic gates
- crash-safe journals
- Git snapshots and detached restore
- fork/replay machinery
- shadow reviewer
- claim/evidence ledger where outcomes are observable
- labels/metrics
- counterfactual experiment harness

Target / not yet implemented includes:

- standalone Homebrew runtime
- `spotterd` live-state ownership
- App Server primary observation
- event-driven signal engine
- live `turn/steer`
- `turn/interrupt`
- `RESTART`

## Scope

Documentation only. No runtime/code behavior changes.

Changed documentation:

- `README.md`
- `docs/README.md` (new)
- `docs/status.md` (new)
- `docs/concept.md`
- `docs/architecture.md`
- `docs/lifecycle.md` (new)
- `docs/roadmap.md`
- `docs/research.md`

All repository documentation in this PR remains in English.