### PR TITLE
feat: add runtime identity lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 App Server can share the TUI's real thread and steer its active turn. The production client in
 [#80](https://github.com/spotter-agent/spotter/issues/80) now exposes events, thread queries,
 control methods, and per-capability degraded state. The remaining Runtime work establishes
-`spotterd` ([#79](https://github.com/spotter-agent/spotter/issues/79)), explicit thread/turn identity
-([#81](https://github.com/spotter-agent/spotter/issues/81)), and lifecycle/recovery boundaries.
+`spotterd` ([#79](https://github.com/spotter-agent/spotter/issues/79)) and the lifecycle/recovery
+boundaries around the implemented thread/turn/attachment identity foundation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,9 +90,11 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 [#78](https://github.com/spotter-agent/spotter/issues/78) proved that a Spotter-managed external
 App Server can share the TUI's real thread and steer its active turn. The production client in
 [#80](https://github.com/spotter-agent/spotter/issues/80) now exposes events, thread queries,
-control methods, and per-capability degraded state. The remaining Runtime work establishes
-`spotterd` ([#79](https://github.com/spotter-agent/spotter/issues/79)) and the lifecycle/recovery
-boundaries around the implemented thread/turn/attachment identity foundation.
+control methods, and per-capability degraded state. [#81](https://github.com/spotter-agent/spotter/issues/81)
+adds a provisional thread/turn/attachment registry; it remains unconsumed until App Server event
+routing in [#85](https://github.com/spotter-agent/spotter/issues/85). The remaining Runtime work also
+establishes `spotterd` ([#79](https://github.com/spotter-agent/spotter/issues/79)) and
+lifecycle/recovery boundaries.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,8 +81,8 @@ PreToolUse Hook only for deterministic blocking
 
 [#78](https://github.com/spotter-agent/spotter/issues/78) proved that the user's Codex TUI and
 Spotter can share a Spotter-managed external App Server and that `turn/steer` reaches the real
-active turn. The managed daemon, concurrent identity, and reconnect lifecycle remain explicit
-Runtime work.
+active turn. The identity foundation is implemented; daemon ownership, event routing, and reconnect
+remain explicit Runtime work.
 
 ## Roadmap vocabulary
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,8 +85,8 @@ prove that an explicitly remote-connected TUI and Spotter can share the server a
 `turn/steer` reaches the real active user turn.
 [#78](https://github.com/spotter-agent/spotter/issues/78) proved that the user's Codex TUI and
 Spotter can share a Spotter-managed external App Server and that `turn/steer` reaches the real
-active turn. The identity foundation is implemented; daemon ownership, event routing, and reconnect
-remain explicit Runtime work.
+active turn. A provisional identity registry exists but has no production event consumer yet;
+daemon ownership, event routing, and reconnect remain explicit Runtime work.
 
 ## Roadmap vocabulary
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -612,6 +612,21 @@ State scope:
 | durable journal lineage | Thread |
 | fork branch point | Thread + Turn/Step |
 
+## Implemented identity foundation
+
+`RuntimeIdentityRegistry` implements this transport-independent boundary:
+
+- agent-scoped external thread and turn IDs are retained as provenance and mapped to stable opaque
+  Spotter IDs, so restart/reconciliation finds the same durable lineage;
+- each attachment period has its own identity, and concurrent attachments do not merge;
+- duplicate lifecycle events are idempotent, while conflicting terminal states fail explicitly;
+- a terminal event observed before its start creates a terminal turn marked `observed_start=False`;
+- Hook-era `session_id` becomes a `RuntimeIdentity` with unknown thread/turn/attachment fields rather
+  than being promoted into an identity it cannot prove.
+
+The registry owns identity and lifecycle only. Semantic `ThreadState` remains #31, and App Server
+event normalization/routing into this registry remains #85.
+
 ---
 
 # 10. App Server connection and capability model
@@ -898,8 +913,8 @@ PreToolUse:  possibly available
   explicit per-capability degradation used by later runtime components.
 - Path A remains unavailable for the tested Homebrew Cask because the managed daemon expects the
   standalone installer layout.
-- Concurrent thread identity is owned by #81, daemon/service ownership by #79/#83, and reconnect
-  reconciliation by #87.
+- The concurrent thread identity foundation is implemented in #81; App Server event routing uses it
+  in #85, daemon/service ownership remains #79/#83, and reconnect reconciliation remains #87.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -614,20 +614,22 @@ State scope:
 | durable journal lineage | Thread |
 | fork branch point | Thread + Turn/Step |
 
-## Implemented identity foundation
+## Provisional identity foundation
 
-`RuntimeIdentityRegistry` implements this transport-independent boundary:
+`RuntimeIdentityRegistry` sketches this transport-independent boundary:
 
-- agent-scoped external thread and turn IDs are retained as provenance and mapped to stable opaque
-  Spotter IDs, so restart/reconciliation finds the same durable lineage;
-- each attachment period has its own identity, and concurrent attachments do not merge;
+- agent-scoped external thread and turn IDs are retained as provenance and mapped deterministically
+  to Spotter IDs;
+- explicit attachment records track active/closed state, and concurrent external attachment IDs do
+  not merge;
 - duplicate lifecycle events are idempotent, while conflicting terminal states fail explicitly;
 - a terminal event observed before its start creates a terminal turn marked `observed_start=False`;
 - Hook-era `session_id` becomes a `RuntimeIdentity` with unknown thread/turn/attachment fields rather
   than being promoted into an identity it cannot prove.
 
-The registry owns identity and lifecycle only. Semantic `ThreadState` remains #31, and App Server
-event normalization/routing into this registry remains #85.
+The registry owns identity and lifecycle only and has no production consumer yet. Semantic
+`ThreadState` remains #31; App Server event normalization/routing in #85 must validate and may
+reshape this interface.
 
 ---
 
@@ -918,8 +920,9 @@ PreToolUse:  possibly available
   explicit per-capability degradation used by later runtime components.
 - Path A remains unavailable for the tested Homebrew Cask because the managed daemon expects the
   standalone installer layout.
-- The concurrent thread identity foundation is implemented in #81; App Server event routing uses it
-  in #85, daemon/service ownership remains #79/#83, and reconnect reconciliation remains #87.
+- A provisional concurrent thread identity registry exists from #81 but is not wired into production;
+  App Server event routing in #85 must validate it, daemon/service ownership remains #79/#83, and
+  reconnect reconciliation remains #87.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,8 +63,8 @@ PreToolUse Hook only where synchronous deterministic enforcement is required
 [#78](https://github.com/spotter-agent/spotter/issues/78) demonstrated that a TUI and Spotter can
 attach to one Spotter-managed external App Server, observe the same thread/turn, and steer the real
 user-visible turn. The Codex-managed daemon path was unavailable to the tested Homebrew Cask install.
-Concurrent identity, daemon ownership, and reconnect remain explicit Runtime work rather than
-assumed properties.
+The concurrent identity foundation is now explicit; daemon ownership, event routing, and reconnect
+remain Runtime work rather than assumed properties.
 
 ## Implementation after the gate
 
@@ -74,7 +74,7 @@ The Runtime milestone is now decomposed into concrete boundaries rather than one
 | --- | --- |
 | [#79](https://github.com/spotter-agent/spotter/issues/79) | `spotterd`, local control RPC, per-user service lifecycle |
 | [#80](https://github.com/spotter-agent/spotter/issues/80) | production App Server client and capability negotiation |
-| [#81](https://github.com/spotter-agent/spotter/issues/81) | Thread / Turn / Runtime Attachment identity lifecycle |
+| [#81](https://github.com/spotter-agent/spotter/issues/81) | Thread / Turn / Runtime Attachment identity lifecycle (implemented foundation) |
 | [#82](https://github.com/spotter-agent/spotter/issues/82) | bounded Hook ↔ daemon IPC for deterministic `PreToolUse` enforcement |
 | [#31](https://github.com/spotter-agent/spotter/issues/31) | independent live supervision state owned by `spotterd` |
 | [#83](https://github.com/spotter-agent/spotter/issues/83) | transactional `setup|teardown codex`, Integration Manifest, legacy migration |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -149,8 +149,8 @@ PreToolUse Hook only where synchronous deterministic enforcement is required
 [#78](https://github.com/spotter-agent/spotter/issues/78) demonstrated that a TUI and Spotter can
 attach to one Spotter-managed external App Server, observe the same thread/turn, and steer the real
 user-visible turn. The Codex-managed daemon path was unavailable to the tested Homebrew Cask install.
-The concurrent identity foundation is now explicit; daemon ownership, event routing, and reconnect
-remain Runtime work rather than assumed properties.
+A provisional concurrent identity registry is now explicit but unconsumed; daemon ownership, event
+routing, and reconnect remain Runtime work rather than assumed properties.
 
 ## Implementation after the gate
 
@@ -160,7 +160,7 @@ The Runtime milestone is now decomposed into concrete boundaries rather than one
 | --- | --- |
 | [#79](https://github.com/spotter-agent/spotter/issues/79) | `spotterd`, local control RPC, per-user service lifecycle |
 | [#80](https://github.com/spotter-agent/spotter/issues/80) | production App Server client and capability negotiation |
-| [#81](https://github.com/spotter-agent/spotter/issues/81) | Thread / Turn / Runtime Attachment identity lifecycle (implemented foundation) |
+| [#81](https://github.com/spotter-agent/spotter/issues/81) | Thread / Turn / Runtime Attachment identity lifecycle (provisional foundation; integration in #85) |
 | [#82](https://github.com/spotter-agent/spotter/issues/82) | bounded Hook ↔ daemon IPC for deterministic `PreToolUse` enforcement |
 | [#31](https://github.com/spotter-agent/spotter/issues/31) | independent live supervision state owned by `spotterd` |
 | [#83](https://github.com/spotter-agent/spotter/issues/83) | transactional `setup|teardown codex`, Integration Manifest, legacy migration |

--- a/docs/status.md
+++ b/docs/status.md
@@ -37,8 +37,8 @@ Runtime → Observe → Detect → Intervene → Recover → Harden
 ```
 
 The shared-server gate in [#78](https://github.com/spotter-agent/spotter/issues/78) passed for the
-Spotter-managed external App Server path. Spotter now has a production WebSocket client with
-explicit observation/control capabilities; the standalone daemon and identity model remain next.
+Spotter-managed external App Server path. Spotter now has a production WebSocket client and an
+explicit Thread/Turn/Runtime Attachment identity registry; the standalone daemon remains next.
 
 ---
 
@@ -54,7 +54,6 @@ typed steer/interrupt methods, and explicit supported/unknown/unavailable capabi
 The remaining implementation boundaries are split into native GitHub issues:
 
 - [#79](https://github.com/spotter-agent/spotter/issues/79) — `spotterd`, local control RPC, and per-user service lifecycle;
-- [#81](https://github.com/spotter-agent/spotter/issues/81) — Thread / Turn / Runtime Attachment identity;
 - [#82](https://github.com/spotter-agent/spotter/issues/82) — bounded fail-open `PreToolUse` ↔ daemon enforcement IPC;
 - [#83](https://github.com/spotter-agent/spotter/issues/83) — transactional Codex setup/teardown and integration ownership;
 - [#84](https://github.com/spotter-agent/spotter/issues/84) — runtime-aware status/doctor;
@@ -87,8 +86,8 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Evaluation labels / metrics | ✅ | Coverage-aware labeling and precision/FP metrics | Broader cost/miss/harm metrics (#33, #38, #34) |
 | Counterfactual harness | ✅ | Control/guidance same-prefix pairs can be prepared/run | Add mechanically scored tasks (#21) |
 | Standalone runtime | ❌ | No long-lived owner, service boundary, or runtime RPC | Build `spotterd` in #79 |
-| Runtime identity | ❌ | Hook-era `session_id` is the dominant identity | Thread/Turn/Attachment model in #81 |
-| App Server primary observation | 🟡 | Async client, raw events, thread queries, controls, capability degradation | Normalize and journal events in #85 after identity #81 |
+| Runtime identity | ✅ | Agent-scoped stable Thread/Turn IDs, attachment periods, lifecycle routing, explicit legacy unknowns | Feed normalized App Server events through it in #85 |
+| App Server primary observation | 🟡 | Async client, raw events, thread queries, controls, capability degradation | Normalize, identity-route, and journal events in #85 |
 | Managed Codex lifecycle | ❌ | Current path is source/plugin installation | transactional setup/teardown in #83; diagnostics in #84 |
 | Runtime reconnect/recovery | ❌ | No long-lived App Server connection to recover | #87 after runtime/state boundaries exist |
 | Event-driven detection | ❌ | Reviewer is still cadence-based | #28 after Runtime/Observe |

--- a/docs/status.md
+++ b/docs/status.md
@@ -38,8 +38,9 @@ Runtime → Observe → Detect → Intervene → Recover → Harden
 ```
 
 The shared-server gate in [#78](https://github.com/spotter-agent/spotter/issues/78) passed for the
-Spotter-managed external App Server path. Spotter now has a production WebSocket client and an
-explicit Thread/Turn/Runtime Attachment identity registry; the standalone daemon remains next.
+Spotter-managed external App Server path. Spotter now has a production WebSocket client and a
+provisional Thread/Turn/Runtime Attachment registry with no production event consumer yet; the
+standalone daemon remains next.
 
 ---
 
@@ -94,7 +95,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Evaluation labels / metrics | ✅ | Coverage-aware labeling and precision/FP metrics | Broader cost/miss/harm metrics (#33, #38, #34) |
 | Counterfactual harness | ✅ | Control/guidance same-prefix pairs can be prepared/run | Add mechanically scored tasks (#21) |
 | Standalone runtime | ❌ | No long-lived owner, service boundary, or runtime RPC | Build `spotterd` in #79 |
-| Runtime identity | ✅ | Agent-scoped stable Thread/Turn IDs, attachment periods, lifecycle routing, explicit legacy unknowns | Feed normalized App Server events through it in #85 |
+| Runtime identity | 🟡 | Provisional lifecycle registry and explicit legacy unknowns; no production consumer | Validate and refine it while routing normalized App Server events in #85 |
 | App Server primary observation | 🟡 | Async client, raw events, thread queries, controls, capability degradation | Normalize, identity-route, and journal events in #85 |
 | Managed Codex lifecycle | ❌ | Current path is source/plugin installation | transactional setup/teardown in #83; diagnostics in #84 |
 | Runtime reconnect/recovery | ❌ | No long-lived App Server connection to recover | #87 after runtime/state boundaries exist |

--- a/src/spotter/identity.py
+++ b/src/spotter/identity.py
@@ -165,7 +165,11 @@ class RuntimeIdentityRegistry:
             key = (thread_id, agent_attachment_id)
             attachment_id = self._attachments_by_agent_id.get(key)
             if attachment_id is not None:
-                return self._attachments[attachment_id]
+                attachment = self._attachments[attachment_id]
+                if attachment.status == AttachmentStatus.CLOSED:
+                    attachment = replace(attachment, status=AttachmentStatus.ACTIVE)
+                    self._attachments[attachment_id] = attachment
+                return attachment
             attachment_id = AttachmentId(
                 _stable_id("attachment", thread_id.value, agent_attachment_id)
             )

--- a/src/spotter/identity.py
+++ b/src/spotter/identity.py
@@ -1,0 +1,319 @@
+"""Runtime-neutral thread, turn, and attachment identity lifecycle."""
+
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from uuid import UUID, uuid4, uuid5
+
+_IDENTITY_NAMESPACE = UUID("409330c4-edc3-4f31-8793-530914c9cc37")
+
+
+@dataclass(frozen=True, order=True)
+class ThreadId:
+    value: str
+
+
+@dataclass(frozen=True, order=True)
+class TurnId:
+    value: str
+
+
+@dataclass(frozen=True, order=True)
+class AttachmentId:
+    value: str
+
+
+class ThreadStatus(StrEnum):
+    ACTIVE = "active"
+    DORMANT = "dormant"
+
+
+class TurnStatus(StrEnum):
+    ACTIVE = "active"
+    COMPLETED = "completed"
+    INTERRUPTED = "interrupted"
+
+
+class AttachmentStatus(StrEnum):
+    ACTIVE = "active"
+    CLOSED = "closed"
+
+
+@dataclass(frozen=True)
+class IdentityProvenance:
+    agent: str
+    agent_thread_id: str | None = None
+    agent_turn_id: str | None = None
+    agent_attachment_id: str | None = None
+    legacy_session_id: str | None = None
+
+
+@dataclass(frozen=True)
+class RuntimeIdentity:
+    """An explicit address; unknown dimensions remain None instead of being inferred."""
+
+    thread_id: ThreadId | None
+    turn_id: TurnId | None
+    attachment_id: AttachmentId | None
+    provenance: IdentityProvenance
+
+    @classmethod
+    def legacy_hook(cls, agent: str, session_id: str | None) -> "RuntimeIdentity":
+        """Represent Hook-era identity without pretending a session is a thread or turn."""
+
+        return cls(
+            thread_id=None,
+            turn_id=None,
+            attachment_id=None,
+            provenance=IdentityProvenance(agent=agent, legacy_session_id=session_id),
+        )
+
+
+@dataclass(frozen=True)
+class AgentThread:
+    id: ThreadId
+    status: ThreadStatus
+    provenance: IdentityProvenance
+
+
+@dataclass(frozen=True)
+class Turn:
+    id: TurnId
+    thread_id: ThreadId
+    attachment_id: AttachmentId | None
+    status: TurnStatus
+    observed_start: bool
+    provenance: IdentityProvenance
+
+
+@dataclass(frozen=True)
+class RuntimeAttachment:
+    id: AttachmentId
+    thread_id: ThreadId
+    status: AttachmentStatus
+    provenance: IdentityProvenance
+
+
+class IdentityError(ValueError):
+    """Base error for invalid or ambiguous runtime identity."""
+
+
+class MissingRuntimeIdentity(IdentityError):
+    """An event omitted an identity required for safe routing."""
+
+
+class UnknownRuntimeIdentity(IdentityError):
+    """An event referenced an identity that hasn't been observed."""
+
+
+class ConflictingRuntimeIdentity(IdentityError):
+    """Events disagree about an existing identity or terminal state."""
+
+
+class RuntimeIdentityRegistry:
+    """Isolate concurrent runtime identities and reconcile duplicate/out-of-order events."""
+
+    def __init__(self) -> None:
+        self._threads: dict[ThreadId, IdentityProvenance] = {}
+        self._threads_by_agent_id: dict[tuple[str, str], ThreadId] = {}
+        self._turns: dict[TurnId, Turn] = {}
+        self._turns_by_agent_id: dict[tuple[ThreadId, str], TurnId] = {}
+        self._attachments: dict[AttachmentId, RuntimeAttachment] = {}
+        self._attachments_by_agent_id: dict[tuple[ThreadId, str], AttachmentId] = {}
+
+    def observe_thread(self, agent: str, agent_thread_id: str) -> AgentThread:
+        agent = _required(agent, "agent")
+        agent_thread_id = _required(agent_thread_id, "agent thread id")
+        key = (agent, agent_thread_id)
+        thread_id = self._threads_by_agent_id.get(key)
+        if thread_id is None:
+            thread_id = ThreadId(_stable_id("thread", agent, agent_thread_id))
+            provenance = IdentityProvenance(agent=agent, agent_thread_id=agent_thread_id)
+            self._threads[thread_id] = provenance
+            self._threads_by_agent_id[key] = thread_id
+        return self.thread(thread_id)
+
+    def resolve_thread(self, agent: str, agent_thread_id: str) -> AgentThread:
+        key = (_required(agent, "agent"), _required(agent_thread_id, "agent thread id"))
+        thread_id = self._threads_by_agent_id.get(key)
+        if thread_id is None:
+            raise UnknownRuntimeIdentity(f"unknown agent thread: {key[0]}:{key[1]}")
+        return self.thread(thread_id)
+
+    def thread(self, thread_id: ThreadId) -> AgentThread:
+        provenance = self._threads.get(thread_id)
+        if provenance is None:
+            raise UnknownRuntimeIdentity(f"unknown thread: {thread_id.value}")
+        is_active = any(
+            attachment.thread_id == thread_id and attachment.status == AttachmentStatus.ACTIVE
+            for attachment in self._attachments.values()
+        ) or any(
+            turn.thread_id == thread_id and turn.status == TurnStatus.ACTIVE
+            for turn in self._turns.values()
+        )
+        return AgentThread(
+            id=thread_id,
+            status=ThreadStatus.ACTIVE if is_active else ThreadStatus.DORMANT,
+            provenance=provenance,
+        )
+
+    def attach(
+        self, thread_id: ThreadId, *, agent_attachment_id: str | None = None
+    ) -> RuntimeAttachment:
+        thread = self.thread(thread_id)
+        if agent_attachment_id is not None:
+            agent_attachment_id = _required(agent_attachment_id, "agent attachment id")
+            key = (thread_id, agent_attachment_id)
+            attachment_id = self._attachments_by_agent_id.get(key)
+            if attachment_id is not None:
+                return self._attachments[attachment_id]
+            attachment_id = AttachmentId(
+                _stable_id("attachment", thread_id.value, agent_attachment_id)
+            )
+            self._attachments_by_agent_id[key] = attachment_id
+        else:
+            attachment_id = AttachmentId(uuid4().hex)
+        attachment = RuntimeAttachment(
+            id=attachment_id,
+            thread_id=thread_id,
+            status=AttachmentStatus.ACTIVE,
+            provenance=IdentityProvenance(
+                agent=thread.provenance.agent,
+                agent_thread_id=thread.provenance.agent_thread_id,
+                agent_attachment_id=agent_attachment_id,
+            ),
+        )
+        self._attachments[attachment_id] = attachment
+        return attachment
+
+    def detach(self, attachment_id: AttachmentId) -> RuntimeAttachment:
+        attachment = self._attachments.get(attachment_id)
+        if attachment is None:
+            raise UnknownRuntimeIdentity(f"unknown attachment: {attachment_id.value}")
+        if attachment.status == AttachmentStatus.CLOSED:
+            return attachment
+        attachment = replace(attachment, status=AttachmentStatus.CLOSED)
+        self._attachments[attachment_id] = attachment
+        return attachment
+
+    def start_turn(
+        self,
+        thread_id: ThreadId,
+        agent_turn_id: str,
+        *,
+        attachment_id: AttachmentId | None = None,
+    ) -> Turn:
+        thread = self.thread(thread_id)
+        agent_turn_id = _required(agent_turn_id, "agent turn id")
+        if attachment_id is not None:
+            attachment = self._attachments.get(attachment_id)
+            if attachment is None:
+                raise UnknownRuntimeIdentity(f"unknown attachment: {attachment_id.value}")
+            if attachment.thread_id != thread_id:
+                raise ConflictingRuntimeIdentity("attachment belongs to another thread")
+
+        key = (thread_id, agent_turn_id)
+        turn_id = self._turns_by_agent_id.get(key)
+        if turn_id is not None:
+            turn = self._turns[turn_id]
+            if (
+                attachment_id is not None
+                and turn.attachment_id is not None
+                and turn.attachment_id != attachment_id
+            ):
+                raise ConflictingRuntimeIdentity("turn belongs to another attachment")
+            turn = replace(
+                turn,
+                attachment_id=turn.attachment_id or attachment_id,
+                observed_start=True,
+            )
+            self._turns[turn_id] = turn
+            return turn
+
+        turn_id = TurnId(_stable_id("turn", thread_id.value, agent_turn_id))
+        turn = Turn(
+            id=turn_id,
+            thread_id=thread_id,
+            attachment_id=attachment_id,
+            status=TurnStatus.ACTIVE,
+            observed_start=True,
+            provenance=IdentityProvenance(
+                agent=thread.provenance.agent,
+                agent_thread_id=thread.provenance.agent_thread_id,
+                agent_turn_id=agent_turn_id,
+                agent_attachment_id=(
+                    self._attachments[attachment_id].provenance.agent_attachment_id
+                    if attachment_id is not None
+                    else None
+                ),
+            ),
+        )
+        self._turns[turn_id] = turn
+        self._turns_by_agent_id[key] = turn_id
+        return turn
+
+    def finish_turn(self, thread_id: ThreadId, agent_turn_id: str, status: TurnStatus) -> Turn:
+        if status == TurnStatus.ACTIVE:
+            raise ValueError("finish status must be completed or interrupted")
+        thread = self.thread(thread_id)
+        agent_turn_id = _required(agent_turn_id, "agent turn id")
+        key = (thread_id, agent_turn_id)
+        turn_id = self._turns_by_agent_id.get(key)
+        if turn_id is None:
+            turn_id = TurnId(_stable_id("turn", thread_id.value, agent_turn_id))
+            turn = Turn(
+                id=turn_id,
+                thread_id=thread_id,
+                attachment_id=None,
+                status=status,
+                observed_start=False,
+                provenance=IdentityProvenance(
+                    agent=thread.provenance.agent,
+                    agent_thread_id=thread.provenance.agent_thread_id,
+                    agent_turn_id=agent_turn_id,
+                ),
+            )
+            self._turns[turn_id] = turn
+            self._turns_by_agent_id[key] = turn_id
+            return turn
+
+        turn = self._turns[turn_id]
+        if turn.status != TurnStatus.ACTIVE and turn.status != status:
+            raise ConflictingRuntimeIdentity(
+                f"turn already ended as {turn.status}; cannot change to {status}"
+            )
+        turn = replace(turn, status=status)
+        self._turns[turn_id] = turn
+        return turn
+
+    def turn(self, turn_id: TurnId) -> Turn:
+        turn = self._turns.get(turn_id)
+        if turn is None:
+            raise UnknownRuntimeIdentity(f"unknown turn: {turn_id.value}")
+        return turn
+
+    def active_turns(self, thread_id: ThreadId) -> tuple[Turn, ...]:
+        self.thread(thread_id)
+        return tuple(
+            turn
+            for turn in self._turns.values()
+            if turn.thread_id == thread_id and turn.status == TurnStatus.ACTIVE
+        )
+
+    def address_turn(self, turn_id: TurnId) -> RuntimeIdentity:
+        turn = self.turn(turn_id)
+        return RuntimeIdentity(
+            thread_id=turn.thread_id,
+            turn_id=turn.id,
+            attachment_id=turn.attachment_id,
+            provenance=turn.provenance,
+        )
+
+
+def _required(value: str, name: str) -> str:
+    if not value.strip():
+        raise MissingRuntimeIdentity(f"missing {name}")
+    return value
+
+
+def _stable_id(kind: str, *parts: str) -> str:
+    return uuid5(_IDENTITY_NAMESPACE, "\0".join((kind, *parts))).hex

--- a/src/spotter/identity.py
+++ b/src/spotter/identity.py
@@ -314,8 +314,8 @@ class RuntimeIdentityRegistry:
 
 
 def _required(value: str, name: str) -> str:
-    if not value.strip():
-        raise MissingRuntimeIdentity(f"missing {name}")
+    if not value.strip() or "\0" in value:
+        raise MissingRuntimeIdentity(f"missing or invalid {name}")
     return value
 
 

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,141 @@
+import pytest
+
+from spotter.identity import (
+    AttachmentStatus,
+    ConflictingRuntimeIdentity,
+    MissingRuntimeIdentity,
+    RuntimeIdentity,
+    RuntimeIdentityRegistry,
+    ThreadStatus,
+    TurnStatus,
+    UnknownRuntimeIdentity,
+)
+
+
+def test_concurrent_threads_and_turns_remain_isolated() -> None:
+    registry = RuntimeIdentityRegistry()
+    first = registry.observe_thread("codex", "thread-1")
+    second = registry.observe_thread("codex", "thread-2")
+    first_attachment = registry.attach(first.id, agent_attachment_id="window-1")
+    second_attachment = registry.attach(second.id, agent_attachment_id="window-2")
+
+    first_turn = registry.start_turn(first.id, "turn-1", attachment_id=first_attachment.id)
+    second_turn = registry.start_turn(second.id, "turn-1", attachment_id=second_attachment.id)
+
+    assert first.id != second.id
+    assert first_turn.id != second_turn.id
+    assert registry.active_turns(first.id) == (first_turn,)
+    assert registry.active_turns(second.id) == (second_turn,)
+
+
+def test_duplicate_events_are_idempotent_and_terminal_turns_do_not_regress() -> None:
+    registry = RuntimeIdentityRegistry()
+    thread = registry.observe_thread("codex", "thread-1")
+    attachment = registry.attach(thread.id, agent_attachment_id="window-1")
+
+    first_start = registry.start_turn(thread.id, "turn-1", attachment_id=attachment.id)
+    duplicate_start = registry.start_turn(thread.id, "turn-1", attachment_id=attachment.id)
+    first_finish = registry.finish_turn(thread.id, "turn-1", TurnStatus.COMPLETED)
+    duplicate_finish = registry.finish_turn(thread.id, "turn-1", TurnStatus.COMPLETED)
+    late_start = registry.start_turn(thread.id, "turn-1", attachment_id=attachment.id)
+
+    assert duplicate_start.id == first_start.id
+    assert duplicate_finish == first_finish
+    assert late_start.status == TurnStatus.COMPLETED
+
+
+def test_multiple_turns_keep_individual_state_and_addresses() -> None:
+    registry = RuntimeIdentityRegistry()
+    thread = registry.observe_thread("codex", "thread-1")
+    first = registry.start_turn(thread.id, "turn-1")
+    registry.finish_turn(thread.id, "turn-1", TurnStatus.COMPLETED)
+    second = registry.start_turn(thread.id, "turn-2")
+
+    assert registry.turn(first.id).status == TurnStatus.COMPLETED
+    assert registry.active_turns(thread.id) == (second,)
+    assert registry.address_turn(second.id).provenance.agent_turn_id == "turn-2"
+
+
+def test_out_of_order_completion_preserves_missing_start_observation() -> None:
+    registry = RuntimeIdentityRegistry()
+    thread = registry.observe_thread("codex", "thread-1")
+
+    completed = registry.finish_turn(thread.id, "turn-1", TurnStatus.INTERRUPTED)
+    assert not completed.observed_start
+
+    started_late = registry.start_turn(thread.id, "turn-1")
+    assert started_late.observed_start
+    assert started_late.status == TurnStatus.INTERRUPTED
+    with pytest.raises(ConflictingRuntimeIdentity):
+        registry.finish_turn(thread.id, "turn-1", TurnStatus.COMPLETED)
+
+
+def test_detach_and_resume_keep_durable_thread_identity() -> None:
+    registry = RuntimeIdentityRegistry()
+    thread = registry.observe_thread("codex", "thread-1")
+    first = registry.attach(thread.id)
+    assert registry.thread(thread.id).status == ThreadStatus.ACTIVE
+
+    closed = registry.detach(first.id)
+    assert closed.status == AttachmentStatus.CLOSED
+    assert registry.thread(thread.id).status == ThreadStatus.DORMANT
+
+    reconciled = registry.resolve_thread("codex", "thread-1")
+    resumed = registry.attach(reconciled.id)
+    assert resumed.id != first.id
+    assert reconciled.id == thread.id
+    assert registry.thread(thread.id).status == ThreadStatus.ACTIVE
+
+
+def test_fresh_registry_reconciles_the_same_external_lineage() -> None:
+    first_registry = RuntimeIdentityRegistry()
+    first_thread = first_registry.observe_thread("codex", "thread-1")
+    first_turn = first_registry.start_turn(first_thread.id, "turn-1")
+
+    recovered_registry = RuntimeIdentityRegistry()
+    recovered_thread = recovered_registry.observe_thread("codex", "thread-1")
+    recovered_turn = recovered_registry.start_turn(recovered_thread.id, "turn-1")
+
+    assert recovered_thread.id == first_thread.id
+    assert recovered_turn.id == first_turn.id
+
+
+def test_concurrent_attachments_are_distinct_and_duplicates_are_stable() -> None:
+    registry = RuntimeIdentityRegistry()
+    thread = registry.observe_thread("codex", "thread-1")
+
+    first = registry.attach(thread.id, agent_attachment_id="window-1")
+    duplicate = registry.attach(thread.id, agent_attachment_id="window-1")
+    second = registry.attach(thread.id, agent_attachment_id="window-2")
+
+    assert duplicate == first
+    assert second.id != first.id
+
+
+def test_turn_address_is_specific_and_keeps_agent_provenance() -> None:
+    registry = RuntimeIdentityRegistry()
+    thread = registry.observe_thread("codex", "thread-1")
+    attachment = registry.attach(thread.id, agent_attachment_id="window-1")
+    turn = registry.start_turn(thread.id, "turn-7", attachment_id=attachment.id)
+
+    address = registry.address_turn(turn.id)
+
+    assert address.thread_id == thread.id
+    assert address.turn_id == turn.id
+    assert address.attachment_id == attachment.id
+    assert address.provenance.agent_thread_id == "thread-1"
+    assert address.provenance.agent_turn_id == "turn-7"
+
+
+def test_missing_and_legacy_identity_are_explicit() -> None:
+    registry = RuntimeIdentityRegistry()
+    with pytest.raises(MissingRuntimeIdentity):
+        registry.observe_thread("codex", "")
+    with pytest.raises(UnknownRuntimeIdentity):
+        registry.resolve_thread("codex", "missing")
+
+    legacy = RuntimeIdentity.legacy_hook("codex", "hook-session-1")
+    assert legacy.thread_id is None
+    assert legacy.turn_id is None
+    assert legacy.attachment_id is None
+    assert legacy.provenance.legacy_session_id == "hook-session-1"

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -70,7 +70,7 @@ def test_out_of_order_completion_preserves_missing_start_observation() -> None:
         registry.finish_turn(thread.id, "turn-1", TurnStatus.COMPLETED)
 
 
-def test_detach_and_resume_keep_durable_thread_identity() -> None:
+def test_detach_and_resume_keep_thread_identity() -> None:
     registry = RuntimeIdentityRegistry()
     thread = registry.observe_thread("codex", "thread-1")
     first = registry.attach(thread.id)
@@ -87,7 +87,20 @@ def test_detach_and_resume_keep_durable_thread_identity() -> None:
     assert registry.thread(thread.id).status == ThreadStatus.ACTIVE
 
 
-def test_fresh_registry_reconciles_the_same_external_lineage() -> None:
+def test_attach_reopens_a_closed_external_attachment() -> None:
+    registry = RuntimeIdentityRegistry()
+    thread = registry.observe_thread("codex", "thread-1")
+    first = registry.attach(thread.id, agent_attachment_id="window-1")
+    registry.detach(first.id)
+
+    resumed = registry.attach(thread.id, agent_attachment_id="window-1")
+
+    assert resumed.id == first.id
+    assert resumed.status == AttachmentStatus.ACTIVE
+    assert registry.thread(thread.id).status == ThreadStatus.ACTIVE
+
+
+def test_new_registry_derives_the_same_external_identity() -> None:
     first_registry = RuntimeIdentityRegistry()
     first_thread = first_registry.observe_thread("codex", "thread-1")
     first_turn = first_registry.start_turn(first_thread.id, "turn-1")

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -144,6 +144,8 @@ def test_missing_and_legacy_identity_are_explicit() -> None:
     registry = RuntimeIdentityRegistry()
     with pytest.raises(MissingRuntimeIdentity):
         registry.observe_thread("codex", "")
+    with pytest.raises(MissingRuntimeIdentity):
+        registry.observe_thread("codex", "thread\0suffix")
     with pytest.raises(UnknownRuntimeIdentity):
         registry.resolve_thread("codex", "missing")
 


### PR DESCRIPTION
## Why

The App Server client exposes raw Codex thread and turn IDs, but runtime policy still lacked a transport-independent lifecycle model for concurrent sessions, resume, and targeted control.

This PR adds a provisional registry foundation. It has no production event consumer yet; App Server routing in #85 must validate and may reshape the interface.

Closes #81

## What changed

- add explicit Spotter Thread, Turn, Runtime Attachment, provenance, and address records
- derive deterministic agent-scoped Thread/Turn IDs while retaining external provenance
- isolate concurrent threads and track attachment lifecycle without a global current session
- make duplicate and out-of-order lifecycle events deterministic, including unobserved turn starts
- reopen a known external attachment when it reconnects after detach
- represent missing and Hook-era identity explicitly instead of guessing
- mark runtime identity as provisional and unconsumed in current-state documentation

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (268 passed)

## Notes

Semantic `ThreadState` remains #31. App Server normalization and identity routing remain #85; daemon/service ownership remains #79.