### PR TITLE
feat: prove shared Codex App Server steering

### DIFF
--- a/docs/app-server-poc.md
+++ b/docs/app-server-poc.md
@@ -1,0 +1,88 @@
+# App Server lifecycle / attach PoC
+
+This is the reproducible experiment harness for issue
+[#78](https://github.com/spotter-agent/spotter/issues/78). It is deliberately not a production
+App Server client.
+
+## Requirements
+
+- Codex CLI 0.147.0 or newer with `codex app-server --listen` and `codex --remote`
+- Node.js 22 or newer; the harness uses Node's built-in WebSocket client
+
+Run the self-check:
+
+```bash
+node scripts/app_server_poc.mjs --self-test
+```
+
+## Spotter-managed external server
+
+Start an App Server and copy the printed WebSocket URL:
+
+```bash
+codex app-server --listen ws://127.0.0.1:0
+```
+
+Verify a second client can initialize and list threads:
+
+```bash
+node scripts/app_server_poc.mjs probe --endpoint ws://127.0.0.1:PORT
+```
+
+Start the observer before starting the TUI:
+
+```bash
+node scripts/app_server_poc.mjs observe \
+  --endpoint ws://127.0.0.1:PORT \
+  --cwd /absolute/test/directory \
+  --steer "Reply with exactly: SPOTTER_STEER_OK" \
+  --expect SPOTTER_STEER_OK \
+  --out /tmp/spotter-app-server-poc.json
+```
+
+In another terminal, connect the ordinary TUI to the same endpoint:
+
+```bash
+codex --remote ws://127.0.0.1:PORT -C /absolute/test/directory
+```
+
+The report succeeds only after the observer joins the TUI-created thread, observes its active
+turn, receives a successful `turn/steer` response, sees the expected text in an `agentMessage`,
+and sees that turn complete.
+
+## Codex-managed daemon
+
+Test the managed path separately:
+
+```bash
+codex app-server daemon start
+codex app-server daemon version
+```
+
+As of Codex CLI 0.147.0, a Homebrew Cask install cannot start this daemon: the command requires
+the standalone installer's fixed `~/.codex/packages/standalone/current/codex` path. This path
+must be retested on a standalone install before selecting it as Spotter's default lifecycle.
+
+## Observed protocol constraint
+
+A second initialized client receives global `thread/started` and `thread/status/changed`
+notifications, but does not receive the new thread's turn/item stream until it calls
+`thread/resume`. Immediately resuming from `thread/started` can race rollout creation and return
+`no rollout found`; the harness retries this bounded race.
+
+## First local result
+
+On 2026-08-13, Codex CLI 0.147.0 passed the Spotter-managed path on macOS:
+
+- an ordinary `codex --remote ...` TUI created thread
+  `019ff8a9-e7f0-70b3-8e42-872dc6bcb0ed`;
+- the observer joined it and tracked active turn
+  `019ff8a9-e97a-7ed2-ba3b-870cbd9772cc`;
+- `turn/steer` returned that same turn ID;
+- the observer received tool lifecycle events and the final `agentMessage` was
+  `SPOTTER_STEER_OK` instead of the original requested response;
+- the TUI visibly rendered `SPOTTER_STEER_OK`.
+
+This proves same-thread observation and real same-turn steering for the Spotter-managed path.
+It does not yet select the production lifecycle: the Codex-managed standalone installation,
+multiple concurrent TUIs, and reconnect behavior still need recorded runs.

--- a/scripts/app_server_poc.mjs
+++ b/scripts/app_server_poc.mjs
@@ -8,19 +8,21 @@ const usage = `usage:
   node scripts/app_server_poc.mjs observe --endpoint URL [--cwd PATH] [--steer TEXT]
        [--expect TEXT] [--timeout SECONDS] [--out FILE]
   node scripts/app_server_poc.mjs --self-test`;
+const optionKeys = new Set(["endpoint", "cwd", "steer", "expect", "timeout", "out"]);
 
 function parseArgs(argv) {
   if (argv[0] === "--self-test") return { mode: "self-test" };
   const options = { mode: argv[0], timeout: 120 };
   for (let i = 1; i < argv.length; i += 2) {
     const key = argv[i]?.replace(/^--/, "");
-    if (!key || argv[i + 1] === undefined) throw new Error(usage);
+    if (!optionKeys.has(key) || argv[i + 1] === undefined) throw new Error(usage);
     options[key] = key === "timeout" ? Number(argv[i + 1]) : argv[i + 1];
   }
   if (!["probe", "observe"].includes(options.mode) || !options.endpoint) {
     throw new Error(usage);
   }
   if (!Number.isFinite(options.timeout) || options.timeout <= 0) throw new Error(usage);
+  if (options.expect && !options.steer) throw new Error("--expect requires --steer");
   return options;
 }
 
@@ -50,6 +52,8 @@ if (options.mode === "self-test") {
   assert.equal(event.threadId, "t");
   assert.equal(event.cwd, "/tmp");
   assert.equal(activeTurn({ turns: [{ id: "u", status: "inProgress" }] }).id, "u");
+  assert.throws(() => parseArgs(["observe", "--endpoint", "ws://test", "--expct", "ok"]));
+  assert.throws(() => parseArgs(["observe", "--endpoint", "ws://test", "--expect", "ok"]));
   console.log("ok");
   process.exit(0);
 }
@@ -189,6 +193,7 @@ socket.onmessage = (event) => {
       joined.add(context.threadId);
       const turn = activeTurn(message.result?.thread);
       if (turn) {
+        // ponytail: The resume snapshot can race a newer turn; retry it in the concurrent-TUI work.
         targetTurnId = turn.id;
         steer(context.threadId, turn.id);
       }
@@ -198,7 +203,12 @@ socket.onmessage = (event) => {
     if (context.method === "turn/steer") {
       report.steer.response = message.error ?? message.result;
       if (message.error) finish(1);
-      else if (targetCompleted) finish(steerSucceeded() ? 0 : 1);
+      else if (targetCompleted) {
+        if (!steerSucceeded() && options.expect) {
+          report.error = `agent response did not contain: ${options.expect}`;
+        }
+        finish(steerSucceeded() ? 0 : 1);
+      }
     }
     return;
   }

--- a/scripts/app_server_poc.mjs
+++ b/scripts/app_server_poc.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { writeFileSync } from "node:fs";
+
+const usage = `usage:
+  node scripts/app_server_poc.mjs probe --endpoint ws://127.0.0.1:PORT
+  node scripts/app_server_poc.mjs observe --endpoint URL [--cwd PATH] [--steer TEXT]
+       [--expect TEXT] [--timeout SECONDS] [--out FILE]
+  node scripts/app_server_poc.mjs --self-test`;
+
+function parseArgs(argv) {
+  if (argv[0] === "--self-test") return { mode: "self-test" };
+  const options = { mode: argv[0], timeout: 120 };
+  for (let i = 1; i < argv.length; i += 2) {
+    const key = argv[i]?.replace(/^--/, "");
+    if (!key || argv[i + 1] === undefined) throw new Error(usage);
+    options[key] = key === "timeout" ? Number(argv[i + 1]) : argv[i + 1];
+  }
+  if (!["probe", "observe"].includes(options.mode) || !options.endpoint) {
+    throw new Error(usage);
+  }
+  if (!Number.isFinite(options.timeout) || options.timeout <= 0) throw new Error(usage);
+  return options;
+}
+
+function activeTurn(thread) {
+  return thread?.turns?.findLast((turn) => turn.status === "inProgress");
+}
+
+function summarize(message) {
+  const params = message.params ?? {};
+  const item = params.item;
+  return {
+    at: new Date().toISOString(),
+    method: message.method,
+    threadId: params.threadId ?? params.thread?.id,
+    turnId: params.turnId ?? params.turn?.id,
+    status: params.status?.type ?? params.turn?.status,
+    cwd: params.thread?.cwd,
+    source: params.thread?.source,
+    itemType: item?.type,
+    text: item?.type === "agentMessage" ? item.text : undefined,
+  };
+}
+
+const options = parseArgs(process.argv.slice(2));
+if (options.mode === "self-test") {
+  const event = summarize({ method: "thread/started", params: { thread: { id: "t", cwd: "/tmp" } } });
+  assert.equal(event.threadId, "t");
+  assert.equal(event.cwd, "/tmp");
+  assert.equal(activeTurn({ turns: [{ id: "u", status: "inProgress" }] }).id, "u");
+  console.log("ok");
+  process.exit(0);
+}
+
+if (typeof WebSocket === "undefined") throw new Error("Node.js 22+ is required");
+
+const report = {
+  schemaVersion: 1,
+  endpoint: options.endpoint,
+  startedAt: new Date().toISOString(),
+  server: null,
+  events: [],
+  threads: [],
+  steer: options.steer ? { requested: false, response: null } : null,
+  completed: false,
+};
+const pending = new Map();
+const joined = new Set();
+const joining = new Set();
+let nextId = 1;
+let targetThreadId;
+let targetTurnId;
+let targetCompleted = false;
+let finished = false;
+let socket;
+
+function save() {
+  report.finishedAt = new Date().toISOString();
+  if (options.out) writeFileSync(options.out, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(JSON.stringify(report, null, 2));
+}
+
+function finish(code = 0) {
+  if (finished) return;
+  finished = true;
+  clearTimeout(timeout);
+  report.completed = code === 0;
+  save();
+  process.exitCode = code;
+  socket.close();
+}
+
+function notify(method, params = undefined) {
+  socket.send(JSON.stringify({ jsonrpc: "2.0", method, ...(params && { params }) }));
+}
+
+function request(method, params, context = {}) {
+  const id = nextId++;
+  pending.set(id, { method, ...context });
+  socket.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+  return id;
+}
+
+function join(threadId, attempt = 1) {
+  if (joined.has(threadId) || joining.has(threadId) || finished) return;
+  joining.add(threadId);
+  request("thread/resume", { threadId }, { threadId, attempt });
+}
+
+function steerSucceeded() {
+  if (!report.steer?.response) return false;
+  if (!options.expect) return true;
+  return report.events.some(
+    (event) => event.turnId === targetTurnId && event.text?.includes(options.expect),
+  );
+}
+
+function steer(threadId, turnId) {
+  if (!options.steer || report.steer.requested) return;
+  report.steer.requested = true;
+  report.steer.threadId = threadId;
+  report.steer.turnId = turnId;
+  request(
+    "turn/steer",
+    { threadId, expectedTurnId: turnId, input: [{ type: "text", text: options.steer }] },
+    { threadId, turnId },
+  );
+}
+
+const timeout = setTimeout(() => {
+  report.error = `timed out after ${options.timeout}s`;
+  finish(2);
+}, options.timeout * 1000);
+
+socket = new WebSocket(options.endpoint);
+socket.onopen = () => {
+  request("initialize", {
+    clientInfo: { name: "spotter-app-server-poc", version: "0.1" },
+    capabilities: { experimentalApi: true },
+  });
+};
+socket.onerror = () => {
+  report.error = "websocket connection failed";
+  finish(1);
+};
+socket.onmessage = (event) => {
+  const message = JSON.parse(event.data);
+  if (message.id !== undefined) {
+    const context = pending.get(message.id);
+    pending.delete(message.id);
+    if (!context) return;
+
+    if (context.method === "initialize") {
+      if (message.error) {
+        report.error = message.error;
+        finish(1);
+        return;
+      }
+      report.server = message.result;
+      notify("initialized");
+      if (options.mode === "probe") {
+        request("thread/list", { limit: 5, sortKey: "updated_at" });
+      }
+      return;
+    }
+
+    if (context.method === "thread/list") {
+      report.threads = (message.result?.data ?? []).map(({ id, cwd, source, status }) => ({
+        id, cwd, source, status,
+      }));
+      if (message.error) report.error = message.error;
+      finish(message.error ? 1 : 0);
+      return;
+    }
+
+    if (context.method === "thread/resume") {
+      joining.delete(context.threadId);
+      if (message.error) {
+        if (context.attempt < 20 && message.error.message?.includes("no rollout found")) {
+          setTimeout(() => join(context.threadId, context.attempt + 1), 100);
+        } else {
+          report.error = message.error;
+          finish(1);
+        }
+        return;
+      }
+      joined.add(context.threadId);
+      const turn = activeTurn(message.result?.thread);
+      if (turn) {
+        targetTurnId = turn.id;
+        steer(context.threadId, turn.id);
+      }
+      return;
+    }
+
+    if (context.method === "turn/steer") {
+      report.steer.response = message.error ?? message.result;
+      if (message.error) finish(1);
+      else if (targetCompleted) finish(steerSucceeded() ? 0 : 1);
+    }
+    return;
+  }
+
+  if (!message.method) return;
+  const eventThreadId = message.params?.threadId ?? message.params?.thread?.id;
+  const matchesCwd =
+    message.method === "thread/started" &&
+    (!options.cwd || message.params.thread.cwd === options.cwd);
+  if (
+    (matchesCwd || eventThreadId === targetThreadId) &&
+    [
+      "thread/started",
+      "thread/status/changed",
+      "turn/started",
+      "item/started",
+      "item/completed",
+      "turn/completed",
+    ].includes(message.method)
+  ) {
+    report.events.push(summarize(message));
+  }
+
+  if (message.method === "thread/started") {
+    const thread = message.params.thread;
+    if (options.cwd && thread.cwd !== options.cwd) return;
+    targetThreadId = thread.id;
+    report.threads.push({ id: thread.id, cwd: thread.cwd, source: thread.source });
+    setTimeout(() => join(thread.id), 100);
+  } else if (message.method === "thread/status/changed" && message.params.threadId === targetThreadId) {
+    join(targetThreadId);
+  } else if (message.method === "turn/started" && message.params.threadId === targetThreadId) {
+    targetTurnId = message.params.turn.id;
+    steer(targetThreadId, targetTurnId);
+  } else if (message.method === "turn/completed" && message.params.threadId === targetThreadId) {
+    targetCompleted = true;
+    if (!options.steer) finish(0);
+    else if (report.steer.response) {
+      if (!steerSucceeded() && options.expect) {
+        report.error = `agent response did not contain: ${options.expect}`;
+      }
+      finish(steerSucceeded() ? 0 : 1);
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add a dependency-free App Server PoC observer
- join the same TUI-created thread and track its active turn
- verify `turn/steer` changes the user-visible TUI response
- document managed-daemon constraints and remaining lifecycle checks

## Result
Codex CLI 0.147.0 passed the Spotter-managed external App Server path: the TUI and observer shared thread/turn identity, `turn/steer` returned the active turn ID, and the TUI rendered `SPOTTER_STEER_OK`.

The Codex-managed standalone daemon, concurrent TUI, and reconnect checks remain follow-up work, so this PR does not close #78.

## Verification
- `.venv/bin/pytest` (251 passed)
- `.venv/bin/ruff check src tests`
- `.venv/bin/mypy src tests`
- `node --check scripts/app_server_poc.mjs`
- `node scripts/app_server_poc.mjs --self-test`
- live Codex 0.147.0 TUI + independent observer E2E

Refs #78
