### PR TITLE
feat: add Codex App Server client

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ External Codex App Server
        (deterministic synchronous enforcement only)
 ```
 
-The immediate next step is **not** to blindly build the daemon. [#78](https://github.com/spotter-agent/spotter/issues/78) must first prove that ordinary Codex and Spotter can share the same external App Server, observe the same thread/turn, and that Spotter can steer the real active turn.
+[#78](https://github.com/spotter-agent/spotter/issues/78) proved shared observation and steering for a
+Spotter-managed external App Server. Current Runtime work turns that viable control boundary into
+the daemon, identity, lifecycle, and recovery components required for ordinary use.
 
 For the fastest project snapshot, read [Status](docs/status.md). For sequence and evidence gates, read [Roadmap](docs/roadmap.md).
 
@@ -76,25 +78,21 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Evaluation labels / metrics | ✅ | Coverage-aware evaluation and precision/FP metrics |
 | Counterfactual experiment harness | ✅ | Control/guidance same-prefix pairs |
 | Standalone `spotterd` runtime | ❌ | Target runtime boundary |
-| App Server primary observation | 🧪 | Shared-server/control PoC first (#78) |
+| App Server primary observation | 🟡 | Client/capabilities implemented; Trace IR ingestion remains (#85) |
 | Event-driven signal engine | ❌ | Current reviewer trigger is periodic |
 | Live `VERIFY / NUDGE` | ❌ | Target: `turn/steer` |
 | `INTERRUPT` | ❌ | Target: `turn/interrupt` |
 | `RESTART` | ❌ | Requires verified-state + side-effect-aware recovery |
 | Homebrew / setup lifecycle | 🎯 | Target product path |
 
-### Current blocker
+### Current runtime work
 
-[#78](https://github.com/spotter-agent/spotter/issues/78) must establish that:
-
-1. TUI and Spotter see the same thread id;
-2. Spotter sees the same active turn across multiple actions;
-3. the needed runtime events are available;
-4. `turn/steer` affects the real user-visible session;
-5. concurrent Codex sessions remain distinguishable;
-6. embedded/disconnected modes can be reported as degraded rather than silently healthy.
-
-If no viable path passes, the App Server/daemon direction must be revised before more runtime work is built on it.
+[#78](https://github.com/spotter-agent/spotter/issues/78) proved that a Spotter-managed external
+App Server can share the TUI's real thread and steer its active turn. The production client in
+[#80](https://github.com/spotter-agent/spotter/issues/80) now exposes events, thread queries,
+control methods, and per-capability degraded state. The remaining Runtime work establishes
+`spotterd` ([#79](https://github.com/spotter-agent/spotter/issues/79)), explicit thread/turn identity
+([#81](https://github.com/spotter-agent/spotter/issues/81)), and lifecycle/recovery boundaries.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,9 +79,10 @@ spotterd
 PreToolUse Hook only for deterministic blocking
 ```
 
-The target is conditional on [#78](https://github.com/spotter-agent/spotter/issues/78): Spotter must prove that the user's ordinary Codex TUI and Spotter can share the same external App Server and that `turn/steer` reaches the real active user turn.
-
-If that does not work reliably, the target architecture is revisited before the daemon migration continues.
+[#78](https://github.com/spotter-agent/spotter/issues/78) proved that the user's Codex TUI and
+Spotter can share a Spotter-managed external App Server and that `turn/steer` reaches the real
+active turn. The managed daemon, concurrent identity, and reconnect lifecycle remain explicit
+Runtime work.
 
 ## Roadmap vocabulary
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
 > **Status:** this document describes both the current hook-based prototype and the target architecture. Active implementation is tracked by the [Roadmap](roadmap.md) and native GitHub Milestones.
-> `spotterd`, App Server primary observation, and live `turn/steer` delivery are **target behavior**, not current shipping behavior.
+> `spotterd`, App Server primary Trace IR observation, and live supervision delivery are **target behavior**. The shared-server PoC and production App Server transport are implemented foundations.
 
 ---
 
@@ -834,10 +834,10 @@ Every adapter exposes capabilities explicitly.
 
 ```text
 CodexAdapter
-  observation: rich
-  steer: target PoC
-  interrupt: target
-  pre-action veto: Hook
+  observation: available after thread query probe
+  steer: unknown until a successful call; unavailable on method-not-found
+  interrupt: unknown until a successful call; unavailable on method-not-found
+  pre-action veto: unavailable through App Server; Hook boundary remains
 
 FutureAgentAdapter
   observation: maybe partial
@@ -849,9 +849,10 @@ When a capability is missing, Spotter should hide/disable the feature or report 
 
 ---
 
-# 15. Runtime gate: App Server lifecycle / attach PoC
+# 15. Runtime gate result: App Server lifecycle / attach PoC
 
-The target architecture is gated by this experiment.
+The experiment proved the control premise for Path B. Its harness and recorded result live in
+[App Server lifecycle / attach PoC](app-server-poc.md).
 
 ## Path A — Codex-managed daemon
 
@@ -890,18 +891,15 @@ Interrupt:   unavailable
 PreToolUse:  possibly available
 ```
 
-## Exit criteria
+## Result and remaining lifecycle work
 
-- ordinary `codex` UX is preserved;
-- TUI and Spotter prove they share the same App Server/thread;
-- live event subscription works;
-- active turn identity remains correct;
-- real `turn/steer` delivery is demonstrated;
-- concurrent sessions are distinguishable;
-- reconnect/degraded behavior is understood;
-- App Server ownership/lifecycle strategy is selected.
-
-**If a core property fails, revisit the architecture before P1.**
+- Path B proved a shared App Server/thread, live event delivery, and real `turn/steer` delivery.
+- `CodexAppServerClient` provides the initialized transport, raw events, thread/control methods, and
+  explicit per-capability degradation used by later runtime components.
+- Path A remains unavailable for the tested Homebrew Cask because the managed daemon expects the
+  standalone installer layout.
+- Concurrent thread identity is owned by #81, daemon/service ownership by #79/#83, and reconnect
+  reconciliation by #87.
 
 ---
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -54,7 +54,9 @@ The most important lifecycle constraint is this:
 
 > **If full Codex mode requires an external App Server, that server must be available before ordinary `codex` chooses its App Server target.**
 
-That can conflict with a completely lazy “wake Spotter on the first Hook” design. The Runtime App Server gate (#78) must determine the canonical startup strategy before the service lifecycle is finalized.
+That conflicts with a completely lazy “wake Spotter on the first Hook” design. #78 proved a
+Spotter-managed external path; #79 and #83 must now make its service ownership and startup strategy
+explicit before the lifecycle is finalized.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,9 +25,9 @@ Harden
 
 The stages are not release versions and they are not strict single-threaded sprints. Work can overlap when dependencies allow.
 
-The current blocker is [#78](https://github.com/spotter-agent/spotter/issues/78): prove that ordinary Codex and Spotter can share the same external App Server, observe the same thread/turn, and steer the real active turn.
-
-If that PoC fails, revise the runtime architecture before building further on the App Server assumption.
+[#78](https://github.com/spotter-agent/spotter/issues/78) proved the shared-server control premise for
+the Spotter-managed external path. Runtime work now productizes that path through the App Server
+client, `spotterd`, explicit identity, lifecycle, and recovery boundaries.
 
 | Stage | Product outcome | Evidence gate |
 | --- | --- | --- |
@@ -58,18 +58,13 @@ spotterd
 PreToolUse Hook only where synchronous deterministic enforcement is required
 ```
 
-## Current gate
+## Gate result
 
-[#78](https://github.com/spotter-agent/spotter/issues/78) must establish that:
-
-- ordinary `codex` can use an externally reachable App Server without a special per-session ritual;
-- Spotter can attach to the same real thread and active turn;
-- required live events are visible;
-- `turn/steer` affects the user-visible turn;
-- concurrent sessions remain distinguishable;
-- embedded/disconnected cases can be surfaced as degraded rather than silently healthy.
-
-Do not treat the App Server architecture as settled until this is proven end to end.
+[#78](https://github.com/spotter-agent/spotter/issues/78) demonstrated that a TUI and Spotter can
+attach to one Spotter-managed external App Server, observe the same thread/turn, and steer the real
+user-visible turn. The Codex-managed daemon path was unavailable to the tested Homebrew Cask install.
+Concurrent identity, daemon ownership, and reconnect remain explicit Runtime work rather than
+assumed properties.
 
 ## Implementation after the gate
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -36,7 +36,9 @@ The roadmap no longer uses `P0–P9` / `E0–E5`. It is organized by named outco
 Runtime → Observe → Detect → Intervene → Recover → Harden
 ```
 
-The **current blocker** is [#78](https://github.com/spotter-agent/spotter/issues/78): prove that ordinary `codex` and Spotter can use the same external App Server, observe the same thread/turn, and that `turn/steer` reaches the real active user turn.
+The shared-server gate in [#78](https://github.com/spotter-agent/spotter/issues/78) passed for the
+Spotter-managed external App Server path. Spotter now has a production WebSocket client with
+explicit observation/control capabilities; the standalone daemon and identity model remain next.
 
 ---
 
@@ -44,23 +46,14 @@ The **current blocker** is [#78](https://github.com/spotter-agent/spotter/issues
 
 ### Runtime
 
-Before building the standalone daemon around App Server assumptions, prove the control boundary itself.
+[#78](https://github.com/spotter-agent/spotter/issues/78) demonstrated same-thread observation and
+same-turn steering through a Spotter-managed external App Server. [#80](https://github.com/spotter-agent/spotter/issues/80)
+turns that PoC into an async client with initialize/disconnect, raw event delivery, thread queries,
+typed steer/interrupt methods, and explicit supported/unknown/unavailable capability state.
 
-[#78](https://github.com/spotter-agent/spotter/issues/78) must establish:
-
-- TUI and Spotter see the same thread id;
-- Spotter sees the same active turn id over multiple actions;
-- the needed runtime events are available;
-- `turn/steer` affects the real user-visible turn;
-- concurrent Codex sessions can be distinguished;
-- embedded/disconnected modes are diagnosable as degraded.
-
-If no viable path passes, revise the architecture before proceeding.
-
-If the gate passes, the immediate implementation boundaries are already split into native GitHub issues:
+The remaining implementation boundaries are split into native GitHub issues:
 
 - [#79](https://github.com/spotter-agent/spotter/issues/79) — `spotterd`, local control RPC, and per-user service lifecycle;
-- [#80](https://github.com/spotter-agent/spotter/issues/80) — production App Server client and capability negotiation;
 - [#81](https://github.com/spotter-agent/spotter/issues/81) — Thread / Turn / Runtime Attachment identity;
 - [#82](https://github.com/spotter-agent/spotter/issues/82) — bounded fail-open `PreToolUse` ↔ daemon enforcement IPC;
 - [#83](https://github.com/spotter-agent/spotter/issues/83) — transactional Codex setup/teardown and integration ownership;
@@ -93,9 +86,9 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Audit ledger | 🟡 | Claim/evidence state and stale propagation where outcomes are observable | Move independent state into `spotterd` (#31) |
 | Evaluation labels / metrics | ✅ | Coverage-aware labeling and precision/FP metrics | Broader cost/miss/harm metrics (#33, #38, #34) |
 | Counterfactual harness | ✅ | Control/guidance same-prefix pairs can be prepared/run | Add mechanically scored tasks (#21) |
-| Standalone runtime | ❌ | No long-lived owner, service boundary, or runtime RPC | #79 after #78; App Server transport in #80 |
+| Standalone runtime | ❌ | No long-lived owner, service boundary, or runtime RPC | Build `spotterd` in #79 |
 | Runtime identity | ❌ | Hook-era `session_id` is the dominant identity | Thread/Turn/Attachment model in #81 |
-| App Server primary observation | 🧪 | Target design only | Prove #78, then implement #80 + #85 |
+| App Server primary observation | 🟡 | Async client, raw events, thread queries, controls, capability degradation | Normalize and journal events in #85 after identity #81 |
 | Managed Codex lifecycle | ❌ | Current path is source/plugin installation | transactional setup/teardown in #83; diagnostics in #84 |
 | Runtime reconnect/recovery | ❌ | No long-lived App Server connection to recover | #87 after runtime/state boundaries exist |
 | Event-driven detection | ❌ | Reviewer is still cadence-based | #28 after Runtime/Observe |
@@ -148,7 +141,7 @@ Implementation progress and research evidence remain separate.
 | Is the fork instrument's causal noise floor known? | **No — #42** |
 | Is there a reproducible mechanically scored task corpus? | **No — #21** |
 | Has live Spotter guidance been shown to improve outcomes? | **No** |
-| Is the App Server target architecture operationally viable? | **Not yet — #78 is the blocker** |
+| Is the App Server control boundary operationally viable? | **Yes for the Spotter-managed external path; daemon lifecycle and reconnect remain** |
 
 A mechanism being implemented does not prove it improves outcomes. Null and negative results are first-class outcomes for this project.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "Spotter contributors" }]
-dependencies = []
+dependencies = ["websockets>=17,<18"]
 
 [project.optional-dependencies]
 dev = [
@@ -40,4 +40,3 @@ files = ["src", "tests"]
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["tests"]
-

--- a/src/spotter/app_server.py
+++ b/src/spotter/app_server.py
@@ -90,7 +90,12 @@ _CAPABILITY_BY_METHOD = {
 
 
 class CodexAppServerClient:
-    """One initialized JSON-RPC client for an external Codex App Server."""
+    """One initialized JSON-RPC client for an external Codex App Server.
+
+    A request timeout invalidates and closes the entire connection. This avoids accepting late
+    responses after callers have already acted on a timeout. Server-initiated requests are exposed
+    as events and rejected with method-not-found because this observer doesn't own approval flows.
+    """
 
     def __init__(
         self,
@@ -109,11 +114,13 @@ class CodexAppServerClient:
         self.last_error: AppServerError | None = None
         self._socket: ClientConnection | None = None
         self._reader: asyncio.Task[None] | None = None
+        self._failure_close: asyncio.Task[None] | None = None
         self._closed = asyncio.Event()
         self._closing = False
         self._next_id = 1
         self._pending: dict[int, asyncio.Future[JsonObject]] = {}
-        self._events: asyncio.Queue[AppServerEvent] = asyncio.Queue()
+        # ponytail: #85 owns bounded backpressure once a real ingestion consumer exists.
+        self._events: asyncio.Queue[AppServerEvent | AppServerError] = asyncio.Queue()
         self._capabilities = self._initial_capabilities()
 
     @staticmethod
@@ -138,7 +145,9 @@ class CodexAppServerClient:
         self.state = ConnectionState.CONNECTING
         self._capabilities = self._initial_capabilities()
         self._closing = False
+        self._failure_close = None
         self._closed.clear()
+        self._events = asyncio.Queue()
         self.last_error = None
         try:
             self._socket = await websocket_connect(
@@ -188,6 +197,7 @@ class CodexAppServerClient:
 
     async def disconnect(self) -> None:
         self._closing = True
+        was_closed = self._closed.is_set()
         socket, reader = self._socket, self._reader
         self._socket = None
         self._reader = None
@@ -197,19 +207,34 @@ class CodexAppServerClient:
             reader.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await reader
-        self._fail_pending(AppServerTransportError("App Server client disconnected"))
+        if self._failure_close is not None:
+            await self._failure_close
+            self._failure_close = None
+        disconnect_error = AppServerTransportError("App Server client disconnected")
+        self._fail_pending(disconnect_error)
+        if not was_closed:
+            self._events.put_nowait(disconnect_error)
         self.server_info = None
         self.last_error = None
         self.state = ConnectionState.DISCONNECTED
         self._closed.set()
 
     async def next_event(self) -> AppServerEvent:
-        return await self._events.get()
+        """Return the next server message or raise once the connection ends."""
+
+        if self._closed.is_set() and self._events.empty():
+            raise self.last_error or AppServerTransportError("App Server client disconnected")
+        event = await self._events.get()
+        if isinstance(event, AppServerError):
+            raise event
+        return event
 
     async def wait_closed(self) -> AppServerError | None:
         """Wait for intentional shutdown or connection loss."""
 
         await self._closed.wait()
+        if self._failure_close is not None:
+            await self._failure_close
         return self.last_error
 
     async def list_threads(
@@ -253,8 +278,8 @@ class CodexAppServerClient:
 
     async def _request(self, method: str, params: JsonObject) -> Any:
         socket = self._socket
-        if socket is None:
-            raise AppServerTransportError("App Server client is not connected")
+        if socket is None or self._closed.is_set():
+            raise self.last_error or AppServerTransportError("App Server client is not connected")
         request_id = self._next_id
         self._next_id += 1
         future = asyncio.get_running_loop().create_future()
@@ -324,11 +349,30 @@ class CodexAppServerClient:
                 message = self._decode_message(raw)
                 request_id = message.get("id")
                 method = message.get("method")
-                if isinstance(request_id, int) and method is None:
+                if (
+                    isinstance(request_id, int)
+                    and not isinstance(request_id, bool)
+                    and method is None
+                ):
                     future = self._pending.pop(request_id, None)
                     if future is not None and not future.done():
                         future.set_result(message)
                 elif isinstance(method, str):
+                    if request_id is not None:
+                        if not self._is_request_id(request_id):
+                            raise AppServerProtocolError("server request has an invalid id")
+                        await socket.send(
+                            json.dumps(
+                                {
+                                    "jsonrpc": "2.0",
+                                    "id": request_id,
+                                    "error": {
+                                        "code": -32601,
+                                        "message": f"Spotter does not handle {method} requests",
+                                    },
+                                }
+                            )
+                        )
                     await self._events.put(AppServerEvent(method, message))
                 else:
                     raise AppServerProtocolError("received an invalid JSON-RPC message")
@@ -356,10 +400,15 @@ class CodexAppServerClient:
         return cast(JsonObject, message)
 
     def _connection_failed(self, error: AppServerError) -> None:
+        if self._closed.is_set():
+            return
         self.last_error = error
         self.state = ConnectionState.DEGRADED
         self._fail_pending(error)
+        self._events.put_nowait(error)
         self._closed.set()
+        if self._socket is not None:
+            self._failure_close = asyncio.create_task(self._socket.close())
 
     def _raise_protocol_error(self, message: str) -> NoReturn:
         error = AppServerProtocolError(message)
@@ -371,3 +420,7 @@ class CodexAppServerClient:
             if not future.done():
                 future.set_exception(error)
         self._pending.clear()
+
+    @staticmethod
+    def _is_request_id(value: Any) -> bool:
+        return isinstance(value, (int, str)) and not isinstance(value, bool)

--- a/src/spotter/app_server.py
+++ b/src/spotter/app_server.py
@@ -1,0 +1,373 @@
+"""Async Codex App Server transport with explicit capability state."""
+
+import asyncio
+import contextlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, NoReturn, cast
+
+from websockets.asyncio.client import ClientConnection
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.exceptions import ConnectionClosed, WebSocketException
+
+JsonObject = dict[str, Any]
+
+
+class ConnectionState(StrEnum):
+    DISCONNECTED = "disconnected"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    DEGRADED = "degraded"
+    UNAVAILABLE = "unavailable"
+
+
+class CapabilityStatus(StrEnum):
+    UNKNOWN = "unknown"
+    AVAILABLE = "available"
+    UNAVAILABLE = "unavailable"
+
+
+class AppServerCapability(StrEnum):
+    OBSERVATION = "observation"
+    THREAD_QUERY = "thread_query"
+    STEER = "steer"
+    INTERRUPT = "interrupt"
+    ATOMIC_PRE_TOOL_VETO = "atomic_pre_tool_veto"
+
+
+@dataclass(frozen=True)
+class AppServerCapabilities:
+    observation: CapabilityStatus
+    thread_query: CapabilityStatus
+    steer: CapabilityStatus
+    interrupt: CapabilityStatus
+    atomic_pre_tool_veto: CapabilityStatus
+
+
+@dataclass(frozen=True)
+class AppServerEvent:
+    """A raw server notification retained for later Trace IR normalization."""
+
+    method: str
+    raw: Mapping[str, Any]
+
+
+class AppServerError(RuntimeError):
+    """Base error for the App Server boundary."""
+
+
+class AppServerTransportError(AppServerError):
+    """The server couldn't be reached or the live connection was lost."""
+
+
+class AppServerProtocolError(AppServerError):
+    """The peer sent malformed JSON-RPC data."""
+
+
+class AppServerRpcError(AppServerError):
+    """The server rejected a valid JSON-RPC request."""
+
+    def __init__(self, method: str, code: int, message: str, data: Any = None) -> None:
+        super().__init__(f"{method} failed ({code}): {message}")
+        self.method = method
+        self.code = code
+        self.data = data
+
+
+class UnsupportedAppServerCapability(AppServerRpcError):
+    """The connected server doesn't implement the requested capability."""
+
+
+_CAPABILITY_BY_METHOD = {
+    "thread/list": AppServerCapability.THREAD_QUERY,
+    "thread/read": AppServerCapability.THREAD_QUERY,
+    "thread/resume": AppServerCapability.OBSERVATION,
+    "turn/steer": AppServerCapability.STEER,
+    "turn/interrupt": AppServerCapability.INTERRUPT,
+}
+
+
+class CodexAppServerClient:
+    """One initialized JSON-RPC client for an external Codex App Server."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        *,
+        request_timeout: float = 10,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        if request_timeout <= 0:
+            raise ValueError("request_timeout must be positive")
+        self.endpoint = endpoint
+        self.request_timeout = request_timeout
+        self.headers = headers
+        self.state = ConnectionState.DISCONNECTED
+        self.server_info: Mapping[str, Any] | None = None
+        self.last_error: AppServerError | None = None
+        self._socket: ClientConnection | None = None
+        self._reader: asyncio.Task[None] | None = None
+        self._closed = asyncio.Event()
+        self._closing = False
+        self._next_id = 1
+        self._pending: dict[int, asyncio.Future[JsonObject]] = {}
+        self._events: asyncio.Queue[AppServerEvent] = asyncio.Queue()
+        self._capabilities = self._initial_capabilities()
+
+    @staticmethod
+    def _initial_capabilities() -> dict[AppServerCapability, CapabilityStatus]:
+        capabilities = {capability: CapabilityStatus.UNKNOWN for capability in AppServerCapability}
+        capabilities[AppServerCapability.ATOMIC_PRE_TOOL_VETO] = CapabilityStatus.UNAVAILABLE
+        return capabilities
+
+    @property
+    def capabilities(self) -> AppServerCapabilities:
+        return AppServerCapabilities(
+            observation=self._capabilities[AppServerCapability.OBSERVATION],
+            thread_query=self._capabilities[AppServerCapability.THREAD_QUERY],
+            steer=self._capabilities[AppServerCapability.STEER],
+            interrupt=self._capabilities[AppServerCapability.INTERRUPT],
+            atomic_pre_tool_veto=self._capabilities[AppServerCapability.ATOMIC_PRE_TOOL_VETO],
+        )
+
+    async def connect(self) -> None:
+        if self._socket is not None:
+            raise AppServerTransportError("App Server client is already connected")
+        self.state = ConnectionState.CONNECTING
+        self._capabilities = self._initial_capabilities()
+        self._closing = False
+        self._closed.clear()
+        self.last_error = None
+        try:
+            self._socket = await websocket_connect(
+                self.endpoint,
+                additional_headers=self.headers,
+                open_timeout=self.request_timeout,
+                proxy=None,
+            )
+            self._reader = asyncio.create_task(self._read_messages())
+            result = await self._request(
+                "initialize",
+                {
+                    "clientInfo": {"name": "spotter", "version": "0.1.0"},
+                    "capabilities": {"experimentalApi": True},
+                },
+            )
+            if not isinstance(result, dict):
+                raise AppServerProtocolError("initialize returned a non-object result")
+            self.server_info = result
+            await self._notify("initialized")
+            try:
+                await self.list_threads(limit=1)
+            except UnsupportedAppServerCapability:
+                self.state = ConnectionState.DEGRADED
+            else:
+                if self._closed.is_set():
+                    raise self.last_error or AppServerTransportError(
+                        "App Server connection closed during initialization"
+                    )
+                self._capabilities[AppServerCapability.OBSERVATION] = CapabilityStatus.AVAILABLE
+                self.state = ConnectionState.CONNECTED
+        except AppServerError as error:
+            await self._abort_connect()
+            self.last_error = error
+            raise
+        except (OSError, TimeoutError, WebSocketException) as error:
+            transport_error = AppServerTransportError(
+                f"could not connect to {self.endpoint}: {error}"
+            )
+            await self._abort_connect()
+            self.last_error = transport_error
+            raise transport_error from error
+
+    async def _abort_connect(self) -> None:
+        await self.disconnect()
+        self.state = ConnectionState.UNAVAILABLE
+
+    async def disconnect(self) -> None:
+        self._closing = True
+        socket, reader = self._socket, self._reader
+        self._socket = None
+        self._reader = None
+        if socket is not None:
+            await socket.close()
+        if reader is not None and reader is not asyncio.current_task():
+            reader.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await reader
+        self._fail_pending(AppServerTransportError("App Server client disconnected"))
+        self.server_info = None
+        self.last_error = None
+        self.state = ConnectionState.DISCONNECTED
+        self._closed.set()
+
+    async def next_event(self) -> AppServerEvent:
+        return await self._events.get()
+
+    async def wait_closed(self) -> AppServerError | None:
+        """Wait for intentional shutdown or connection loss."""
+
+        await self._closed.wait()
+        return self.last_error
+
+    async def list_threads(
+        self, *, limit: int = 100, cursor: str | None = None
+    ) -> Mapping[str, Any]:
+        params: JsonObject = {"limit": limit, "sortKey": "updated_at"}
+        if cursor is not None:
+            params["cursor"] = cursor
+        return await self._object_request("thread/list", params)
+
+    async def read_thread(
+        self, thread_id: str, *, include_turns: bool = False
+    ) -> Mapping[str, Any]:
+        return await self._object_request(
+            "thread/read", {"threadId": thread_id, "includeTurns": include_turns}
+        )
+
+    async def resume_thread(self, thread_id: str) -> Mapping[str, Any]:
+        return await self._object_request("thread/resume", {"threadId": thread_id})
+
+    async def steer(self, thread_id: str, turn_id: str, text: str) -> Mapping[str, Any]:
+        return await self._object_request(
+            "turn/steer",
+            {
+                "threadId": thread_id,
+                "expectedTurnId": turn_id,
+                "input": [{"type": "text", "text": text}],
+            },
+        )
+
+    async def interrupt(self, thread_id: str, turn_id: str) -> Mapping[str, Any]:
+        return await self._object_request(
+            "turn/interrupt", {"threadId": thread_id, "turnId": turn_id}
+        )
+
+    async def _object_request(self, method: str, params: JsonObject) -> Mapping[str, Any]:
+        result = await self._request(method, params)
+        if not isinstance(result, dict):
+            self._raise_protocol_error(f"{method} returned a non-object result")
+        return result
+
+    async def _request(self, method: str, params: JsonObject) -> Any:
+        socket = self._socket
+        if socket is None:
+            raise AppServerTransportError("App Server client is not connected")
+        request_id = self._next_id
+        self._next_id += 1
+        future = asyncio.get_running_loop().create_future()
+        self._pending[request_id] = future
+        try:
+            await socket.send(
+                json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+            )
+            response = await asyncio.wait_for(future, timeout=self.request_timeout)
+        except TimeoutError as error:
+            self._pending.pop(request_id, None)
+            transport_error = AppServerTransportError(f"{method} timed out")
+            self._connection_failed(transport_error)
+            raise transport_error from error
+        except ConnectionClosed as error:
+            self._pending.pop(request_id, None)
+            transport_error = AppServerTransportError(f"connection lost during {method}")
+            self._connection_failed(transport_error)
+            raise transport_error from error
+        except asyncio.CancelledError:
+            self._pending.pop(request_id, None)
+            future.cancel()
+            raise
+
+        rpc_error = response.get("error")
+        if rpc_error is not None:
+            if not isinstance(rpc_error, dict):
+                self._raise_protocol_error(f"{method} returned a malformed error")
+            code = rpc_error.get("code")
+            message = rpc_error.get("message")
+            if not isinstance(code, int) or not isinstance(message, str):
+                self._raise_protocol_error(f"{method} returned a malformed error")
+            capability = _CAPABILITY_BY_METHOD.get(method)
+            if code == -32601 and capability is not None:
+                self._capabilities[capability] = CapabilityStatus.UNAVAILABLE
+                unsupported = UnsupportedAppServerCapability(
+                    method, code, message, rpc_error.get("data")
+                )
+                self.last_error = unsupported
+                if self.state == ConnectionState.CONNECTED:
+                    self.state = ConnectionState.DEGRADED
+                raise unsupported
+            raise AppServerRpcError(method, code, message, rpc_error.get("data"))
+
+        capability = _CAPABILITY_BY_METHOD.get(method)
+        if capability is not None:
+            self._capabilities[capability] = CapabilityStatus.AVAILABLE
+        if "result" not in response:
+            self._raise_protocol_error(f"{method} response has no result")
+        return response["result"]
+
+    async def _notify(self, method: str, params: JsonObject | None = None) -> None:
+        socket = self._socket
+        if socket is None:
+            raise AppServerTransportError("App Server client is not connected")
+        message: JsonObject = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            message["params"] = params
+        await socket.send(json.dumps(message))
+
+    async def _read_messages(self) -> None:
+        socket = self._socket
+        if socket is None:
+            return
+        try:
+            async for raw in socket:
+                message = self._decode_message(raw)
+                request_id = message.get("id")
+                method = message.get("method")
+                if isinstance(request_id, int) and method is None:
+                    future = self._pending.pop(request_id, None)
+                    if future is not None and not future.done():
+                        future.set_result(message)
+                elif isinstance(method, str):
+                    await self._events.put(AppServerEvent(method, message))
+                else:
+                    raise AppServerProtocolError("received an invalid JSON-RPC message")
+        except asyncio.CancelledError:
+            raise
+        except ConnectionClosed as error:
+            if not self._closing:
+                self._connection_failed(
+                    AppServerTransportError(f"App Server connection closed: {error}")
+                )
+        except AppServerProtocolError as error:
+            self._connection_failed(error)
+        else:
+            if not self._closing:
+                self._connection_failed(AppServerTransportError("App Server connection closed"))
+
+    @staticmethod
+    def _decode_message(raw: str | bytes) -> JsonObject:
+        try:
+            message = json.loads(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError) as error:
+            raise AppServerProtocolError("received invalid JSON from App Server") from error
+        if not isinstance(message, dict):
+            raise AppServerProtocolError("received a non-object JSON-RPC message")
+        return cast(JsonObject, message)
+
+    def _connection_failed(self, error: AppServerError) -> None:
+        self.last_error = error
+        self.state = ConnectionState.DEGRADED
+        self._fail_pending(error)
+        self._closed.set()
+
+    def _raise_protocol_error(self, message: str) -> NoReturn:
+        error = AppServerProtocolError(message)
+        self._connection_failed(error)
+        raise error
+
+    def _fail_pending(self, error: AppServerError) -> None:
+        for future in self._pending.values():
+            if not future.done():
+                future.set_exception(error)
+        self._pending.clear()

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -150,6 +150,35 @@ def test_concurrent_requests_are_matched_by_id() -> None:
     asyncio.run(scenario())
 
 
+def test_server_request_is_rejected_without_blocking_the_server() -> None:
+    async def scenario() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await _ready(connection)
+            await connection.send(
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "approval-1",
+                        "method": "commandExecution/requestApproval",
+                        "params": {"threadId": "thread-1"},
+                    }
+                )
+            )
+            response = _message(await connection.recv())
+            assert response["id"] == "approval-1"
+            assert response["error"]["code"] == -32601
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            client = CodexAppServerClient(endpoint)
+            await client.connect()
+            event = await client.next_event()
+            assert event.method == "commandExecution/requestApproval"
+            await client.disconnect()
+
+    asyncio.run(scenario())
+
+
 def test_missing_capability_degrades_only_that_surface() -> None:
     async def scenario() -> None:
         async def handler(connection: ServerConnection) -> None:
@@ -263,6 +292,18 @@ def test_disconnect_and_protocol_failure_are_structured() -> None:
             error = await client.wait_closed()
             assert isinstance(error, AppServerTransportError)
             assert client.state == ConnectionState.DEGRADED
+            try:
+                await client.next_event()
+            except AppServerTransportError:
+                pass
+            else:
+                raise AssertionError("event consumer wasn't released on disconnect")
+            try:
+                await client.next_event()
+            except AppServerTransportError:
+                pass
+            else:
+                raise AssertionError("closed event stream became readable again")
             await client.disconnect()
 
     async def malformed_result() -> None:
@@ -285,7 +326,33 @@ def test_disconnect_and_protocol_failure_are_structured() -> None:
             assert client.state == ConnectionState.DEGRADED
             await client.disconnect()
 
+    async def request_timeout() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await _ready(connection)
+            await _receive(connection, "thread/read")
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            client = CodexAppServerClient(endpoint, request_timeout=0.1)
+            await client.connect()
+            try:
+                await client.read_thread("thread-1")
+            except AppServerTransportError as error:
+                assert "timed out" in str(error)
+            else:
+                raise AssertionError("request timeout wasn't reported")
+            assert client.state == ConnectionState.DEGRADED
+            assert isinstance(await client.wait_closed(), AppServerTransportError)
+            try:
+                await client.list_threads()
+            except AppServerTransportError:
+                pass
+            else:
+                raise AssertionError("failed connection accepted another request")
+            await client.disconnect()
+
     asyncio.run(disconnected())
     asyncio.run(malformed())
     asyncio.run(clean_close())
     asyncio.run(malformed_result())
+    asyncio.run(request_timeout())

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -1,0 +1,291 @@
+import asyncio
+import json
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager, suppress
+from typing import Any, cast
+
+from websockets.asyncio.server import ServerConnection, serve
+
+from spotter.app_server import (
+    AppServerProtocolError,
+    AppServerTransportError,
+    CapabilityStatus,
+    CodexAppServerClient,
+    ConnectionState,
+    UnsupportedAppServerCapability,
+)
+
+Handler = Callable[[ServerConnection], Awaitable[None]]
+
+
+def _message(raw: str | bytes) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(raw))
+
+
+async def _receive(connection: ServerConnection, method: str) -> dict[str, Any]:
+    message = _message(await connection.recv())
+    assert message["method"] == method
+    return message
+
+
+async def _reply(connection: ServerConnection, request: dict[str, Any], result: Any) -> None:
+    await connection.send(json.dumps({"jsonrpc": "2.0", "id": request["id"], "result": result}))
+
+
+async def _initialize(connection: ServerConnection) -> None:
+    request = await _receive(connection, "initialize")
+    assert request["params"]["capabilities"] == {"experimentalApi": True}
+    await _reply(
+        connection,
+        request,
+        {
+            "codexHome": "/tmp/codex",
+            "platformFamily": "unix",
+            "platformOs": "macos",
+            "userAgent": "codex_cli_rs/0.147.0",
+        },
+    )
+    await _receive(connection, "initialized")
+
+
+@asynccontextmanager
+async def _server(handler: Handler) -> AsyncIterator[str]:
+    async with serve(handler, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        yield f"ws://127.0.0.1:{port}"
+
+
+async def _ready(connection: ServerConnection) -> None:
+    await _initialize(connection)
+    request = await _receive(connection, "thread/list")
+    await _reply(connection, request, {"data": [], "nextCursor": None})
+
+
+def test_connect_negotiates_observation_and_preserves_raw_events() -> None:
+    async def scenario() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await _ready(connection)
+            await connection.send(
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "method": "turn/started",
+                        "params": {"threadId": "thread-1", "turn": {"id": "turn-1"}},
+                    }
+                )
+            )
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            client = CodexAppServerClient(endpoint)
+            await client.connect()
+            event = await client.next_event()
+            assert client.state == ConnectionState.CONNECTED
+            assert client.capabilities.observation == CapabilityStatus.AVAILABLE
+            assert client.capabilities.thread_query == CapabilityStatus.AVAILABLE
+            assert client.capabilities.steer == CapabilityStatus.UNKNOWN
+            assert client.capabilities.atomic_pre_tool_veto == CapabilityStatus.UNAVAILABLE
+            assert event.method == "turn/started"
+            assert event.raw["params"] == {"threadId": "thread-1", "turn": {"id": "turn-1"}}
+            await client.disconnect()
+
+    asyncio.run(scenario())
+
+
+def test_thread_queries_and_controls_hide_codex_method_names() -> None:
+    async def scenario() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await _ready(connection)
+            for method, result in [
+                ("thread/read", {"thread": {"id": "thread-1"}}),
+                ("thread/resume", {"thread": {"id": "thread-1"}}),
+                ("turn/steer", {"turnId": "turn-1"}),
+                ("turn/interrupt", {}),
+            ]:
+                request = await _receive(connection, method)
+                if method == "turn/steer":
+                    assert request["params"] == {
+                        "threadId": "thread-1",
+                        "expectedTurnId": "turn-1",
+                        "input": [{"type": "text", "text": "verify this"}],
+                    }
+                await _reply(connection, request, result)
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            client = CodexAppServerClient(endpoint)
+            await client.connect()
+            assert (await client.read_thread("thread-1"))["thread"] == {"id": "thread-1"}
+            await client.resume_thread("thread-1")
+            assert (await client.steer("thread-1", "turn-1", "verify this"))["turnId"] == "turn-1"
+            await client.interrupt("thread-1", "turn-1")
+            assert client.capabilities.observation == CapabilityStatus.AVAILABLE
+            assert client.capabilities.steer == CapabilityStatus.AVAILABLE
+            assert client.capabilities.interrupt == CapabilityStatus.AVAILABLE
+            await client.disconnect()
+
+    asyncio.run(scenario())
+
+
+def test_concurrent_requests_are_matched_by_id() -> None:
+    async def scenario() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await _ready(connection)
+            first = await _receive(connection, "thread/read")
+            second = await _receive(connection, "thread/read")
+            await _reply(connection, second, {"thread": {"id": second["params"]["threadId"]}})
+            await _reply(connection, first, {"thread": {"id": first["params"]["threadId"]}})
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            client = CodexAppServerClient(endpoint)
+            await client.connect()
+            first, second = await asyncio.gather(
+                client.read_thread("thread-1"), client.read_thread("thread-2")
+            )
+            assert first["thread"] == {"id": "thread-1"}
+            assert second["thread"] == {"id": "thread-2"}
+            await client.disconnect()
+
+    asyncio.run(scenario())
+
+
+def test_missing_capability_degrades_only_that_surface() -> None:
+    async def scenario() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await _ready(connection)
+            request = await _receive(connection, "turn/steer")
+            await connection.send(
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": request["id"],
+                        "error": {"code": -32601, "message": "method not found"},
+                    }
+                )
+            )
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            client = CodexAppServerClient(endpoint)
+            await client.connect()
+            try:
+                await client.steer("thread-1", "turn-1", "verify")
+            except UnsupportedAppServerCapability as error:
+                assert error.method == "turn/steer"
+            else:
+                raise AssertionError("missing turn/steer wasn't reported")
+            assert client.state == ConnectionState.DEGRADED
+            assert client.capabilities.observation == CapabilityStatus.AVAILABLE
+            assert client.capabilities.steer == CapabilityStatus.UNAVAILABLE
+            assert client.capabilities.interrupt == CapabilityStatus.UNKNOWN
+            await client.disconnect()
+
+    asyncio.run(scenario())
+
+
+def test_reconnect_renegotiates_changed_capability() -> None:
+    async def scenario() -> None:
+        connection_number = 0
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connection_number
+            connection_number += 1
+            await _ready(connection)
+            request = await _receive(connection, "turn/steer")
+            if connection_number == 1:
+                await connection.send(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": request["id"],
+                            "error": {"code": -32601, "message": "method not found"},
+                        }
+                    )
+                )
+            else:
+                await _reply(connection, request, {"turnId": "turn-1"})
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            client = CodexAppServerClient(endpoint)
+            await client.connect()
+            with suppress(UnsupportedAppServerCapability):
+                await client.steer("thread-1", "turn-1", "verify")
+            await client.disconnect()
+
+            await client.connect()
+            await client.steer("thread-1", "turn-1", "verify")
+            assert client.capabilities.steer == CapabilityStatus.AVAILABLE
+            await client.disconnect()
+
+    asyncio.run(scenario())
+
+
+def test_disconnect_and_protocol_failure_are_structured() -> None:
+    async def disconnected() -> None:
+        client = CodexAppServerClient("ws://127.0.0.1:1", request_timeout=0.1)
+        try:
+            await client.connect()
+        except AppServerTransportError:
+            pass
+        else:
+            raise AssertionError("unreachable server wasn't reported")
+        assert client.state == ConnectionState.UNAVAILABLE
+
+    async def malformed() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await connection.recv()
+            await connection.send("not json")
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            client = CodexAppServerClient(endpoint)
+            try:
+                await client.connect()
+            except AppServerProtocolError:
+                pass
+            else:
+                raise AssertionError("malformed JSON wasn't reported")
+            assert client.state == ConnectionState.UNAVAILABLE
+
+    async def clean_close() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await _ready(connection)
+            request = await _receive(connection, "thread/read")
+            await _reply(connection, request, {"thread": {"id": "thread-1"}})
+            await connection.close()
+
+        async with _server(handler) as endpoint:
+            client = CodexAppServerClient(endpoint)
+            await client.connect()
+            await client.read_thread("thread-1")
+            error = await client.wait_closed()
+            assert isinstance(error, AppServerTransportError)
+            assert client.state == ConnectionState.DEGRADED
+            await client.disconnect()
+
+    async def malformed_result() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await _ready(connection)
+            request = await _receive(connection, "thread/read")
+            await _reply(connection, request, None)
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            client = CodexAppServerClient(endpoint)
+            await client.connect()
+            try:
+                await client.read_thread("thread-1")
+            except AppServerProtocolError:
+                pass
+            else:
+                raise AssertionError("malformed result wasn't reported")
+            assert isinstance(client.last_error, AppServerProtocolError)
+            assert client.state == ConnectionState.DEGRADED
+            await client.disconnect()
+
+    asyncio.run(disconnected())
+    asyncio.run(malformed())
+    asyncio.run(clean_close())
+    asyncio.run(malformed_result())


### PR DESCRIPTION
## Why

The shared-server PoC proved Spotter can observe and steer the TUI's real turn, but production runtime work still lacked a typed, diagnosable App Server transport.

Closes #80

## What changed

- add an async initialized WebSocket/JSON-RPC client for raw events, thread queries, resume, steer, and interrupt
- expose supported, unknown, and unavailable capability state plus structured transport, protocol, and RPC failures
- reject unsupported server-initiated requests without blocking Codex and terminate event consumers on connection loss
- close failed/timed-out connections so late responses and additional RPCs cannot enter an inconsistent state
- cover concurrent requests, capability loss/change, disconnects, timeouts, and malformed protocol data with a local test server
- update current-state documentation after the #78 gate result

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (258 passed)
- wheel build and metadata inspection
- live initialize + thread/list against Codex App Server 0.147.0

## Notes

Trace IR normalization and event backpressure remain #85, thread/turn/attachment identity remains #81, and reconnect reconciliation remains #87. Atomic pre-tool veto remains unavailable through App Server and stays on the Hook boundary.
