### PR TITLE
feat: add spotterd runtime boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Spotter asks a more specific question than “is the agent wrong?”
 
 > **Can we detect a bad assumption, loop, scope drift, or missing validation while the agent is still working, and intervene before the mistake becomes expensive?**
 
-The repository is already beyond a scaffold. The current prototype implements Hook-based trajectory collection, deterministic gates, crash-safe journals, Git snapshots, fork/replay, a shadow reviewer, claim/evidence state, evaluation labels/metrics, and counterfactual experiment machinery.
+The repository is already beyond a scaffold. The current prototype implements Hook-based trajectory collection, deterministic gates, crash-safe journals, Git snapshots, fork/replay, a shadow reviewer, claim/evidence state, evaluation labels/metrics, counterfactual experiment machinery, and a standalone daemon/control foundation.
 
 The current prototype and target product architecture are different:
 
@@ -77,7 +77,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Claim/evidence audit ledger | 🟡 | Works where observable outcomes exist |
 | Evaluation labels / metrics | ✅ | Coverage-aware evaluation and precision/FP metrics |
 | Counterfactual experiment harness | ✅ | Control/guidance same-prefix pairs |
-| Standalone `spotterd` runtime | ❌ | Target runtime boundary |
+| Standalone `spotterd` runtime | 🟡 | Process, local control handshake, and manual lifecycle implemented; managed startup/runtime consumers remain |
 | App Server primary observation | 🟡 | Client/capabilities implemented; Trace IR ingestion remains (#85) |
 | Event-driven signal engine | ❌ | Current reviewer trigger is periodic |
 | Live `VERIFY / NUDGE` | ❌ | Target: `turn/steer` |
@@ -92,9 +92,9 @@ App Server can share the TUI's real thread and steer its active turn. The produc
 [#80](https://github.com/spotter-agent/spotter/issues/80) now exposes events, thread queries,
 control methods, and per-capability degraded state. [#81](https://github.com/spotter-agent/spotter/issues/81)
 adds a provisional thread/turn/attachment registry; it remains unconsumed until App Server event
-routing in [#85](https://github.com/spotter-agent/spotter/issues/85). The remaining Runtime work also
-establishes `spotterd` ([#79](https://github.com/spotter-agent/spotter/issues/79)) and
-lifecycle/recovery boundaries.
+routing in [#85](https://github.com/spotter-agent/spotter/issues/85). [#79](https://github.com/spotter-agent/spotter/issues/79)
+adds the `spotterd` process, versioned local control handshake, manual lifecycle commands, and a
+platform-neutral service boundary. Managed setup, event routing, and recovery remain separate work.
 
 ---
 
@@ -313,6 +313,7 @@ Plugin installation is the **current prototype path**, not the long-term product
 Useful commands:
 
 ```bash
+spotter daemon start|stop|restart|status
 spotter analyze
 spotter review --session <id>
 spotter label --session <id> --step <n> --verdict fp

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
 > **Status:** this document describes both the current hook-based prototype and the target architecture. Active implementation is tracked by the [Roadmap](roadmap.md) and native GitHub Milestones.
-> `spotterd`, App Server primary Trace IR observation, and live supervision delivery are **target behavior**. The shared-server PoC and production App Server transport are implemented foundations.
+> The `spotterd` process/control foundation, shared-server PoC, and production App Server transport are implemented. App Server primary Trace IR observation and live supervision delivery remain **target behavior**.
 
 ---
 
@@ -105,7 +105,20 @@ Its limitations are now structural:
 - periodic review spends tokens even when nothing looks wrong;
 - richer App Server events are not the primary observation surface.
 
-## 1.2 Target runtime
+## 1.2 Implemented runtime foundation
+
+`spotterd` is an installable long-lived process with a versioned newline-delimited JSON control
+protocol over a per-user UNIX socket. `spotter daemon start|stop|restart|status` exercises a real
+handshake rather than treating a PID file as liveness. The server serializes ownership, accepts
+concurrent clients, reports `healthy` / `degraded` / `recovering`, and makes absence explicit as
+`unavailable`.
+
+Manual process management implements the `ServiceManager` boundary used by the CLI. Managed
+`launchd` / `systemd --user` registration belongs to setup lifecycle work. This daemon currently
+owns no App Server, semantic `ThreadState`, Hook IPC, or event routing, so stopping it cannot stop a
+shared Codex App Server and existing Hook behavior remains independent.
+
+## 1.3 Target runtime
 
 The target hot path is daemon-owned:
 
@@ -761,6 +774,11 @@ Conceptual layout:
 
 The current prototype uses `~/.spotter`; migration must preserve compatibility or provide an explicit data move.
 
+The current daemon control socket is `~/.spotter/runtime/spotterd.sock`. When a configured
+`SPOTTER_HOME` would exceed the platform UNIX-socket path limit, Spotter uses a short, private,
+user-and-home-specific runtime directory under `/tmp`. The socket handshake is the liveness source;
+the adjacent lock only serializes ownership.
+
 Repository/Git-owned Spotter resources may include:
 
 ```text
@@ -921,7 +939,7 @@ PreToolUse:  possibly available
 - Path A remains unavailable for the tested Homebrew Cask because the managed daemon expects the
   standalone installer layout.
 - A provisional concurrent thread identity registry exists from #81 but is not wired into production;
-  App Server event routing in #85 must validate it, daemon/service ownership remains #79/#83, and
+  App Server event routing in #85 must validate it, managed service registration remains #83, and
   reconnect reconciliation remains #87.
 
 ---

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,7 +1,7 @@
 # Lifecycle and Operations
 
 > **Status:** target design. Active implementation is tracked by the [Roadmap](roadmap.md) and native GitHub Milestones.
-> The current prototype is still hook/plugin-centered. Commands such as Homebrew installation, managed `spotterd`, and full App Server integration described here are the **intended product lifecycle**, not current shipping behavior.
+> The current prototype is still hook/plugin-centered. A manual `spotterd` process/control lifecycle exists, but Homebrew installation, managed service registration, and full App Server integration described here are the **intended product lifecycle**, not current shipping behavior.
 
 ---
 
@@ -56,8 +56,8 @@ The most important lifecycle constraint is this:
 > explicitly when the TUI starts (currently with `--remote`).**
 
 That conflicts with a completely lazy “wake Spotter on the first Hook” design. #78 proved a
-Spotter-managed external path; #79 and #83 must now make its service ownership and startup strategy
-explicit before the lifecycle is finalized.
+Spotter-managed external path, and #79 provides the daemon/control and `ServiceManager` foundation.
+#83 must register the selected managed startup strategy before the lifecycle is finalized.
 
 ---
 
@@ -602,6 +602,17 @@ Possible implementations:
 - Linux: `systemd --user`.
 
 Do not hard-code these mechanisms into Spotter core. Hide them behind a `ServiceManager` abstraction.
+
+The current manual escape hatch exercises that boundary without claiming managed setup:
+
+```bash
+spotter daemon start
+spotter daemon status
+spotter daemon restart
+spotter daemon stop
+```
+
+These commands control only `spotterd`. They never stop or reset a shared Codex App Server.
 
 A portable mode may trade capability for zero persistent service registration:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -149,8 +149,9 @@ PreToolUse Hook only where synchronous deterministic enforcement is required
 [#78](https://github.com/spotter-agent/spotter/issues/78) demonstrated that a TUI and Spotter can
 attach to one Spotter-managed external App Server, observe the same thread/turn, and steer the real
 user-visible turn. The Codex-managed daemon path was unavailable to the tested Homebrew Cask install.
-A provisional concurrent identity registry is now explicit but unconsumed; daemon ownership, event
-routing, and reconnect remain Runtime work rather than assumed properties.
+A provisional concurrent identity registry is now explicit but unconsumed. The standalone daemon
+and local control foundation exist; managed registration, event routing, and reconnect remain
+Runtime work rather than assumed properties.
 
 ## Implementation after the gate
 
@@ -158,7 +159,7 @@ The Runtime milestone is now decomposed into concrete boundaries rather than one
 
 | Issue | Boundary |
 | --- | --- |
-| [#79](https://github.com/spotter-agent/spotter/issues/79) | `spotterd`, local control RPC, per-user service lifecycle |
+| [#79](https://github.com/spotter-agent/spotter/issues/79) | `spotterd`, versioned local control, manual lifecycle, and platform-neutral service boundary (implemented) |
 | [#80](https://github.com/spotter-agent/spotter/issues/80) | production App Server client and capability negotiation |
 | [#81](https://github.com/spotter-agent/spotter/issues/81) | Thread / Turn / Runtime Attachment identity lifecycle (provisional foundation; integration in #85) |
 | [#82](https://github.com/spotter-agent/spotter/issues/82) | bounded Hook ↔ daemon IPC for deterministic `PreToolUse` enforcement |

--- a/docs/status.md
+++ b/docs/status.md
@@ -7,7 +7,7 @@
 
 ## 30-second summary
 
-Spotter is currently a **Hook-based research prototype**. It already has real trajectory journals, deterministic gates, Git snapshots, fork/replay, a shadow reviewer, an audit ledger, labeling/metrics, and a counterfactual experiment harness.
+Spotter is currently a **Hook-based research prototype** with a standalone runtime foundation. It already has real trajectory journals, deterministic gates, Git snapshots, fork/replay, a shadow reviewer, an audit ledger, labeling/metrics, a counterfactual experiment harness, and a manually managed `spotterd` process with local control IPC.
 
 The target product is a standalone runtime:
 
@@ -30,7 +30,7 @@ PreToolUse Hook only
 (deterministic synchronous enforcement)
 ```
 
-The **immediate blocker** is not writing `spotterd`. Current Codex documentation and CLI source show that a separately started App Server is **not auto-discovered by plain `codex`**; the TUI must select it with `codex --remote <endpoint>`. The remaining PoC must prove that an explicitly connected TUI and Spotter can observe and steer the same real turn, then select an acceptable launch UX. See [App Server connection validation](app-server-validation.md).
+The shared App Server gate is resolved: an explicitly connected TUI and Spotter can observe and steer the same real turn. The immediate work is now wiring the implemented process foundations into a managed lifecycle: `spotterd` exists, but App Server event routing, Hook IPC, setup registration, and reconnect behavior remain separate issues. See [App Server connection validation](app-server-validation.md).
 The roadmap no longer uses `P0–P9` / `E0–E5`. It is organized by named outcomes:
 
 ```text
@@ -39,8 +39,9 @@ Runtime → Observe → Detect → Intervene → Recover → Harden
 
 The shared-server gate in [#78](https://github.com/spotter-agent/spotter/issues/78) passed for the
 Spotter-managed external App Server path. Spotter now has a production WebSocket client and a
-provisional Thread/Turn/Runtime Attachment registry with no production event consumer yet; the
-standalone daemon remains next.
+provisional Thread/Turn/Runtime Attachment registry with no production event consumer yet. It also
+has a standalone daemon process and versioned local control handshake; managed startup and runtime
+consumers remain next.
 
 ---
 
@@ -52,10 +53,12 @@ standalone daemon remains next.
 same-turn steering through a Spotter-managed external App Server. [#80](https://github.com/spotter-agent/spotter/issues/80)
 turns that PoC into an async client with initialize/disconnect, raw event delivery, thread queries,
 typed steer/interrupt methods, and explicit supported/unknown/unavailable capability state.
+[#79](https://github.com/spotter-agent/spotter/issues/79) adds the `spotterd` process, versioned
+local control handshake, explicit health states, manual lifecycle commands, and a testable
+`ServiceManager` boundary. It deliberately does not own or stop a shared Codex App Server.
 
 The remaining implementation boundaries are split into native GitHub issues:
 
-- [#79](https://github.com/spotter-agent/spotter/issues/79) — `spotterd`, local control RPC, and per-user service lifecycle;
 - [#82](https://github.com/spotter-agent/spotter/issues/82) — bounded fail-open `PreToolUse` ↔ daemon enforcement IPC;
 - [#83](https://github.com/spotter-agent/spotter/issues/83) — transactional Codex setup/teardown and integration ownership;
 - [#84](https://github.com/spotter-agent/spotter/issues/84) — runtime-aware status/doctor;
@@ -94,7 +97,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Audit ledger | 🟡 | Claim/evidence state and stale propagation where outcomes are observable | Move independent state into `spotterd` (#31) |
 | Evaluation labels / metrics | ✅ | Coverage-aware labeling and precision/FP metrics | Broader cost/miss/harm metrics (#33, #38, #34) |
 | Counterfactual harness | ✅ | Control/guidance same-prefix pairs can be prepared/run | Add mechanically scored tasks (#21) |
-| Standalone runtime | ❌ | No long-lived owner, service boundary, or runtime RPC | Build `spotterd` in #79 |
+| Standalone runtime | 🟡 | Long-lived process, versioned local handshake, health states, manual lifecycle, service abstraction | Register managed startup in #83; add Hook IPC in #82 and runtime consumers in #31/#85 |
 | Runtime identity | 🟡 | Provisional lifecycle registry and explicit legacy unknowns; no production consumer | Validate and refine it while routing normalized App Server events in #85 |
 | App Server primary observation | 🟡 | Async client, raw events, thread queries, controls, capability degradation | Normalize, identity-route, and journal events in #85 |
 | Managed Codex lifecycle | ❌ | Current path is source/plugin installation | transactional setup/teardown in #83; diagnostics in #84 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dev = [
 
 [project.scripts]
 spotter = "spotter.cli:main"
+spotterd = "spotter.daemon:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/spotter"]

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -1,6 +1,7 @@
 """Command-line entry point: passive observation and the Codex hook bridge."""
 
 import argparse
+import asyncio
 import json
 import subprocess
 import sys
@@ -25,6 +26,7 @@ from spotter.budget import (
 from spotter.codex import CodexAdapter
 from spotter.config import ConfigurationError, MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.core import SpotterRuntime
+from spotter.daemon import DaemonStatus, ManualServiceManager, RuntimeHealth, ServiceManager
 from spotter.doctor import FAIL, OK, WARN, worst
 from spotter.doctor import run as run_doctor
 from spotter.experiment import list_forks, results_path, run_experiment, summarize
@@ -65,6 +67,7 @@ def build_parser() -> argparse.ArgumentParser:
             "metrics",
             "status",
             "doctor",
+            "daemon",
         ],
         default="observe",
         help=(
@@ -76,8 +79,15 @@ def build_parser() -> argparse.ArgumentParser:
             "label: record a human verdict on a gate flag, reviewer decision, or session; "
             "metrics: gate FP rate, reviewer precision and observability ceiling from labels; "
             "status: what Spotter is storing, and whether it is actually running; "
-            "doctor: verify supervision end to end (non-zero exit when broken)"
+            "doctor: verify supervision end to end (non-zero exit when broken); "
+            "daemon: manually start, stop, restart, or inspect spotterd"
         ),
+    )
+    parser.add_argument(
+        "daemon_action",
+        nargs="?",
+        choices=["start", "stop", "restart", "status"],
+        help="daemon lifecycle action",
     )
     parser.add_argument("--config", type=Path, help="path to Spotter TOML config")
     parser.add_argument("--session", help="session id (fork; analyze filters to it)")
@@ -155,6 +165,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         # merely disable supervision, it would block every tool call in the
         # session. Unsupervised beats blocked.
         return _hook_main(None, args.config)
+
+    if args.command == "daemon":
+        if args.daemon_action is None:
+            parser.error("daemon requires start, stop, restart, or status")
+        return _daemon_main(args.daemon_action)
+    if args.daemon_action is not None:
+        parser.error("daemon lifecycle actions require the daemon command")
 
     config = _load_config(parser, args.config)
     # One boundary check for every command that names a session: sanitizing
@@ -522,6 +539,33 @@ def _doctor_main(config_path: Path | None) -> int:
         return 1
     print("\nsupervision is working")
     return 0
+
+
+def _daemon_main(action: str, manager: ServiceManager | None = None) -> int:
+    service = manager or ManualServiceManager()
+
+    async def run() -> DaemonStatus:
+        operations = {
+            "start": service.start,
+            "stop": service.stop,
+            "restart": service.restart,
+            "status": service.status,
+        }
+        return await operations[action]()
+
+    status = asyncio.run(run())
+    details = []
+    if status.pid is not None:
+        details.append(f"pid={status.pid}")
+    if status.protocol is not None:
+        details.append(f"protocol={status.protocol}")
+    if status.detail:
+        details.append(status.detail)
+    suffix = f" ({', '.join(details)})" if details else ""
+    print(f"spotterd: {status.health.value}{suffix}")
+    if action == "stop":
+        return 0 if status.health == RuntimeHealth.UNAVAILABLE else 1
+    return 0 if status.health == RuntimeHealth.HEALTHY else 1
 
 
 def _status_main() -> int:

--- a/src/spotter/daemon.py
+++ b/src/spotter/daemon.py
@@ -1,0 +1,353 @@
+"""Long-lived Spotter runtime and its versioned local control boundary."""
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import sys
+from contextlib import suppress
+from dataclasses import dataclass
+from enum import StrEnum
+from fcntl import LOCK_EX, LOCK_NB, LOCK_UN, flock
+from io import TextIOWrapper
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+from spotter.paths import secure_dir, spotter_home
+
+PROTOCOL_VERSION = 1
+CONTROL_TIMEOUT = 1.0
+START_TIMEOUT = 5.0
+STOP_TIMEOUT = 5.0
+_MAX_REQUEST_BYTES = 64 * 1024
+_SAFE_UNIX_PATH_BYTES = 100
+
+
+class RuntimeHealth(StrEnum):
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    RECOVERING = "recovering"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class DaemonStatus:
+    health: RuntimeHealth
+    pid: int | None = None
+    protocol: int | None = None
+    detail: str | None = None
+
+    @property
+    def available(self) -> bool:
+        return self.health != RuntimeHealth.UNAVAILABLE
+
+
+class DaemonError(RuntimeError):
+    """Base error for local runtime control failures."""
+
+
+class DaemonProtocolError(DaemonError):
+    """The daemon returned an invalid or incompatible response."""
+
+
+class DaemonUnavailable(DaemonError):
+    """The daemon control socket could not serve a request."""
+
+
+class DaemonAlreadyRunning(DaemonError):
+    """Another daemon already owns the runtime socket."""
+
+
+def runtime_socket() -> Path:
+    home = spotter_home()
+    candidate = home / "runtime" / "spotterd.sock"
+    if len(os.fsencode(candidate)) <= _SAFE_UNIX_PATH_BYTES:
+        return candidate
+    digest = hashlib.sha256(os.fsencode(home)).hexdigest()[:12]
+    return Path("/tmp") / f"spotter-{os.getuid()}-{digest}" / "spotterd.sock"
+
+
+class DaemonClient:
+    """One-request-per-connection client for the local control protocol."""
+
+    def __init__(
+        self, socket_path: Path | None = None, *, timeout: float = CONTROL_TIMEOUT
+    ) -> None:
+        self.socket_path = socket_path or runtime_socket()
+        self.timeout = timeout
+
+    async def request(self, method: str) -> dict[str, Any]:
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_unix_connection(self.socket_path, limit=_MAX_REQUEST_BYTES),
+                self.timeout,
+            )
+        except (OSError, TimeoutError) as error:
+            raise DaemonUnavailable(str(error)) from error
+
+        try:
+            request = json.dumps(
+                {"protocol": PROTOCOL_VERSION, "method": method}, separators=(",", ":")
+            )
+            writer.write(request.encode() + b"\n")
+            await asyncio.wait_for(writer.drain(), self.timeout)
+            raw = await asyncio.wait_for(reader.readline(), self.timeout)
+            if not raw:
+                raise DaemonProtocolError("daemon closed the control connection")
+            response = json.loads(raw)
+            if not isinstance(response, dict):
+                raise DaemonProtocolError("daemon response must be an object")
+            response = cast(dict[str, Any], response)
+            if response.get("protocol") != PROTOCOL_VERSION:
+                raise DaemonProtocolError("incompatible daemon protocol")
+            if response.get("ok") is not True:
+                raise DaemonProtocolError(str(response.get("error") or "daemon request failed"))
+            return response
+        except (OSError, TimeoutError) as error:
+            raise DaemonUnavailable(str(error)) from error
+        except (json.JSONDecodeError, UnicodeDecodeError) as error:
+            raise DaemonProtocolError("daemon returned invalid JSON") from error
+        finally:
+            writer.close()
+            with suppress(OSError, TimeoutError):
+                await asyncio.wait_for(writer.wait_closed(), self.timeout)
+
+    async def status(self) -> DaemonStatus:
+        try:
+            response = await self.request("ping")
+            health = RuntimeHealth(response["health"])
+            pid = response.get("pid")
+            if not isinstance(pid, int) or isinstance(pid, bool):
+                raise DaemonProtocolError("daemon returned an invalid pid")
+            return DaemonStatus(
+                health=health,
+                pid=pid,
+                protocol=PROTOCOL_VERSION,
+            )
+        except DaemonUnavailable as error:
+            return DaemonStatus(RuntimeHealth.UNAVAILABLE, detail=str(error))
+        except (DaemonProtocolError, KeyError, ValueError) as error:
+            return DaemonStatus(RuntimeHealth.DEGRADED, detail=str(error))
+
+    async def shutdown(self) -> None:
+        await self.request("shutdown")
+
+
+class DaemonServer:
+    """Own the local runtime socket without owning any agent App Server."""
+
+    def __init__(self, socket_path: Path | None = None) -> None:
+        self.socket_path = socket_path or runtime_socket()
+        self.health = RuntimeHealth.HEALTHY
+        self._server: asyncio.AbstractServer | None = None
+        self._shutdown = asyncio.Event()
+        self._socket_inode: int | None = None
+        self._lock: TextIOWrapper | None = None
+
+    async def start(self) -> None:
+        _secure_runtime_dir(self.socket_path.parent)
+        lock = self.socket_path.with_suffix(".lock").open("a+")
+        try:
+            flock(lock, LOCK_EX | LOCK_NB)
+        except OSError as error:
+            lock.close()
+            raise DaemonAlreadyRunning(f"spotterd already owns {self.socket_path}") from error
+        self._lock = lock
+        try:
+            if self.socket_path.exists():
+                status = await DaemonClient(self.socket_path).status()
+                if status.available:
+                    raise DaemonAlreadyRunning(f"spotterd already owns {self.socket_path}")
+                self.socket_path.unlink(missing_ok=True)
+            self._server = await asyncio.start_unix_server(
+                self._handle,
+                path=self.socket_path,
+                limit=_MAX_REQUEST_BYTES,
+            )
+        except OSError as error:
+            self._release_lock()
+            raise DaemonAlreadyRunning(f"could not own {self.socket_path}: {error}") from error
+        except Exception:
+            self._release_lock()
+            raise
+        self.socket_path.chmod(0o600)
+        self._socket_inode = self.socket_path.stat().st_ino
+
+    async def serve(self) -> None:
+        await self.start()
+        try:
+            await self._shutdown.wait()
+        finally:
+            await self.close()
+
+    async def wait_for_shutdown(self) -> None:
+        await self._shutdown.wait()
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+        with suppress(OSError):
+            if (
+                self._socket_inode is not None
+                and self.socket_path.stat().st_ino == self._socket_inode
+            ):
+                self.socket_path.unlink()
+        self._socket_inode = None
+        self._release_lock()
+
+    def set_health(self, health: RuntimeHealth) -> None:
+        if health == RuntimeHealth.UNAVAILABLE:
+            raise ValueError("a running daemon cannot report itself unavailable")
+        self.health = health
+
+    def _release_lock(self) -> None:
+        if self._lock is None:
+            return
+        flock(self._lock, LOCK_UN)
+        self._lock.close()
+        self._lock = None
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        shutdown = False
+        try:
+            raw = await asyncio.wait_for(reader.readline(), CONTROL_TIMEOUT)
+            request = json.loads(raw)
+            if not isinstance(request, dict):
+                raise DaemonProtocolError("request must be an object")
+            if request.get("protocol") != PROTOCOL_VERSION:
+                raise DaemonProtocolError("incompatible control protocol")
+            method = request.get("method")
+            if method not in {"ping", "shutdown"}:
+                raise DaemonProtocolError(f"unknown control method: {method}")
+            shutdown = method == "shutdown"
+            response: dict[str, Any] = {
+                "protocol": PROTOCOL_VERSION,
+                "ok": True,
+                "health": self.health.value,
+                "pid": os.getpid(),
+            }
+        except (DaemonProtocolError, json.JSONDecodeError, TimeoutError, ValueError) as error:
+            response = {
+                "protocol": PROTOCOL_VERSION,
+                "ok": False,
+                "error": str(error),
+            }
+        try:
+            writer.write(json.dumps(response, separators=(",", ":")).encode() + b"\n")
+            await writer.drain()
+        except (ConnectionError, OSError):
+            pass
+        finally:
+            writer.close()
+            with suppress(ConnectionError, OSError):
+                await writer.wait_closed()
+        if shutdown:
+            self._shutdown.set()
+
+
+class ServiceManager(Protocol):
+    """Platform-neutral lifecycle boundary for manual or managed services."""
+
+    async def start(self) -> DaemonStatus: ...
+
+    async def stop(self) -> DaemonStatus: ...
+
+    async def restart(self) -> DaemonStatus: ...
+
+    async def status(self) -> DaemonStatus: ...
+
+
+class ManualServiceManager:
+    """Portable process lifecycle used by explicit CLI escape hatches."""
+
+    def __init__(self, socket_path: Path | None = None) -> None:
+        self.socket_path = socket_path or runtime_socket()
+        self.client = DaemonClient(self.socket_path)
+
+    async def status(self) -> DaemonStatus:
+        return await self.client.status()
+
+    async def start(self) -> DaemonStatus:
+        current = await self.status()
+        if current.available:
+            return current
+
+        home = secure_dir(spotter_home())
+        logs = secure_dir(home / "logs")
+        log_path = logs / "spotterd.log"
+        with log_path.open("ab") as log:
+            process = subprocess.Popen(
+                [sys.executable, "-m", "spotter.daemon"],
+                cwd=home,
+                stdin=subprocess.DEVNULL,
+                stdout=log,
+                stderr=log,
+                start_new_session=True,
+            )
+        deadline = asyncio.get_running_loop().time() + START_TIMEOUT
+        while asyncio.get_running_loop().time() < deadline:
+            status = await self.status()
+            if status.available:
+                return status
+            if process.poll() is not None:
+                return DaemonStatus(
+                    RuntimeHealth.UNAVAILABLE,
+                    detail=f"spotterd exited during startup; see {log_path}",
+                )
+            await asyncio.sleep(0.05)
+        process.terminate()
+        return DaemonStatus(
+            RuntimeHealth.UNAVAILABLE,
+            detail=f"spotterd did not become ready; see {log_path}",
+        )
+
+    async def stop(self) -> DaemonStatus:
+        current = await self.status()
+        if not current.available:
+            return DaemonStatus(RuntimeHealth.UNAVAILABLE, detail="already stopped")
+        try:
+            await self.client.shutdown()
+        except DaemonError as error:
+            return DaemonStatus(RuntimeHealth.DEGRADED, detail=str(error))
+        deadline = asyncio.get_running_loop().time() + STOP_TIMEOUT
+        while asyncio.get_running_loop().time() < deadline:
+            if not (await self.status()).available:
+                return DaemonStatus(RuntimeHealth.UNAVAILABLE, detail="stopped")
+            await asyncio.sleep(0.05)
+        return DaemonStatus(RuntimeHealth.DEGRADED, detail="spotterd did not stop")
+
+    async def restart(self) -> DaemonStatus:
+        stopped = await self.stop()
+        if stopped.available:
+            return stopped
+        return await self.start()
+
+
+def _secure_runtime_dir(path: Path) -> None:
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    metadata = path.lstat()
+    if not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != os.getuid():
+        raise PermissionError(f"unsafe runtime directory: {path}")
+    path.chmod(0o700)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the Spotter supervision daemon")
+    parser.parse_args(argv)
+    try:
+        asyncio.run(DaemonServer().serve())
+    except DaemonAlreadyRunning as error:
+        print(error, file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/spotter/daemon.py
+++ b/src/spotter/daemon.py
@@ -231,7 +231,13 @@ class DaemonServer:
                 "health": self.health.value,
                 "pid": os.getpid(),
             }
-        except (DaemonProtocolError, json.JSONDecodeError, TimeoutError, ValueError) as error:
+        except (
+            DaemonProtocolError,
+            json.JSONDecodeError,
+            OSError,
+            TimeoutError,
+            ValueError,
+        ) as error:
             response = {
                 "protocol": PROTOCOL_VERSION,
                 "ok": False,

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,113 @@
+import asyncio
+import json
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from spotter.cli import main
+from spotter.daemon import (
+    PROTOCOL_VERSION,
+    DaemonAlreadyRunning,
+    DaemonClient,
+    DaemonServer,
+    RuntimeHealth,
+    runtime_socket,
+)
+
+
+@pytest.fixture()
+def socket_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path / "home"))
+    path = runtime_socket()
+    yield path
+    shutil.rmtree(path.parent, ignore_errors=True)
+
+
+def test_control_socket_handles_concurrent_clients_and_health_states(socket_path: Path) -> None:
+    async def scenario() -> None:
+        server = DaemonServer(socket_path)
+        await server.start()
+        try:
+            statuses = await asyncio.gather(
+                *(DaemonClient(socket_path).status() for _ in range(20))
+            )
+            assert {status.health for status in statuses} == {RuntimeHealth.HEALTHY}
+            assert len({status.pid for status in statuses}) == 1
+            assert socket_path.stat().st_mode & 0o777 == 0o600
+
+            server.set_health(RuntimeHealth.DEGRADED)
+            assert (await DaemonClient(socket_path).status()).health == RuntimeHealth.DEGRADED
+            server.set_health(RuntimeHealth.RECOVERING)
+            assert (await DaemonClient(socket_path).status()).health == RuntimeHealth.RECOVERING
+
+            await DaemonClient(socket_path).shutdown()
+            await asyncio.wait_for(server.wait_for_shutdown(), 1)
+        finally:
+            await server.close()
+        assert not socket_path.exists()
+
+    asyncio.run(scenario())
+
+
+def test_bad_protocol_does_not_break_later_clients(socket_path: Path) -> None:
+    async def scenario() -> None:
+        server = DaemonServer(socket_path)
+        await server.start()
+        try:
+            reader, writer = await asyncio.open_unix_connection(socket_path)
+            writer.write(b'{"protocol":999,"method":"ping"}\n')
+            await writer.drain()
+            response = json.loads(await reader.readline())
+            writer.close()
+            await writer.wait_closed()
+
+            assert response == {
+                "protocol": PROTOCOL_VERSION,
+                "ok": False,
+                "error": "incompatible control protocol",
+            }
+            assert (await DaemonClient(socket_path).status()).health == RuntimeHealth.HEALTHY
+        finally:
+            await server.close()
+
+    asyncio.run(scenario())
+
+
+def test_second_daemon_cannot_take_the_live_socket(socket_path: Path) -> None:
+    async def scenario() -> None:
+        first = DaemonServer(socket_path)
+        second = DaemonServer(socket_path)
+        await first.start()
+        try:
+            with pytest.raises(DaemonAlreadyRunning):
+                await second.start()
+            assert (await DaemonClient(socket_path).status()).health == RuntimeHealth.HEALTHY
+        finally:
+            await second.close()
+            await first.close()
+
+    asyncio.run(scenario())
+
+
+def test_missing_daemon_is_explicitly_unavailable(socket_path: Path) -> None:
+    status = asyncio.run(DaemonClient(socket_path).status())
+
+    assert status.health == RuntimeHealth.UNAVAILABLE
+    assert status.pid is None
+    assert status.detail
+
+
+def test_manual_cli_lifecycle(socket_path: Path) -> None:
+    try:
+        assert main(["daemon", "status"]) == 1
+        assert main(["daemon", "start"]) == 0
+        assert main(["daemon", "start"]) == 0
+        assert runtime_socket().exists()
+        assert main(["daemon", "status"]) == 0
+        assert main(["daemon", "restart"]) == 0
+        assert main(["daemon", "stop"]) == 0
+        assert main(["daemon", "status"]) == 1
+    finally:
+        main(["daemon", "stop"])


### PR DESCRIPTION
## Why

Spotter needs a long-lived per-user runtime and real local liveness/control boundary before Hook IPC, managed setup, live state, or App Server event routing can move behind the daemon.

Closes #79

## What changed

- add the `spotterd` process with a bounded versioned JSON protocol over a private UNIX socket
- expose explicit `healthy`, `degraded`, `recovering`, and `unavailable` states
- add `spotter daemon start|stop|restart|status` through a platform-neutral `ServiceManager`
- serialize daemon ownership, handle long UNIX socket paths, and accept concurrent local clients
- keep shared Codex App Server ownership outside daemon shutdown
- update runtime/current-state documentation without claiming managed setup or event consumers

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (278 passed)

## Notes

Managed service registration remains #83, bounded Hook IPC remains #82, live supervision state remains #31, and App Server event routing remains #85.