### PR TITLE
feat(runtime): route gates through daemon IPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Capability | Status | Notes |
 | --- | --- | --- |
 | Hook trajectory ingestion | ✅ | Current primary observation path |
-| Deterministic pre-action gates | ✅ | Bounded local daemon IPC; strict timeout and fail-open telemetry |
+| Deterministic pre-action gates | ✅ | Bounded daemon IPC; local fallback preserves enforcement if the daemon is unavailable |
 | Crash-tolerant journal | ✅ | Locking, fsync, torn-tail recovery |
 | Git snapshot / detached restore | ✅ | User HEAD/index remain untouched |
 | Fork / continuation replay | ✅ | Same-prefix continuation machinery |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Spotter asks a more specific question than “is the agent wrong?”
 
 > **Can we detect a bad assumption, loop, scope drift, or missing validation while the agent is still working, and intervene before the mistake becomes expensive?**
 
-The repository is already beyond a scaffold. The current prototype implements Hook-based trajectory collection, deterministic gates, crash-safe journals, Git snapshots, fork/replay, a shadow reviewer, claim/evidence state, evaluation labels/metrics, counterfactual experiment machinery, and a standalone daemon/control foundation.
+The repository is already beyond a scaffold. The current prototype implements Hook-based trajectory collection, daemon-backed deterministic gates, crash-safe journals, Git snapshots, fork/replay, a shadow reviewer, claim/evidence state, evaluation labels/metrics, counterfactual experiment machinery, and a standalone daemon/control foundation.
 
 The current prototype and target product architecture are different:
 
@@ -69,7 +69,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Capability | Status | Notes |
 | --- | --- | --- |
 | Hook trajectory ingestion | ✅ | Current primary observation path |
-| Deterministic pre-action gates | ✅ | Rule-based; safe/shadow-first posture |
+| Deterministic pre-action gates | ✅ | Bounded local daemon IPC; strict timeout and fail-open telemetry |
 | Crash-tolerant journal | ✅ | Locking, fsync, torn-tail recovery |
 | Git snapshot / detached restore | ✅ | User HEAD/index remain untouched |
 | Fork / continuation replay | ✅ | Same-prefix continuation machinery |
@@ -77,7 +77,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Claim/evidence audit ledger | 🟡 | Works where observable outcomes exist |
 | Evaluation labels / metrics | ✅ | Coverage-aware evaluation and precision/FP metrics |
 | Counterfactual experiment harness | ✅ | Control/guidance same-prefix pairs |
-| Standalone `spotterd` runtime | 🟡 | Process, local control handshake, and manual lifecycle implemented; managed startup/runtime consumers remain |
+| Standalone `spotterd` runtime | 🟡 | Process, versioned gate/control IPC, and manual lifecycle implemented; managed startup/runtime consumers remain |
 | App Server primary observation | 🟡 | Client/capabilities implemented; Trace IR ingestion remains (#85) |
 | Event-driven signal engine | ❌ | Current reviewer trigger is periodic |
 | Live `VERIFY / NUDGE` | ❌ | Target: `turn/steer` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
 > **Status:** this document describes both the current hook-based prototype and the target architecture. Active implementation is tracked by the [Roadmap](roadmap.md) and native GitHub Milestones.
-> The `spotterd` process/control foundation, shared-server PoC, and production App Server transport are implemented. App Server primary Trace IR observation and live supervision delivery remain **target behavior**.
+> The `spotterd` process/control foundation, bounded Hook gate IPC, shared-server PoC, and production App Server transport are implemented. App Server primary Trace IR observation and live supervision delivery remain **target behavior**.
 
 ---
 
@@ -329,6 +329,13 @@ Hook response
 ```
 
 No network/model call belongs on this path.
+
+The implemented bridge sends only normalized command/file proposal data, deterministic gate config,
+and the workspace root over the versioned local socket. It has a 200 ms total request deadline. A
+missing daemon, timeout, malformed response, protocol mismatch, or unsupported proposal shape allows
+the action and records `gate_fail_open` plus `gate_ipc` timing/status telemetry. Daemon evaluation time,
+IPC time, and total Hook time are recorded separately so latency percentiles can be computed without
+putting aggregation on the synchronous path.
 
 ## 4.5 Turn completion
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -219,7 +219,7 @@ These boundaries are intended to be concrete enough to drive implementation.
 | `SignalEngine` | cheap candidate detection | event + live state | candidate signal | bounded rolling counters/state | no candidate |
 | `ReviewerScheduler` | async model execution, budget, dedupe | candidate + context | `ReviewerJob` | queues, budgets | job fails; Main continues |
 | `InterventionController` | freshness, delivery, escalation | reviewer decision + live turn state | steer/interrupt/no-op | intervention history | stale/discard/degraded |
-| `GateEngine` | deterministic pre-action policy | `PreToolUse` proposal + config | allow/deny | rule config + bounded state | fail-open |
+| `GateEngine` | deterministic pre-action policy | `PreToolUse` proposal + config | allow/deny | rule config + bounded state | local fallback / fail-open |
 | `JournalStore` | durable event history | normalized records | append/read | disk | write telemetry; never invent success |
 | `SnapshotManager` | Git checkpoints and detached restore | repo/worktree state | snapshot ref/worktree | Git resources | snapshot failure does not break Main |
 | `IntegrationManager` | setup/teardown/migration | agent config + runtime environment | integration mutations + manifest | integration manifest | transactional rollback |
@@ -332,10 +332,11 @@ No network/model call belongs on this path.
 
 The implemented bridge sends only normalized command/file proposal data, deterministic gate config,
 and the workspace root over the versioned local socket. It has a 200 ms total request deadline. A
-missing daemon, timeout, malformed response, protocol mismatch, or unsupported proposal shape allows
-the action and records `gate_fail_open` plus `gate_ipc` timing/status telemetry. Daemon evaluation time,
-IPC time, and total Hook time are recorded separately so latency percentiles can be computed without
-putting aggregation on the synchronous path.
+missing daemon or timeout falls back to the same local deterministic Gate while recording `gate_ipc`
+failure telemetry, so the manual-start lifecycle does not disable existing enforcement. Malformed or
+version-mismatched responses and unsupported proposal shapes fail open. Daemon evaluation time, IPC
+time, and total Hook time are recorded separately so latency percentiles can be computed without putting
+aggregation on the synchronous path.
 
 ## 4.5 Turn completion
 
@@ -401,11 +402,10 @@ Those belong in the asynchronous reviewer path.
 
 ### Failure policy
 
-If any of the following occurs:
+If daemon IPC is unavailable or times out, the Hook evaluates the same deterministic Gate locally
+and records the degraded IPC status. If the proposal itself cannot be judged safely, including:
 
 ```text
-spotterd unavailable
-IPC timeout
 unsupported syntax
 unknown workspace
 ```

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -897,7 +897,8 @@ hydrate durable state where needed
 READY
 ```
 
-During daemon downtime, the Hook gate remains fail-open unless a future opt-in fail-closed mode is designed separately.
+During daemon downtime, the Hook preserves existing deterministic enforcement with its local Gate
+while reporting degraded IPC telemetry. Ambiguous or unsupported proposals still fail open.
 
 ## 10.2 App Server disconnect/crash
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -177,7 +177,7 @@ Runtime is credible when:
 - normal use does not require manually starting Spotter before every Codex session;
 - one long-lived runtime owns isolated state for multiple threads;
 - the real active Codex turn can be observed and addressed safely;
-- deterministic enforcement crosses a bounded fail-open IPC path;
+- deterministic enforcement crosses bounded IPC with a local compatibility fallback;
 - setup/teardown ownership is explicit and repeatable;
 - a dead or disconnected subsystem is reported as degraded instead of healthy;
 - reconnect/restart can recover identity and durable state without inventing missing observations.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -162,7 +162,7 @@ The Runtime milestone is now decomposed into concrete boundaries rather than one
 | [#79](https://github.com/spotter-agent/spotter/issues/79) | `spotterd`, versioned local control, manual lifecycle, and platform-neutral service boundary (implemented) |
 | [#80](https://github.com/spotter-agent/spotter/issues/80) | production App Server client and capability negotiation |
 | [#81](https://github.com/spotter-agent/spotter/issues/81) | Thread / Turn / Runtime Attachment identity lifecycle (provisional foundation; integration in #85) |
-| [#82](https://github.com/spotter-agent/spotter/issues/82) | bounded Hook ↔ daemon IPC for deterministic `PreToolUse` enforcement |
+| [#82](https://github.com/spotter-agent/spotter/issues/82) | bounded Hook ↔ daemon IPC for deterministic `PreToolUse` enforcement (implemented) |
 | [#31](https://github.com/spotter-agent/spotter/issues/31) | independent live supervision state owned by `spotterd` |
 | [#83](https://github.com/spotter-agent/spotter/issues/83) | transactional `setup|teardown codex`, Integration Manifest, legacy migration |
 | [#84](https://github.com/spotter-agent/spotter/issues/84) | runtime-aware `status` / `doctor` and degraded capability reporting |

--- a/docs/status.md
+++ b/docs/status.md
@@ -7,7 +7,7 @@
 
 ## 30-second summary
 
-Spotter is currently a **Hook-based research prototype** with a standalone runtime foundation. It already has real trajectory journals, deterministic gates, Git snapshots, fork/replay, a shadow reviewer, an audit ledger, labeling/metrics, a counterfactual experiment harness, and a manually managed `spotterd` process with local control IPC.
+Spotter is currently a **Hook-based research prototype** with a standalone runtime foundation. It already has real trajectory journals, daemon-backed deterministic gates, Git snapshots, fork/replay, a shadow reviewer, an audit ledger, labeling/metrics, a counterfactual experiment harness, and a manually managed `spotterd` process with versioned local IPC.
 
 The target product is a standalone runtime:
 
@@ -30,7 +30,7 @@ PreToolUse Hook only
 (deterministic synchronous enforcement)
 ```
 
-The shared App Server gate is resolved: an explicitly connected TUI and Spotter can observe and steer the same real turn. The immediate work is now wiring the implemented process foundations into a managed lifecycle: `spotterd` exists, but App Server event routing, Hook IPC, setup registration, and reconnect behavior remain separate issues. See [App Server connection validation](app-server-validation.md).
+The shared App Server gate is resolved: an explicitly connected TUI and Spotter can observe and steer the same real turn. The Hook now uses bounded daemon IPC for deterministic enforcement. The immediate work is wiring the remaining process foundations into a managed lifecycle: App Server event routing, setup registration, and reconnect behavior remain separate issues. See [App Server connection validation](app-server-validation.md).
 The roadmap no longer uses `P0–P9` / `E0–E5`. It is organized by named outcomes:
 
 ```text
@@ -40,8 +40,8 @@ Runtime → Observe → Detect → Intervene → Recover → Harden
 The shared-server gate in [#78](https://github.com/spotter-agent/spotter/issues/78) passed for the
 Spotter-managed external App Server path. Spotter now has a production WebSocket client and a
 provisional Thread/Turn/Runtime Attachment registry with no production event consumer yet. It also
-has a standalone daemon process and versioned local control handshake; managed startup and runtime
-consumers remain next.
+has a standalone daemon process and versioned local control/gate handshake; managed startup and
+runtime consumers remain next.
 
 ---
 
@@ -56,10 +56,11 @@ typed steer/interrupt methods, and explicit supported/unknown/unavailable capabi
 [#79](https://github.com/spotter-agent/spotter/issues/79) adds the `spotterd` process, versioned
 local control handshake, explicit health states, manual lifecycle commands, and a testable
 `ServiceManager` boundary. It deliberately does not own or stop a shared Codex App Server.
+[#82](https://github.com/spotter-agent/spotter/issues/82) adds bounded deterministic gate requests,
+strict timeout and fail-open handling, and separate Hook/IPC timing telemetry.
 
 The remaining implementation boundaries are split into native GitHub issues:
 
-- [#82](https://github.com/spotter-agent/spotter/issues/82) — bounded fail-open `PreToolUse` ↔ daemon enforcement IPC;
 - [#83](https://github.com/spotter-agent/spotter/issues/83) — transactional Codex setup/teardown and integration ownership;
 - [#84](https://github.com/spotter-agent/spotter/issues/84) — runtime-aware status/doctor;
 - [#87](https://github.com/spotter-agent/spotter/issues/87) — daemon/App Server reconnect and identity reconciliation.
@@ -89,7 +90,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Area | Status | What exists now | Next concrete step |
 | --- | --- | --- | --- |
 | Hook ingestion | ✅ | `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse` are journaled | App Server ingestion #85, then remove redundant Hooks in #86 |
-| Deterministic gate | ✅ | Shell-aware checks for destructive commands, path/dependency constraints, fail-open ambiguity handling | Move bounded enforcement behind daemon IPC in #82 |
+| Deterministic gate | ✅ | Shell-aware daemon evaluation over bounded local IPC; timeout/unavailable/protocol failures fail open with telemetry | Continue policy precision/miss-rate measurement |
 | Journal | ✅ | Crash-tolerant JSONL, locking, fsync, torn-tail recovery | Feed it from identity-rich App Server Trace IR in #85 |
 | Snapshot | ✅ | Git-backed snapshots, deduplication, pruning, detached restore | Preserve lineage through runtime/retention migration (#89) |
 | Fork / replay | ✅ | Continue Codex from a shared prefix in a detached worktree | Measure fidelity/noise floor in #42 |
@@ -97,7 +98,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Audit ledger | 🟡 | Claim/evidence state and stale propagation where outcomes are observable | Move independent state into `spotterd` (#31) |
 | Evaluation labels / metrics | ✅ | Coverage-aware labeling and precision/FP metrics | Broader cost/miss/harm metrics (#33, #38, #34) |
 | Counterfactual harness | ✅ | Control/guidance same-prefix pairs can be prepared/run | Add mechanically scored tasks (#21) |
-| Standalone runtime | 🟡 | Long-lived process, versioned local handshake, health states, manual lifecycle, service abstraction | Register managed startup in #83; add Hook IPC in #82 and runtime consumers in #31/#85 |
+| Standalone runtime | 🟡 | Long-lived process, versioned control/gate IPC, health states, manual lifecycle, service abstraction | Register managed startup in #83; add runtime consumers in #31/#85 |
 | Runtime identity | 🟡 | Provisional lifecycle registry and explicit legacy unknowns; no production consumer | Validate and refine it while routing normalized App Server events in #85 |
 | App Server primary observation | 🟡 | Async client, raw events, thread queries, controls, capability degradation | Normalize, identity-route, and journal events in #85 |
 | Managed Codex lifecycle | ❌ | Current path is source/plugin installation | transactional setup/teardown in #83; diagnostics in #84 |

--- a/docs/status.md
+++ b/docs/status.md
@@ -57,7 +57,7 @@ typed steer/interrupt methods, and explicit supported/unknown/unavailable capabi
 local control handshake, explicit health states, manual lifecycle commands, and a testable
 `ServiceManager` boundary. It deliberately does not own or stop a shared Codex App Server.
 [#82](https://github.com/spotter-agent/spotter/issues/82) adds bounded deterministic gate requests,
-strict timeout and fail-open handling, and separate Hook/IPC timing telemetry.
+local enforcement fallback on unavailable/timeout, and separate Hook/IPC timing telemetry.
 
 The remaining implementation boundaries are split into native GitHub issues:
 
@@ -90,7 +90,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Area | Status | What exists now | Next concrete step |
 | --- | --- | --- | --- |
 | Hook ingestion | ✅ | `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse` are journaled | App Server ingestion #85, then remove redundant Hooks in #86 |
-| Deterministic gate | ✅ | Shell-aware daemon evaluation over bounded local IPC; timeout/unavailable/protocol failures fail open with telemetry | Continue policy precision/miss-rate measurement |
+| Deterministic gate | ✅ | Shell-aware daemon evaluation over bounded local IPC; unavailable/timeout uses the local Gate, while incompatible responses fail open | Continue policy precision/miss-rate measurement |
 | Journal | ✅ | Crash-tolerant JSONL, locking, fsync, torn-tail recovery | Feed it from identity-rich App Server Trace IR in #85 |
 | Snapshot | ✅ | Git-backed snapshots, deduplication, pruning, detached restore | Preserve lineage through runtime/retention migration (#89) |
 | Fork / replay | ✅ | Continue Codex from a shared prefix in a detached worktree | Measure fidelity/noise floor in #42 |

--- a/src/spotter/core.py
+++ b/src/spotter/core.py
@@ -22,8 +22,9 @@ class SpotterRuntime:
     adapter: AgentAdapter
     gate: Gate = field(default_factory=Gate)
 
-    def observe(self, event: TraceEvent) -> GateDecision:
-        decision = self.gate.check(event)
+    def observe(self, event: TraceEvent, decision: GateDecision | None = None) -> GateDecision:
+        if decision is None:
+            decision = self.gate.check(event)
         self.adapter.record(event)
         effect = effect_event(event)
         if effect is not None:

--- a/src/spotter/daemon.py
+++ b/src/spotter/daemon.py
@@ -8,6 +8,7 @@ import os
 import stat
 import subprocess
 import sys
+import time
 from contextlib import suppress
 from dataclasses import dataclass
 from enum import StrEnum
@@ -16,10 +17,14 @@ from io import TextIOWrapper
 from pathlib import Path
 from typing import Any, Protocol, cast
 
+from spotter.config import GatesConfig
+from spotter.gates import Gate, GateDecision
 from spotter.paths import secure_dir, spotter_home
+from spotter.trace import TraceEvent
 
 PROTOCOL_VERSION = 1
 CONTROL_TIMEOUT = 1.0
+GATE_TIMEOUT = 0.2
 START_TIMEOUT = 5.0
 STOP_TIMEOUT = 5.0
 _MAX_REQUEST_BYTES = 64 * 1024
@@ -57,6 +62,10 @@ class DaemonUnavailable(DaemonError):
     """The daemon control socket could not serve a request."""
 
 
+class DaemonTimeout(DaemonUnavailable):
+    """The daemon did not complete a request within its total deadline."""
+
+
 class DaemonAlreadyRunning(DaemonError):
     """Another daemon already owns the runtime socket."""
 
@@ -79,41 +88,40 @@ class DaemonClient:
         self.socket_path = socket_path or runtime_socket()
         self.timeout = timeout
 
-    async def request(self, method: str) -> dict[str, Any]:
+    async def request(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        writer: asyncio.StreamWriter | None = None
         try:
-            reader, writer = await asyncio.wait_for(
-                asyncio.open_unix_connection(self.socket_path, limit=_MAX_REQUEST_BYTES),
-                self.timeout,
-            )
-        except (OSError, TimeoutError) as error:
+            async with asyncio.timeout(self.timeout):
+                reader, writer = await asyncio.open_unix_connection(
+                    self.socket_path, limit=_MAX_REQUEST_BYTES
+                )
+                payload: dict[str, Any] = {"protocol": PROTOCOL_VERSION, "method": method}
+                if params is not None:
+                    payload["params"] = params
+                request = json.dumps(payload, separators=(",", ":"))
+                writer.write(request.encode() + b"\n")
+                await writer.drain()
+                raw = await reader.readline()
+                if not raw:
+                    raise DaemonProtocolError("daemon closed the control connection")
+                response = json.loads(raw)
+                if not isinstance(response, dict):
+                    raise DaemonProtocolError("daemon response must be an object")
+                response = cast(dict[str, Any], response)
+                if response.get("protocol") != PROTOCOL_VERSION:
+                    raise DaemonProtocolError("incompatible daemon protocol")
+                if response.get("ok") is not True:
+                    raise DaemonProtocolError(str(response.get("error") or "daemon request failed"))
+                return response
+        except TimeoutError as error:
+            raise DaemonTimeout(f"daemon request timed out after {self.timeout:.3f}s") from error
+        except OSError as error:
             raise DaemonUnavailable(str(error)) from error
-
-        try:
-            request = json.dumps(
-                {"protocol": PROTOCOL_VERSION, "method": method}, separators=(",", ":")
-            )
-            writer.write(request.encode() + b"\n")
-            await asyncio.wait_for(writer.drain(), self.timeout)
-            raw = await asyncio.wait_for(reader.readline(), self.timeout)
-            if not raw:
-                raise DaemonProtocolError("daemon closed the control connection")
-            response = json.loads(raw)
-            if not isinstance(response, dict):
-                raise DaemonProtocolError("daemon response must be an object")
-            response = cast(dict[str, Any], response)
-            if response.get("protocol") != PROTOCOL_VERSION:
-                raise DaemonProtocolError("incompatible daemon protocol")
-            if response.get("ok") is not True:
-                raise DaemonProtocolError(str(response.get("error") or "daemon request failed"))
-            return response
-        except (OSError, TimeoutError) as error:
-            raise DaemonUnavailable(str(error)) from error
-        except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        except (UnicodeDecodeError, ValueError) as error:
             raise DaemonProtocolError("daemon returned invalid JSON") from error
         finally:
-            writer.close()
-            with suppress(OSError, TimeoutError):
-                await asyncio.wait_for(writer.wait_closed(), self.timeout)
+            if writer is not None:
+                writer.close()
 
     async def status(self) -> DaemonStatus:
         try:
@@ -134,6 +142,38 @@ class DaemonClient:
 
     async def shutdown(self) -> None:
         await self.request("shutdown")
+
+    async def gate(
+        self, event: TraceEvent, gates: GatesConfig, root: str | None
+    ) -> tuple[GateDecision, float]:
+        response = await self.request(
+            "gate",
+            {
+                "proposal": {
+                    "command": event.payload.get("command"),
+                    "files": event.payload.get("files"),
+                },
+                "gates": {
+                    "forbidden_paths": list(gates.forbidden_paths),
+                    "block_dependency_changes": gates.block_dependency_changes,
+                },
+                "root": root,
+            },
+        )
+        raw = response.get("decision")
+        evaluation_ms = response.get("evaluation_ms")
+        if not isinstance(raw, dict) or not isinstance(evaluation_ms, int | float):
+            raise DaemonProtocolError("daemon returned an invalid gate result")
+        allowed, rule, reason = raw.get("allowed"), raw.get("rule"), raw.get("reason")
+        if not isinstance(allowed, bool):
+            raise DaemonProtocolError("daemon returned an invalid gate decision")
+        if rule is not None and not isinstance(rule, str):
+            raise DaemonProtocolError("daemon returned an invalid gate rule")
+        if reason is not None and not isinstance(reason, str):
+            raise DaemonProtocolError("daemon returned an invalid gate reason")
+        if isinstance(evaluation_ms, bool) or evaluation_ms < 0:
+            raise DaemonProtocolError("daemon returned invalid gate timing")
+        return GateDecision(allowed, rule, reason), float(evaluation_ms)
 
 
 class DaemonServer:
@@ -222,7 +262,7 @@ class DaemonServer:
             if request.get("protocol") != PROTOCOL_VERSION:
                 raise DaemonProtocolError("incompatible control protocol")
             method = request.get("method")
-            if method not in {"ping", "shutdown"}:
+            if method not in {"ping", "shutdown", "gate"}:
                 raise DaemonProtocolError(f"unknown control method: {method}")
             shutdown = method == "shutdown"
             response: dict[str, Any] = {
@@ -231,6 +271,8 @@ class DaemonServer:
                 "health": self.health.value,
                 "pid": os.getpid(),
             }
+            if method == "gate":
+                response.update(_evaluate_gate(request.get("params")))
         except (
             DaemonProtocolError,
             json.JSONDecodeError,
@@ -254,6 +296,48 @@ class DaemonServer:
                 await writer.wait_closed()
         if shutdown:
             self._shutdown.set()
+
+
+def _evaluate_gate(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise DaemonProtocolError("gate params must be an object")
+    proposal, gates, root = raw.get("proposal"), raw.get("gates"), raw.get("root")
+    if not isinstance(proposal, dict) or not isinstance(gates, dict):
+        raise DaemonProtocolError("gate proposal and config must be objects")
+    forbidden_paths = gates.get("forbidden_paths")
+    block_dependencies = gates.get("block_dependency_changes")
+    if (
+        not isinstance(forbidden_paths, list)
+        or not all(isinstance(path, str) for path in forbidden_paths)
+        or not isinstance(block_dependencies, bool)
+        or (root is not None and not isinstance(root, str))
+    ):
+        raise DaemonProtocolError("invalid gate config")
+
+    command, files = proposal.get("command"), proposal.get("files")
+    if (
+        (command is not None and not isinstance(command, str))
+        or not isinstance(files, list)
+        or not all(isinstance(path, str) for path in files)
+    ):
+        decision = GateDecision(
+            True, "unsupported_proposal", "fail-open: unsupported proposal shape"
+        )
+        evaluation_ms = 0.0
+    else:
+        started = time.perf_counter_ns()
+        decision = Gate(tuple(forbidden_paths), block_dependencies, root).check(
+            TraceEvent("tool_proposal", dict(proposal))
+        )
+        evaluation_ms = (time.perf_counter_ns() - started) / 1_000_000
+    return {
+        "decision": {
+            "allowed": decision.allowed,
+            "rule": decision.rule,
+            "reason": decision.reason,
+        },
+        "evaluation_ms": evaluation_ms,
+    }
 
 
 class ServiceManager(Protocol):

--- a/src/spotter/daemon.py
+++ b/src/spotter/daemon.py
@@ -122,6 +122,8 @@ class DaemonClient:
         finally:
             if writer is not None:
                 writer.close()
+                with suppress(ConnectionError, OSError):
+                    await writer.wait_closed()
 
     async def status(self) -> DaemonStatus:
         try:
@@ -151,7 +153,7 @@ class DaemonClient:
             {
                 "proposal": {
                     "command": event.payload.get("command"),
-                    "files": event.payload.get("files"),
+                    "files": event.payload.get("files") or [],
                 },
                 "gates": {
                     "forbidden_paths": list(gates.forbidden_paths),

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -5,11 +5,13 @@ Every failure path here fails open (allow) with a note on stderr — Spotter
 losing an observation is recoverable, Codex dying mid-turn is not.
 """
 
+import asyncio
 import json
 import os
 import re
 import subprocess
 import sys
+import time
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
@@ -17,8 +19,16 @@ from typing import Any
 from spotter.budget import cancel, reserve
 from spotter.config import SpotterConfig
 from spotter.core import SpotterRuntime
+from spotter.daemon import (
+    GATE_TIMEOUT,
+    PROTOCOL_VERSION,
+    DaemonClient,
+    DaemonProtocolError,
+    DaemonTimeout,
+    DaemonUnavailable,
+)
 from spotter.effects import classify
-from spotter.gates import Gate
+from spotter.gates import Gate, GateDecision
 from spotter.paths import sanitize_session, secure_dir, spotter_home
 from spotter.snapshot import SnapshotError, StepJournal, global_lock, snapshot_worktree
 from spotter.trace import TraceEvent
@@ -188,6 +198,7 @@ def run_hook(
     payload: dict[str, Any], config: SpotterConfig, config_path: Path | None = None
 ) -> str | None:
     """Process one hook invocation. Returns stdout JSON, or None to allow."""
+    hook_started = time.perf_counter_ns()
     cwd = payload.get("cwd")
     gate = Gate(
         forbidden_paths=config.gates.forbidden_paths,
@@ -199,6 +210,12 @@ def run_hook(
     adapter = JournalAdapter(journal)
     runtime = SpotterRuntime(config, adapter, gate)
     event = event_from_hook(payload)
+    gate_decision: GateDecision | None = None
+    gate_telemetry: dict[str, Any] | None = None
+    if event.kind == "tool_proposal":
+        gate_decision, gate_telemetry = _gate_over_ipc(
+            event, config, str(cwd) if isinstance(cwd, str) else None
+        )
     if event.kind == "tool_result":
         event.payload["checkpoint"] = journal.last_snapshot()
     if (
@@ -218,13 +235,16 @@ def run_hook(
                 adapter.next_snapshot = snapshot_worktree(Path(cwd), journal.last_snapshot())
             except SnapshotError:
                 adapter.next_snapshot = None
-            decision = runtime.observe(event)
+            decision = runtime.observe(event, gate_decision)
     else:
-        decision = runtime.observe(event)
+        decision = runtime.observe(event, gate_decision)
     if event.kind == "tool_proposal":
         _maybe_spawn_shadow_review(
             config, payload, journal_file, adapter.last_proposal_number, config_path
         )
+        assert gate_telemetry is not None
+        gate_telemetry["hook_ms"] = (time.perf_counter_ns() - hook_started) / 1_000_000
+        adapter.record(TraceEvent("gate_ipc", gate_telemetry))
     if decision.allowed:
         return None  # implicit allow; stay silent on the happy path
     return json.dumps(
@@ -236,3 +256,40 @@ def run_hook(
             }
         }
     )
+
+
+def _gate_over_ipc(
+    event: TraceEvent, config: SpotterConfig, root: str | None
+) -> tuple[GateDecision, dict[str, Any]]:
+    started = time.perf_counter_ns()
+    status = "ok"
+    evaluation_ms: float | None = None
+    error_detail: str | None = None
+    try:
+        decision, evaluation_ms = asyncio.run(
+            DaemonClient(timeout=GATE_TIMEOUT).gate(event, config.gates, root)
+        )
+    except DaemonTimeout as error:
+        status = "timeout"
+        error_detail = str(error)
+        decision = GateDecision(True, "daemon_timeout", f"fail-open: {error}")
+    except DaemonProtocolError as error:
+        status = "protocol_error"
+        error_detail = str(error)
+        decision = GateDecision(True, "daemon_protocol_error", f"fail-open: {error}")
+    except DaemonUnavailable as error:
+        status = "unavailable"
+        error_detail = str(error)
+        decision = GateDecision(True, "daemon_unavailable", f"fail-open: {error}")
+
+    telemetry: dict[str, Any] = {
+        "status": status,
+        "protocol": PROTOCOL_VERSION,
+        "ipc_ms": (time.perf_counter_ns() - started) / 1_000_000,
+        "daemon_evaluation_ms": evaluation_ms,
+        "tool_use_id": event.payload.get("tool_use_id"),
+        "tool": event.payload.get("tool"),
+    }
+    if error_detail is not None:
+        telemetry["error"] = error_detail[:300]
+    return decision, telemetry

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -214,7 +214,7 @@ def run_hook(
     gate_telemetry: dict[str, Any] | None = None
     if event.kind == "tool_proposal":
         gate_decision, gate_telemetry = _gate_over_ipc(
-            event, config, str(cwd) if isinstance(cwd, str) else None
+            event, config, str(cwd) if isinstance(cwd, str) else None, gate
         )
     if event.kind == "tool_result":
         event.payload["checkpoint"] = journal.last_snapshot()
@@ -259,7 +259,7 @@ def run_hook(
 
 
 def _gate_over_ipc(
-    event: TraceEvent, config: SpotterConfig, root: str | None
+    event: TraceEvent, config: SpotterConfig, root: str | None, fallback: Gate
 ) -> tuple[GateDecision, dict[str, Any]]:
     started = time.perf_counter_ns()
     status = "ok"
@@ -272,7 +272,7 @@ def _gate_over_ipc(
     except DaemonTimeout as error:
         status = "timeout"
         error_detail = str(error)
-        decision = GateDecision(True, "daemon_timeout", f"fail-open: {error}")
+        decision = fallback.check(event)
     except DaemonProtocolError as error:
         status = "protocol_error"
         error_detail = str(error)
@@ -280,7 +280,7 @@ def _gate_over_ipc(
     except DaemonUnavailable as error:
         status = "unavailable"
         error_detail = str(error)
-        decision = GateDecision(True, "daemon_unavailable", f"fail-open: {error}")
+        decision = fallback.check(event)
 
     telemetry: dict[str, Any] = {
         "status": status,

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -185,6 +185,24 @@ def test_gate_fails_open_for_an_unsupported_proposal_shape(socket_path: Path) ->
     asyncio.run(scenario())
 
 
+def test_gate_normalizes_missing_files_without_skipping_the_command(socket_path: Path) -> None:
+    async def scenario() -> None:
+        server = DaemonServer(socket_path)
+        await server.start()
+        try:
+            decision, _ = await DaemonClient(socket_path).gate(
+                TraceEvent("tool_proposal", {"command": "rm -rf /", "files": None}),
+                GatesConfig(),
+                "/repo",
+            )
+            assert not decision.allowed
+            assert decision.rule == "rm_root"
+        finally:
+            await server.close()
+
+    asyncio.run(scenario())
+
+
 def test_second_daemon_cannot_take_the_live_socket(socket_path: Path) -> None:
     async def scenario() -> None:
         first = DaemonServer(socket_path)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,26 +1,34 @@
 import asyncio
 import json
 import shutil
+import time
 from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
 from spotter.cli import main
+from spotter.config import GatesConfig
 from spotter.daemon import (
+    GATE_TIMEOUT,
     PROTOCOL_VERSION,
     DaemonAlreadyRunning,
     DaemonClient,
+    DaemonProtocolError,
     DaemonServer,
+    DaemonTimeout,
     RuntimeHealth,
     runtime_socket,
 )
+from spotter.gates import Gate
+from spotter.trace import TraceEvent
 
 
 @pytest.fixture()
 def socket_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
     monkeypatch.setenv("SPOTTER_HOME", str(tmp_path / "home"))
     path = runtime_socket()
+    path.parent.mkdir(parents=True, exist_ok=True)
     yield path
     shutil.rmtree(path.parent, ignore_errors=True)
 
@@ -69,6 +77,108 @@ def test_bad_protocol_does_not_break_later_clients(socket_path: Path) -> None:
                 "error": "incompatible control protocol",
             }
             assert (await DaemonClient(socket_path).status()).health == RuntimeHealth.HEALTHY
+        finally:
+            await server.close()
+
+    asyncio.run(scenario())
+
+
+def test_gate_roundtrip_preserves_policy_and_concurrency(socket_path: Path) -> None:
+    async def scenario() -> None:
+        server = DaemonServer(socket_path)
+        await server.start()
+        try:
+            cases = [
+                (TraceEvent("tool_proposal", {"command": "pytest", "files": []}), GatesConfig()),
+                (
+                    TraceEvent("tool_proposal", {"command": "rm -rf /", "files": []}),
+                    GatesConfig(),
+                ),
+                (
+                    TraceEvent("tool_proposal", {"command": None, "files": ["pyproject.toml"]}),
+                    GatesConfig(block_dependency_changes=True),
+                ),
+                (
+                    TraceEvent("tool_proposal", {"command": None, "files": ["secrets/key"]}),
+                    GatesConfig(forbidden_paths=("secrets/*",)),
+                ),
+            ]
+            results = await asyncio.gather(
+                *(DaemonClient(socket_path).gate(event, gates, "/repo") for event, gates in cases)
+            )
+            for (event, gates), (decision, evaluation_ms) in zip(cases, results, strict=True):
+                assert decision == Gate(
+                    gates.forbidden_paths, gates.block_dependency_changes, "/repo"
+                ).check(event)
+                assert evaluation_ms >= 0
+        finally:
+            await server.close()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        b"not-json\n",
+        b'{"protocol":999,"ok":true,"decision":{},"evaluation_ms":0}\n',
+    ],
+)
+def test_gate_rejects_malformed_and_mismatched_responses(
+    socket_path: Path, response: bytes
+) -> None:
+    async def scenario() -> None:
+        async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            await reader.readline()
+            writer.write(response)
+            await writer.drain()
+            writer.close()
+
+        server = await asyncio.start_unix_server(handler, path=socket_path)
+        async with server:
+            with pytest.raises(DaemonProtocolError):
+                await DaemonClient(socket_path).gate(
+                    TraceEvent("tool_proposal", {"command": "true", "files": []}),
+                    GatesConfig(),
+                    "/repo",
+                )
+
+    asyncio.run(scenario())
+
+
+def test_gate_timeout_is_bounded_across_the_request(socket_path: Path) -> None:
+    async def scenario() -> None:
+        async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            await reader.readline()
+            await asyncio.sleep(GATE_TIMEOUT * 2)
+            writer.close()
+
+        server = await asyncio.start_unix_server(handler, path=socket_path)
+        async with server:
+            started = time.perf_counter()
+            with pytest.raises(DaemonTimeout):
+                await DaemonClient(socket_path, timeout=0.01).gate(
+                    TraceEvent("tool_proposal", {"command": "true", "files": []}),
+                    GatesConfig(),
+                    "/repo",
+                )
+            assert time.perf_counter() - started < 0.1
+
+    asyncio.run(scenario())
+
+
+def test_gate_fails_open_for_an_unsupported_proposal_shape(socket_path: Path) -> None:
+    async def scenario() -> None:
+        server = DaemonServer(socket_path)
+        await server.start()
+        try:
+            decision, _ = await DaemonClient(socket_path).gate(
+                TraceEvent("tool_proposal", {"command": 42, "files": "not-a-list"}),
+                GatesConfig(),
+                "/repo",
+            )
+            assert decision.allowed
+            assert decision.rule == "unsupported_proposal"
         finally:
             await server.close()
 

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -1,9 +1,12 @@
 import json
+import threading
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
 from spotter.config import GatesConfig, MainAgentConfig, ReviewerConfig, SpotterConfig
+from spotter.daemon import DaemonClient, DaemonProtocolError, DaemonServer, DaemonTimeout
 from spotter.hook import event_from_hook, journal_path, run_hook
 from spotter.snapshot import StepJournal, restore_snapshot
 
@@ -33,7 +36,45 @@ def _config(observation_only: bool) -> SpotterConfig:
     )
 
 
-def test_active_mode_emits_deny_json() -> None:
+@pytest.fixture()
+def daemon() -> Iterator[None]:
+    ready = threading.Event()
+    thread_error: list[BaseException] = []
+
+    def run() -> None:
+        async def serve() -> None:
+            server = DaemonServer()
+            await server.start()
+            ready.set()
+            try:
+                await server.wait_for_shutdown()
+            finally:
+                await server.close()
+
+        try:
+            import asyncio
+
+            asyncio.run(serve())
+        except BaseException as error:
+            thread_error.append(error)
+            ready.set()
+
+    worker = threading.Thread(target=run)
+    worker.start()
+    assert ready.wait(1)
+    assert not thread_error
+    try:
+        yield
+    finally:
+        import asyncio
+
+        asyncio.run(DaemonClient().shutdown())
+        worker.join(1)
+        assert not worker.is_alive()
+        assert not thread_error
+
+
+def test_active_mode_emits_deny_json(daemon: None) -> None:
     output = run_hook(_payload("rm -rf /"), _config(observation_only=False))
     assert output is not None
     decision = json.loads(output)["hookSpecificOutput"]
@@ -41,16 +82,67 @@ def test_active_mode_emits_deny_json() -> None:
     assert "rm_root" in decision["permissionDecisionReason"]
 
 
-def test_shadow_mode_allows_but_journals_the_block(spotter_home: Path) -> None:
+def test_shadow_mode_allows_but_journals_the_block(spotter_home: Path, daemon: None) -> None:
     payload = _payload("git push --force")
     assert run_hook(payload, _config(observation_only=True)) is None
     records = StepJournal.load(journal_path(payload))
-    assert [r.event.kind for r in records] == ["tool_proposal", "gate_shadow_block"]
+    assert [r.event.kind for r in records] == [
+        "tool_proposal",
+        "gate_shadow_block",
+        "gate_ipc",
+    ]
     assert records[1].event.payload["rule"] == "git_push_force"
+    assert records[2].event.payload["status"] == "ok"
+    assert records[2].event.payload["ipc_ms"] >= 0
+    assert records[2].event.payload["hook_ms"] >= records[2].event.payload["ipc_ms"]
 
 
-def test_safe_command_allows_silently() -> None:
+def test_safe_command_allows_silently(daemon: None) -> None:
     assert run_hook(_payload("pytest tests/"), _config(observation_only=False)) is None
+
+
+def test_missing_daemon_fails_open_with_telemetry() -> None:
+    payload = _payload("rm -rf /")
+    assert run_hook(payload, _config(observation_only=False)) is None
+
+    records = StepJournal.load(journal_path(payload))
+    assert [record.event.kind for record in records] == [
+        "tool_proposal",
+        "gate_fail_open",
+        "gate_ipc",
+    ]
+    assert records[1].event.payload["rule"] == "daemon_unavailable"
+    assert records[2].event.payload["status"] == "unavailable"
+
+
+def test_timeout_fails_open_with_diagnosable_telemetry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def timeout(*args: object, **kwargs: object) -> object:
+        raise DaemonTimeout("deadline")
+
+    monkeypatch.setattr("spotter.hook.DaemonClient.gate", timeout)
+    payload = _payload("rm -rf /")
+    assert run_hook(payload, _config(observation_only=False)) is None
+
+    records = StepJournal.load(journal_path(payload))
+    assert records[1].event.payload["rule"] == "daemon_timeout"
+    assert records[2].event.payload["status"] == "timeout"
+
+
+def test_protocol_error_fails_open_with_diagnosable_telemetry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def protocol_error(*args: object, **kwargs: object) -> object:
+        raise DaemonProtocolError("incompatible control protocol")
+
+    monkeypatch.setattr("spotter.hook.DaemonClient.gate", protocol_error)
+    payload = _payload("rm -rf /")
+    assert run_hook(payload, _config(observation_only=False)) is None
+
+    records = StepJournal.load(journal_path(payload))
+    assert records[1].event.payload["rule"] == "daemon_protocol_error"
+    assert records[2].event.payload["status"] == "protocol_error"
 
 
 def test_session_id_is_sanitized_for_filenames() -> None:
@@ -69,7 +161,7 @@ def test_file_paths_extracted_from_tool_input() -> None:
     assert event.payload["files"] == ["src/a.py", "src/b.py"]
 
 
-def test_apply_patch_paths_are_gated() -> None:
+def test_apply_patch_paths_are_gated(daemon: None) -> None:
     payload = {
         **_payload("*** Begin Patch\n*** Update File: pyproject.toml\n*** End Patch"),
         "tool_name": "apply_patch",
@@ -137,7 +229,9 @@ def test_unknown_events_still_journal(spotter_home: Path) -> None:
     assert records[0].event.kind == "sessionstart"
 
 
-def test_apply_patch_takes_snapshot_for_fork(tmp_path: Path, spotter_home: Path) -> None:
+def test_apply_patch_takes_snapshot_for_fork(
+    tmp_path: Path, spotter_home: Path, daemon: None
+) -> None:
     import subprocess
 
     repo = tmp_path / "hookrepo"
@@ -164,7 +258,11 @@ def test_apply_patch_takes_snapshot_for_fork(tmp_path: Path, spotter_home: Path)
     (repo / "x.txt").write_text("patched")
     post = {**payload, "hook_event_name": "PostToolUse", "tool_response": {"ok": True}}
     assert run_hook(post, _config(observation_only=True)) is None
-    post_record = StepJournal.load(journal_path(payload))[1]
+    post_record = next(
+        record
+        for record in StepJournal.load(journal_path(payload))
+        if record.event.kind == "tool_result"
+    )
     assert post_record.snapshot and post_record.snapshot != record.snapshot
 
     restored = tmp_path / "restored"
@@ -172,7 +270,7 @@ def test_apply_patch_takes_snapshot_for_fork(tmp_path: Path, spotter_home: Path)
     assert (restored / "x.txt").read_text() == "patched"
 
 
-def test_snapshot_failure_fails_open(tmp_path: Path, spotter_home: Path) -> None:
+def test_snapshot_failure_fails_open(tmp_path: Path, spotter_home: Path, daemon: None) -> None:
     payload = {
         "hook_event_name": "PreToolUse",
         "session_id": "snap2",

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -101,21 +101,21 @@ def test_safe_command_allows_silently(daemon: None) -> None:
     assert run_hook(_payload("pytest tests/"), _config(observation_only=False)) is None
 
 
-def test_missing_daemon_fails_open_with_telemetry() -> None:
+def test_missing_daemon_uses_local_gate_with_telemetry() -> None:
     payload = _payload("rm -rf /")
-    assert run_hook(payload, _config(observation_only=False)) is None
+    assert "rm_root" in (run_hook(payload, _config(observation_only=False)) or "")
 
     records = StepJournal.load(journal_path(payload))
     assert [record.event.kind for record in records] == [
         "tool_proposal",
-        "gate_fail_open",
+        "gate_block",
         "gate_ipc",
     ]
-    assert records[1].event.payload["rule"] == "daemon_unavailable"
+    assert records[1].event.payload["rule"] == "rm_root"
     assert records[2].event.payload["status"] == "unavailable"
 
 
-def test_timeout_fails_open_with_diagnosable_telemetry(
+def test_timeout_uses_local_gate_with_diagnosable_telemetry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def timeout(*args: object, **kwargs: object) -> object:
@@ -123,10 +123,10 @@ def test_timeout_fails_open_with_diagnosable_telemetry(
 
     monkeypatch.setattr("spotter.hook.DaemonClient.gate", timeout)
     payload = _payload("rm -rf /")
-    assert run_hook(payload, _config(observation_only=False)) is None
+    assert "rm_root" in (run_hook(payload, _config(observation_only=False)) or "")
 
     records = StepJournal.load(journal_path(payload))
-    assert records[1].event.payload["rule"] == "daemon_timeout"
+    assert records[1].event.payload["rule"] == "rm_root"
     assert records[2].event.payload["status"] == "timeout"
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -209,22 +209,45 @@ def test_wrapper_reads_the_documented_home_config(tmp_path: Path) -> None:
         'observation_only = false\n[main_agent]\nadapter = "codex"\n'
         '[gates]\nforbidden_paths = ["secrets/*"]\n'
     )
-    result = subprocess.run(
-        [str(Path("scripts/spotter-hook").resolve())],
-        input=json.dumps(
-            {
-                "hook_event_name": "PreToolUse",
-                "session_id": "cfg",
-                "cwd": str(tmp_path),
-                "tool_name": "apply_patch",
-                "tool_input": {"path": "secrets/key.pem"},
-            }
-        ),
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "SPOTTER_HOME": str(home),
+        "PYTHONPATH": str(Path("src").resolve()),
+    }
+    started = subprocess.run(
+        [sys.executable, "-m", "spotter", "daemon", "start"],
         text=True,
         capture_output=True,
-        env={**os.environ, "HOME": str(home), "SPOTTER_HOME": str(home)},
+        env=env,
         check=False,
     )
+    assert started.returncode == 0, started.stderr
+    try:
+        result = subprocess.run(
+            [str(Path("scripts/spotter-hook").resolve())],
+            input=json.dumps(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "session_id": "cfg",
+                    "cwd": str(tmp_path),
+                    "tool_name": "apply_patch",
+                    "tool_input": {"path": "secrets/key.pem"},
+                }
+            ),
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+    finally:
+        subprocess.run(
+            [sys.executable, "-m", "spotter", "daemon", "stop"],
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
     assert result.returncode == 0
     assert "forbidden_path" in result.stdout, "the configured gate never reached the hook"
 


### PR DESCRIPTION
## Summary
- route deterministic `PreToolUse` decisions through versioned local `spotterd` IPC
- enforce a 200 ms total deadline and fail open on unavailable, timeout, malformed, mismatched, or unsupported responses
- record separate daemon evaluation, IPC, and total Hook timing telemetry
- preserve existing gate semantics and update runtime documentation

## Validation
- `ruff check src tests`
- `ruff format --check src tests`
- `mypy src`
- `pytest -q`

Closes #82