### PR TITLE
chore: add contribution guides and purpose-specific templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/architecture.yml
+++ b/.github/ISSUE_TEMPLATE/architecture.yml
@@ -1,0 +1,28 @@
+name: Architecture / design
+description: Propose a change to ownership, interfaces, lifecycle, state, or runtime boundaries.
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Decision / problem
+      description: What architectural question must be resolved, and why now?
+    validations:
+      required: true
+  - type: textarea
+    id: boundary
+    attributes:
+      label: Current vs desired boundary
+      description: What owns the behavior/state today, and what should own it instead?
+      placeholder: Observation, control, enforcement, persistence, process, adapter, lifecycle...
+    validations:
+      required: true
+  - type: textarea
+    id: tradeoffs
+    attributes:
+      label: Constraints / tradeoffs
+      description: Latency, compatibility, failure modes, migration, resource ownership, or alternatives.
+  - type: textarea
+    id: exit
+    attributes:
+      label: Proof / exit criteria
+      description: What PoC, test, or observable result would be enough to make the decision?

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,25 @@
+name: Bug report
+description: Something is broken or behaves differently from the intended contract.
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the incorrect behavior and its impact.
+      placeholder: What did Spotter do, and what did you expect instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction / context
+      description: Minimal steps, command, session context, logs, or a small example. Remove secrets first.
+      placeholder: Steps or context that make the problem reproducible...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Add only details that may matter.
+      placeholder: Spotter version/commit, OS, Python, Codex/Claude version, relevant config...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,17 @@
+name: Documentation
+description: Report unclear, missing, inconsistent, or outdated documentation.
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is unclear or outdated?
+      description: Point to the page/section when possible and describe the confusion or mismatch.
+    validations:
+      required: true
+  - type: textarea
+    id: desired
+    attributes:
+      label: Desired outcome
+      description: What should a reader understand or find more easily after this is fixed?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/experiment.yml
+++ b/.github/ISSUE_TEMPLATE/experiment.yml
@@ -1,0 +1,29 @@
+name: Research / experiment
+description: Define an experiment whose main output is evidence for a Spotter decision.
+body:
+  - type: textarea
+    id: hypothesis
+    attributes:
+      label: Question / hypothesis
+      description: What are we trying to learn? State the decision this evidence should inform.
+    validations:
+      required: true
+  - type: textarea
+    id: design
+    attributes:
+      label: Experiment design
+      description: Baseline/comparison, task or trajectory source, controls, and execution budget.
+    validations:
+      required: true
+  - type: textarea
+    id: measurement
+    attributes:
+      label: Measurement / decision rule
+      description: What metric or mechanical check will be used, and what result would change the decision?
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Optional. Known confounders, related papers/issues, expected artifacts, or negative-result handling.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Propose a new capability or user/developer-facing behavior.
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / outcome
+      description: What should become possible, easier, safer, or more observable?
+      placeholder: Describe the problem before the implementation idea.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed direction
+      description: Optional. Sketch an approach, API, UX, or runtime behavior if you have one.
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints / tradeoffs
+      description: Optional. Latency, compatibility, lifecycle, safety, or scope constraints that matter.

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,0 +1,15 @@
+name: Maintenance / chore
+description: Tooling, CI, dependency, cleanup, packaging, or repository maintenance.
+body:
+  - type: textarea
+    id: task
+    attributes:
+      label: Task / problem
+      description: What maintenance work is needed and why now?
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Done when
+      description: Optional. A short completion or verification condition.

--- a/.github/PULL_REQUEST_TEMPLATE/architecture.md
+++ b/.github/PULL_REQUEST_TEMPLATE/architecture.md
@@ -1,0 +1,13 @@
+## Decision / problem
+<!-- What architectural problem is this PR resolving? Link the design/umbrella issue. -->
+
+Related: #
+
+## Boundary change
+<!-- What ownership/interface/lifecycle changes? Be explicit about observation, control, enforcement, state, or persistence boundaries when relevant. -->
+
+## Compatibility / migration
+<!-- Existing runtime behavior, persisted state, setup, or adapter compatibility affected? Delete if none. -->
+
+## Validation
+<!-- PoC, tests, failure/degraded cases, or measurements supporting the change. -->

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,13 @@
+## Bug
+<!-- What was wrong? Link the issue/reproduction when available. -->
+
+Fixes: #
+
+## Root cause
+<!-- Keep this short: what condition or assumption caused the bug? -->
+
+## Fix
+<!-- What changed, and why is this the right boundary for the fix? -->
+
+## Verification
+<!-- Regression test, reproduction before/after, or other checks. -->

--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,0 +1,10 @@
+## Purpose
+<!-- What should be clearer, more accurate, or easier to find after this PR? -->
+
+Related: #
+
+## What changed
+<!-- Which docs/claims/navigation were updated? -->
+
+## Accuracy check
+<!-- Is this documenting current behavior, target design, or research evidence? Call out any code/docs mismatch intentionally left open. -->

--- a/.github/PULL_REQUEST_TEMPLATE/experiment.md
+++ b/.github/PULL_REQUEST_TEMPLATE/experiment.md
@@ -1,0 +1,13 @@
+## Question / hypothesis
+<!-- What are we trying to learn? What result would change a decision? -->
+
+Related: #
+
+## Method
+<!-- Baseline/comparison, task or trajectory source, metric/check, important controls. -->
+
+## Evidence
+<!-- Results if available; otherwise state what this PR adds to make the experiment runnable. Include negative/inconclusive results. -->
+
+## Decision impact
+<!-- What should we do differently, if anything, based on this evidence? -->

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,13 @@
+## Why
+<!-- What problem or user/developer outcome does this address? Link the issue when relevant. -->
+
+Related: #
+
+## What changed
+<!-- Describe the behavior/contract added. Keep implementation detail only where it helps review. -->
+
+## Validation
+<!-- Tests, manual checks, traces, experiments, or why validation is not applicable. -->
+
+## Notes
+<!-- Optional: tradeoffs, compatibility/migration impact, follow-ups, or intentionally out-of-scope work. Delete if none. -->

--- a/.github/PULL_REQUEST_TEMPLATE/maintenance.md
+++ b/.github/PULL_REQUEST_TEMPLATE/maintenance.md
@@ -1,0 +1,10 @@
+## Purpose
+<!-- Dependency/tooling/CI/cleanup/housekeeping change and why it is useful now. -->
+
+Related: #
+
+## Changes
+<!-- Keep this to the meaningful operational changes. -->
+
+## Validation
+<!-- CI/local checks, upgrade/install check, or why validation is not applicable. -->

--- a/.github/PULL_REQUEST_TEMPLATE/refactor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/refactor.md
@@ -1,0 +1,13 @@
+## Why refactor this now?
+<!-- What complexity, coupling, or maintenance cost is being reduced? -->
+
+Related: #
+
+## What changed
+<!-- Describe the boundary/structure change. -->
+
+## Behavior
+<!-- State the intended behavioral contract. If behavior changes too, say exactly how. -->
+
+## Validation
+<!-- Tests/checks showing behavior was preserved or deliberately changed. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!--
+Purpose-specific templates also exist under .github/PULL_REQUEST_TEMPLATE/:
+feature, bugfix, documentation, refactor, architecture, experiment, maintenance.
+Keep this fallback short; delete optional sections that do not apply.
+-->
+
+## Why
+<!-- Problem, outcome, or reason for the change. Link the issue when relevant. -->
+
+Related: #
+
+## What changed
+<!-- Behavior/contract or meaningful repository changes. -->
+
+## Validation
+<!-- Tests, checks, reproduction, experiment, or why not applicable. -->
+
+## Notes
+<!-- Optional: tradeoffs, migration/compatibility impact, follow-ups, or out-of-scope work. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md
+
+This file is the operating guide for coding agents working in this repository.
+
+## Start here
+
+Before changing code, read only what the task needs:
+
+- Project state and immediate priorities: [`docs/status.md`](docs/status.md)
+- Runtime boundaries and invariants: [`docs/architecture.md`](docs/architecture.md)
+- Install/setup/update/remove behavior: [`docs/lifecycle.md`](docs/lifecycle.md)
+- Implementation order and phase gates: [`docs/roadmap.md`](docs/roadmap.md)
+- Contribution and repository conventions: [`CONTRIBUTING.md`](CONTRIBUTING.md), [`docs/conventions.md`](docs/conventions.md)
+
+Do not treat target architecture as current behavior. `docs/status.md` is the source of truth for what is implemented today.
+
+## Working rules
+
+1. **Keep the change scoped.** Do not opportunistically redesign adjacent systems.
+2. **Preserve runtime boundaries.** Agent-specific transport belongs behind adapters; supervision policy should not depend directly on Codex event shapes.
+3. **Keep semantic review off synchronous hot paths.** `PreToolUse`-style enforcement must remain bounded and deterministic.
+4. **Fail visibly, not silently.** Degraded observation/control must be diagnosable. Existing fail-open gate behavior should remain explicit.
+5. **Preserve durable-state safety.** Do not weaken journal, snapshot, ref, worktree, or migration guarantees without a deliberate design change.
+6. **Separate implementation from evidence.** A mechanism being implemented does not prove it improves outcomes.
+7. **Update docs when contracts change.** Architecture/lifecycle/roadmap/status changes should land with the code that changes them.
+
+## Where changes usually belong
+
+| Change | Primary area |
+| --- | --- |
+| CLI commands / UX | `src/spotter/cli.py` |
+| Configuration | `src/spotter/config.py`, `spotter.example.toml` |
+| Hook ingestion / hook responses | `src/spotter/hook.py`, `hooks/`, `scripts/` |
+| Agent integration | `src/spotter/adapters.py`, agent-specific modules/plugins |
+| Deterministic policy | `src/spotter/gates.py` |
+| Reviewer behavior | `src/spotter/reviewer.py`, reviewer scheduling/budget modules |
+| Claim/evidence state | `src/spotter/audit.py` |
+| Snapshot / fork / replay | snapshot/replay/experiment modules and Git helpers |
+| Metrics / labels | `src/spotter/metrics.py`, `src/spotter/labels.py` |
+| Runtime architecture direction | `docs/architecture.md`, `docs/lifecycle.md`, `docs/roadmap.md` |
+
+If the right boundary is unclear, inspect nearby tests before creating a new abstraction.
+
+## Validation
+
+Run the checks relevant to the change. For code changes, the default full suite is:
+
+```bash
+ruff format --check .
+ruff check .
+mypy src tests
+pytest
+```
+
+Prefer focused tests while iterating, then run the full suite before finishing when practical.
+
+For behavior changes, add or update tests that demonstrate the contract rather than only exercising the implementation.
+
+## Change discipline
+
+- Avoid new dependencies unless they materially simplify the design; Spotter intentionally has no runtime dependencies today.
+- Keep Python 3.11 compatibility.
+- Keep public/user-facing behavior backward compatible unless the issue/PR explicitly introduces a migration.
+- Never write tests that depend on hidden reasoning or private chain-of-thought.
+- Do not invent observed outcomes when the runtime did not provide them.
+- Do not delete Spotter-owned Git refs/worktrees with raw filesystem deletion when Git-aware cleanup is required.
+- Do not couple `spotterd` lifetime to shared Codex App Server lifetime without an explicit ownership rule.
+
+## Before opening a PR
+
+Confirm:
+
+- the change matches an issue/roadmap direction or explains why it intentionally diverges;
+- tests/checks were run and failures are disclosed;
+- docs/status are updated if implementation state changed;
+- architecture/lifecycle docs are updated if a contract changed;
+- the PR describes **why**, **what changed**, and **how it was validated**.
+
+Keep PRs reviewable. Prefer a small complete change over a broad partial rewrite.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+# Contributing to Spotter
+
+Thanks for contributing. Spotter is still a research-oriented runtime project, so small, well-scoped changes with explicit validation are especially valuable.
+
+## Before you start
+
+Use the repository docs to avoid solving the wrong layer of the problem:
+
+- [`docs/status.md`](docs/status.md) — what exists now and what is blocked
+- [`docs/architecture.md`](docs/architecture.md) — runtime boundaries and component contracts
+- [`docs/lifecycle.md`](docs/lifecycle.md) — install/setup/update/remove behavior
+- [`docs/roadmap.md`](docs/roadmap.md) — implementation order and phase gates
+- [`docs/conventions.md`](docs/conventions.md) — code, branch, commit, test, and documentation conventions
+
+For agent-assisted work, also read [`AGENTS.md`](AGENTS.md).
+
+## Pick the right workflow
+
+### Small bug / clear maintenance change
+
+Open a PR directly if the scope and expected behavior are obvious. Link an existing issue when one exists.
+
+### Feature or behavioral change
+
+Prefer an issue first when the change introduces a new user-facing behavior, runtime capability, configuration surface, or non-trivial tradeoff.
+
+### Architecture change
+
+Open an architecture issue before implementation when the change alters process ownership, observation/control/enforcement boundaries, durable-state contracts, lifecycle semantics, or core adapter interfaces.
+
+### Research / experiment
+
+Open an experiment issue when the main output is evidence rather than product behavior. Define the hypothesis, comparison, metric, and success/failure interpretation before running the experiment.
+
+### Documentation-only change
+
+A dedicated issue is optional unless the documentation change represents a new project decision.
+
+## Local setup
+
+Spotter requires Python 3.11+.
+
+```bash
+git clone https://github.com/spotter-agent/spotter.git
+cd spotter
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e '.[dev]'
+```
+
+Run the full local checks with:
+
+```bash
+ruff format --check .
+ruff check .
+mypy src tests
+pytest
+```
+
+Use focused tests during iteration, but run the relevant full checks before requesting review whenever practical.
+
+## Pull requests
+
+Keep PRs narrow enough that a reviewer can understand the behavioral change without reconstructing unrelated work.
+
+A good PR answers four questions quickly:
+
+1. **Why is this change needed?**
+2. **What behavior or contract changed?**
+3. **How was it validated?**
+4. **What remains intentionally out of scope?**
+
+Purpose-specific templates live under [`.github/PULL_REQUEST_TEMPLATE/`](.github/PULL_REQUEST_TEMPLATE/). Use the closest match; delete sections that genuinely do not apply.
+
+Available templates:
+
+- feature
+- bugfix
+- documentation
+- refactor
+- experiment / research
+- maintenance
+
+Do not pad a PR description just to fill a template. Short, specific answers are better than boilerplate.
+
+## Issues
+
+The issue picker provides purpose-specific forms for:
+
+- bug reports
+- feature requests
+- architecture / design changes
+- research / experiments
+- documentation
+- maintenance / chores
+
+Use a blank issue when none of the forms fit. The forms are intentionally lightweight; add detail only where it helps someone make a decision or reproduce a result.
+
+## Review expectations
+
+Review should focus on contracts and evidence, not stylistic preference.
+
+For code changes, reviewers should be able to determine:
+
+- whether the change is in the right component/layer;
+- whether failure/degraded behavior is explicit;
+- whether durable state and Git resources remain safe;
+- whether synchronous paths remain bounded;
+- whether tests cover the behavior that changed;
+- whether docs/status accurately describe the new implementation state.
+
+Research claims need stronger evidence than implementation claims. “The mechanism works” and “the mechanism improves task outcomes” are different statements.
+
+## Compatibility and migrations
+
+Avoid silent breaking changes. If a change affects configuration, journal/schema formats, plugin/setup behavior, or persisted state:
+
+- document the compatibility boundary;
+- provide a migration or explicit refusal path where necessary;
+- update lifecycle/convention docs as part of the same PR.
+
+## Security and sensitive reports
+
+Do not put credentials, private logs, tokens, or exploitable secrets into public issues or PRs. If a future private vulnerability-reporting channel is configured, use it for security-sensitive disclosures rather than a public issue.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,9 @@ Start here if you are reading the repository for the first time.
 | What happens from install through uninstall/reinstall? | [Lifecycle](lifecycle.md) | command-by-command operational lifecycle |
 | What should be implemented first, and what gates each phase? | [Roadmap](roadmap.md) | dependency graph, deliverables, exit criteria |
 | Which papers/ideas inform the design, and what remains unproven? | [Research](research.md) | literature-to-mechanism map + evidence gates |
-| What is the umbrella direction decision? | [Issue #66](https://github.com/Bogyie/spotter/issues/66) | design rationale and ongoing decisions |
+| How should code, branches, commits, tests, and docs be structured? | [Conventions](conventions.md) | repository-wide working conventions |
+| How do I contribute? | [Contributing](../CONTRIBUTING.md) | issue/PR workflow, setup, and review expectations |
+| What is the umbrella direction decision? | [Issue #66](https://github.com/spotter-agent/spotter/issues/66) | design rationale and ongoing decisions |
 
 ## Recommended reading paths
 
@@ -50,6 +52,16 @@ Roadmap → Evaluation track
 Status → Evidence status
 ```
 
+### I want to contribute code or docs
+
+```text
+Contributing
+  ↓
+Conventions
+  ↓
+Status / Architecture as needed
+```
+
 ## Current architectural decision in one screen
 
 ```text
@@ -84,5 +96,7 @@ To avoid maintaining duplicate specifications:
 - **Lifecycle** owns package/service/integration/session/update/removal behavior.
 - **Roadmap** owns implementation dependencies, deliverables, and exit criteria.
 - **Research** owns prior work, hypotheses, evidence, and evaluation questions.
+- **Conventions** owns repository-wide code/test/git/documentation conventions.
+- **Contributing** owns the human contribution workflow.
 
 When a detail belongs to another document, link to it rather than maintaining two competing definitions.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,282 @@
+# Repository Conventions
+
+This document is the shared convention reference for contributors and coding agents.
+
+The goal is consistency where consistency saves review time, not ceremony for its own sake.
+
+## Quick reference
+
+| Area | Convention |
+| --- | --- |
+| Python | 3.11+, typed, `ruff` + strict `mypy` |
+| Runtime dependencies | Avoid by default; justify additions |
+| Tests | Behavior-focused, deterministic, no hidden reasoning dependency |
+| Branches | `<type>/<short-kebab-description>` |
+| Commits | Short imperative summary; explain non-obvious why in body |
+| PRs | One coherent purpose, explicit validation, link issue when relevant |
+| Docs | English; current state and target design must be distinguishable |
+| Architecture | Agent transport behind adapters; semantic review async; deterministic gates bounded |
+| Persisted state | Version contracts; migrate or refuse explicitly |
+
+---
+
+## 1. Code style
+
+The repository tooling is authoritative:
+
+```bash
+ruff format --check .
+ruff check .
+mypy src tests
+pytest
+```
+
+Python conventions:
+
+- support Python 3.11+;
+- keep type annotations complete enough for strict `mypy`;
+- prefer small explicit data structures over loosely shaped dictionaries at core boundaries;
+- use standard-library facilities unless an external dependency materially improves correctness or maintainability;
+- keep side effects close to the boundary that owns them;
+- prefer pure parsing/decision functions where practical so policy is easy to test.
+
+Avoid abstractions whose only purpose is speculative future flexibility. Add a boundary when there are already distinct responsibilities or transports to isolate.
+
+## 2. Naming
+
+Use names that describe runtime meaning rather than implementation accidents.
+
+Prefer:
+
+```text
+thread_id
+turn_id
+reviewer_job
+intervention
+observation
+control
+enforcement
+```
+
+over overloaded generic names such as `session`, `state`, or `event` when a more precise scope exists.
+
+For booleans, prefer names that read as predicates (`is_stale`, `has_outcome`, `can_interrupt`).
+
+For enums/state machines, use explicit states rather than multiple loosely related flags when the lifecycle matters.
+
+## 3. Module boundaries
+
+The target architecture separates:
+
+```text
+agent adapter / transport
+        ↓
+normalized runtime representation
+        ↓
+Spotter state + policy
+        ↓
+intervention / persistence
+```
+
+Keep these invariants:
+
+- Codex-specific payload shapes should not leak throughout Spotter core.
+- App Server, hooks, and future agent transports should normalize into shared internal contracts.
+- Deterministic policy belongs outside reviewer prompts when it can be implemented directly.
+- Semantic reviewer work must not be inserted into latency-sensitive synchronous gate paths.
+- Durable logs are not a substitute for live runtime state in the target architecture.
+
+If a change intentionally violates one of these boundaries, call it out in the PR and update `docs/architecture.md`.
+
+## 4. Error and degraded behavior
+
+Spotter supervises another tool; it should not accidentally become a new single point of failure.
+
+General rules:
+
+- distinguish **healthy**, **degraded**, and **unavailable** where capabilities can fail independently;
+- do not report silence as health when observation/control is disconnected;
+- existing deterministic gate ambiguity should fail open unless an explicit policy changes that contract;
+- error messages should state the failed capability and the user-visible consequence;
+- do not silently infer missing runtime facts.
+
+Example:
+
+```text
+Observation: unavailable
+Live intervention: unavailable
+PreToolUse gate: active
+```
+
+is more useful than a single `Spotter: running` status.
+
+## 5. Persisted state and migrations
+
+Anything persisted beyond one process run is a contract.
+
+Examples:
+
+- journals
+- labels / metrics metadata
+- experiment metadata
+- integration manifests
+- configuration schemas
+- snapshot refs / repository registry
+
+When changing a persisted format:
+
+1. identify the schema/version boundary;
+2. keep compatible reads where reasonable;
+3. migrate deliberately or reject unsupported newer data;
+4. test upgrade/read behavior;
+5. update lifecycle documentation.
+
+Do not guess how to interpret unknown newer schemas.
+
+## 6. Git resources
+
+Spotter can create refs, snapshots, and detached worktrees. Treat them as managed resources, not disposable directories.
+
+- use Spotter-owned ref namespaces;
+- do not touch user HEAD/index as a side effect of snapshot/restore operations;
+- use Git-aware worktree/ref cleanup;
+- make destructive cleanup conservative and inspectable;
+- retain lineage needed by replay/experiment results.
+
+## 7. Tests
+
+Tests should prove behavior or contracts.
+
+Prefer tests that answer questions such as:
+
+- Does this gate allow/deny the intended action?
+- Does stale reviewer output stay out of a later turn?
+- Does a torn journal preserve the valid prefix?
+- Does setup remain idempotent?
+- Does degraded App Server state appear in status?
+
+Avoid tests that merely mirror internal function calls without protecting behavior.
+
+For bug fixes, add a regression test when the failure can be reproduced deterministically.
+
+For async/concurrent behavior, test ordering and identity explicitly rather than relying on sleeps when possible.
+
+## 8. Research and experiment conventions
+
+Experiments must separate hypothesis from result.
+
+Before running a meaningful experiment, record:
+
+```text
+hypothesis
+comparison / baseline
+controlled prefix or task set
+metric / mechanical check
+budget
+what result would change the decision
+```
+
+Report negative, tied, and inconclusive results. Do not promote a mechanism into default behavior merely because it was implemented successfully.
+
+When claiming intervention benefit, prefer same-prefix or otherwise controlled comparisons over anecdotes.
+
+## 9. Documentation conventions
+
+Repository documentation is written in English.
+
+Keep these categories distinct:
+
+- **Current** — implemented behavior supported by code/tests/observations
+- **Partial / shadow** — implemented but not fully active or validated
+- **PoC required** — architectural premise still needing E2E proof
+- **Target** — agreed direction, not implemented
+- **Evidence gap** — mechanism exists but its value is unproven
+
+Document ownership:
+
+- `docs/status.md` — current state and next blocker
+- `docs/concept.md` — problem, principles, intervention semantics
+- `docs/architecture.md` — component and runtime contracts
+- `docs/lifecycle.md` — install/setup/runtime/update/remove contracts
+- `docs/roadmap.md` — dependency order and exit criteria
+- `docs/research.md` — prior work, hypotheses, evidence
+
+Avoid duplicating a detailed contract across documents. Link to the owning document.
+
+## 10. Branch conventions
+
+Use:
+
+```text
+<type>/<short-kebab-description>
+```
+
+Recommended types:
+
+```text
+feature/
+fix/
+docs/
+refactor/
+experiment/
+chore/
+```
+
+Examples:
+
+```text
+feature/app-server-client
+fix/torn-journal-recovery
+docs/contribution-workflow
+experiment/reviewer-trigger-thresholds
+```
+
+Branch names are descriptive aids, not release metadata.
+
+## 11. Commit conventions
+
+Use a short imperative subject. Conventional-commit-style prefixes are encouraged but not required.
+
+Good examples:
+
+```text
+feat: add App Server capability probe
+fix: keep stale review out of completed turns
+docs: define setup and teardown contracts
+test: cover concurrent journal recovery
+```
+
+A commit body is useful when the reason is not obvious from the diff. Explain **why the chosen behavior is correct**, not a line-by-line summary.
+
+Do not spend time rewriting a useful commit history solely to satisfy a cosmetic rule.
+
+## 12. Pull request conventions
+
+Prefer one coherent purpose per PR.
+
+A PR should make these easy to find:
+
+- why the change exists;
+- behavior/contract changed;
+- validation performed;
+- issue/roadmap relationship;
+- intentionally out-of-scope work.
+
+Use the closest purpose-specific template and remove irrelevant optional sections.
+
+Architecture-changing PRs should identify changed ownership/boundaries. Research PRs should identify the evidence generated. Documentation PRs should state whether they describe current behavior or target direction.
+
+## 13. Issue conventions
+
+Issues should be decision-ready rather than exhaustive.
+
+For most issues, enough information is:
+
+```text
+problem / desired outcome
+context or reproduction
+constraints / tradeoffs when relevant
+acceptance or evidence criteria
+```
+
+Use sub-issues or follow-up issues rather than growing one implementation ticket into an unbounded backlog. Umbrella issues are appropriate for architecture/direction when they explicitly delegate concrete work.


### PR DESCRIPTION
## Purpose

Add a lightweight contribution workflow that fits Spotter's current mix of runtime engineering, architecture work, documentation, and research/experiments.

The goal is **not** to add process for its own sake. The new guides/templates should make a change decision-ready with the smallest useful amount of structure.

## What this adds

### Agent guidance

- `AGENTS.md`
  - short, execution-oriented repository guide for coding agents
  - points to the minimum docs to read by task
  - captures core runtime invariants and change-routing guidance
  - defines default validation and change-discipline rules

### Contribution / convention docs

- `CONTRIBUTING.md`
  - when to open an issue first vs PR directly
  - feature / bug / architecture / research / docs workflows
  - local setup and validation
  - review, compatibility, and migration expectations
- `docs/conventions.md`
  - Python/type/test conventions
  - module/runtime boundary rules
  - degraded-state and persisted-state conventions
  - Git resource safety
  - research/experiment conventions
  - documentation ownership/status vocabulary
  - branch / commit / PR / issue conventions
- `docs/README.md`
  - links the new contribution/convention docs
  - updates the #66 link to the transferred `spotter-agent/spotter` repository

### Pull request templates

Purpose-specific templates under `.github/PULL_REQUEST_TEMPLATE/`:

- `feature.md`
- `bugfix.md`
- `documentation.md`
- `refactor.md`
- `architecture.md`
- `experiment.md`
- `maintenance.md`

Each template stays intentionally small (roughly 3–4 sections). Architecture asks for boundary/migration impact; experiment asks for hypothesis/method/evidence/decision impact. The rest avoid generic checklist noise.

A minimal `.github/pull_request_template.md` fallback keeps normal GitHub PR creation useful even when a purpose-specific template is not selected.

### Issue forms

Purpose-specific GitHub issue forms:

- bug
- feature
- architecture / design
- research / experiment
- documentation
- maintenance / chore

Blank issues remain enabled for cases that do not fit a form cleanly.

The forms ask only for information needed to reproduce a problem or make a decision. In particular:

- architecture issues ask for **current vs desired ownership/boundary** and proof/exit criteria;
- experiment issues ask for **hypothesis, design, and decision rule** rather than feature acceptance criteria.

## Design choices

- Keep repository documentation in English.
- Prefer short free-form answers over long mandatory checklists.
- Keep architecture and research work first-class rather than forcing them into generic feature templates.
- Separate **implementation status** from **evidence of benefit**.
- Treat `AGENTS.md` as an operating guide, not a duplicate architecture document.
- Keep `CONTRIBUTING.md` focused on workflow and `docs/conventions.md` as the detailed convention reference.

## Validation

Documentation/configuration-only change.

- branch diff reviewed: 19 files, no runtime/source changes
- existing CI remains unchanged
- issue forms use GitHub issue-form YAML and blank issues remain enabled

No product behavior changes are intended.