### PR TITLE
feat(operations): add transactional Codex setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Claim/evidence audit ledger | 🟡 | Works where observable outcomes exist |
 | Evaluation labels / metrics | ✅ | Coverage-aware evaluation and precision/FP metrics |
 | Counterfactual experiment harness | ✅ | Control/guidance same-prefix pairs |
-| Standalone `spotterd` runtime | 🟡 | Process, versioned gate/control IPC, and manual lifecycle implemented; managed startup/runtime consumers remain |
+| Standalone `spotterd` runtime | 🟡 | Process, versioned gate/control IPC, and managed user-service startup implemented; runtime consumers remain |
 | App Server primary observation | 🟡 | Client/capabilities implemented; Trace IR ingestion remains (#85) |
 | Event-driven signal engine | ❌ | Current reviewer trigger is periodic |
 | Live `VERIFY / NUDGE` | ❌ | Target: `turn/steer` |
 | `INTERRUPT` | ❌ | Target: `turn/interrupt` |
 | `RESTART` | ❌ | Requires verified-state + side-effect-aware recovery |
-| Homebrew / setup lifecycle | 🎯 | Target product path |
+| Codex setup lifecycle | 🟡 | Transactional setup/teardown and manifest implemented; packaging and full App Server integration remain |
 
 ### Current runtime work
 
@@ -94,7 +94,9 @@ control methods, and per-capability degraded state. [#81](https://github.com/spo
 adds a provisional thread/turn/attachment registry; it remains unconsumed until App Server event
 routing in [#85](https://github.com/spotter-agent/spotter/issues/85). [#79](https://github.com/spotter-agent/spotter/issues/79)
 adds the `spotterd` process, versioned local control handshake, manual lifecycle commands, and a
-platform-neutral service boundary. Managed setup, event routing, and recovery remain separate work.
+platform-neutral service boundary. [#83](https://github.com/spotter-agent/spotter/issues/83) adds
+transactional Codex setup/teardown, managed user-service registration, and integration ownership.
+Event routing and recovery remain separate work.
 
 ---
 
@@ -312,13 +314,24 @@ claude plugin marketplace add spotter-agent/spotter
 claude plugin install spotter@spotter
 ```
 
-Plugin installation is the **current prototype path**, not the long-term product boundary.
+Plugin installation remains a compatibility path. New standalone integration can use:
+
+```bash
+spotter setup codex --dry-run
+spotter setup codex
+spotter teardown codex
+```
+
+The explicit external App Server still has to be selected with the launch command printed by setup
+until the remaining App Server ingestion/lifecycle work lands.
 
 Useful commands:
 
 ```bash
 spotter observe
 spotter hook  # hook bridge; JSON payload on stdin
+spotter setup codex [--dry-run|--portable]
+spotter teardown codex
 spotter daemon start|stop|restart|status
 spotter analyze
 spotter review --session <id>

--- a/README.md
+++ b/README.md
@@ -322,8 +322,8 @@ spotter setup codex
 spotter teardown codex
 ```
 
-The explicit external App Server still has to be selected with the launch command printed by setup
-until the remaining App Server ingestion/lifecycle work lands.
+App Server endpoint selection remains pending until the remaining ingestion/lifecycle work lands;
+setup does not print or claim an endpoint that it has not verified.
 
 Useful commands:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -946,8 +946,9 @@ PreToolUse:  possibly available
 - Path A remains unavailable for the tested Homebrew Cask because the managed daemon expects the
   standalone installer layout.
 - A provisional concurrent thread identity registry exists from #81 but is not wired into production;
-  App Server event routing in #85 must validate it, managed service registration remains #83, and
-  reconnect reconciliation remains #87.
+  App Server event routing in #85 must validate it, while reconnect reconciliation remains #87.
+- Transactional Codex setup now owns only its recorded Hook/plugin/service mutations. It records the
+  explicit remote endpoint but neither owns nor stops a shared Codex App Server.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -947,8 +947,8 @@ PreToolUse:  possibly available
   standalone installer layout.
 - A provisional concurrent thread identity registry exists from #81 but is not wired into production;
   App Server event routing in #85 must validate it, while reconnect reconciliation remains #87.
-- Transactional Codex setup now owns only its recorded Hook/plugin/service mutations. It records the
-  explicit remote endpoint but neither owns nor stops a shared Codex App Server.
+- Transactional Codex setup now owns only its recorded Hook/plugin/service mutations. App Server
+  endpoint selection remains explicitly pending; setup neither owns nor stops a shared App Server.
 
 ---
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -424,9 +424,9 @@ Spotter ↔ App Server initialized
 Hook IPC reachable
 ```
 
-The current #83 implementation verifies Codex's `app-server --listen` and `--remote` capability and
-records the selected explicit endpoint, but does not create or stop a shared App Server. Live
-App Server initialize/event verification joins the ingestion and diagnostic work in #85/#84.
+The current #83 implementation verifies Codex's `app-server --listen` and `--remote` capability but
+records endpoint selection as pending because it does not create or own a shared App Server. Live
+endpoint selection and App Server initialize/event verification join #85/#87 and #84 diagnostics.
 
 ## 4.7 VERIFY
 
@@ -457,7 +457,8 @@ Example manifest:
   "setup_by": "0.6.0",
   "agent_path": "/opt/homebrew/bin/codex",
   "agent_version": "...",
-  "app_server_strategy": "codex-managed-external",
+  "app_server_strategy": "pending-external",
+  "app_server_endpoint": null,
   "runtime_mode": "managed",
   "service_owned": true,
   "owned_hook": {"event": "PreToolUse", "matcher": ".*", "hook": {"type": "command"}},
@@ -478,7 +479,9 @@ Example manifest:
 | START/CONNECT | either roll back or leave an explicit incomplete/degraded manifest |
 | VERIFY | do not report READY; preserve actionable diagnostics |
 
-A second `spotter setup codex` must reconcile safely from any interrupted setup state.
+A second `spotter setup codex` heals an interruption after inspectable changes were written. A
+process crash before the manifest commit can leave the owned Hook without an ownership record;
+re-running setup heals forward, while teardown cannot remove an unrecorded mutation automatically.
 
 ---
 
@@ -1327,7 +1330,7 @@ The target lifecycle is not complete until all of these work end-to-end:
 
 - [ ] clean package install does not modify Codex;
 - [x] `spotter setup codex` is idempotent;
-- [x] interrupted setup can be resumed/reconciled;
+- [x] interrupted setup can heal forward when setup is re-run (pre-manifest teardown cannot infer ownership);
 - [ ] ordinary `codex` requires no manual Spotter/App Server startup in managed mode;
 - [ ] `status` distinguishes daemon, observation, control, enforcement, storage health;
 - [ ] `doctor` performs a real synthetic round-trip;

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,7 +1,7 @@
 # Lifecycle and Operations
 
-> **Status:** target design. Active implementation is tracked by the [Roadmap](roadmap.md) and native GitHub Milestones.
-> The current prototype is still hook/plugin-centered. A manual `spotterd` process/control lifecycle exists, but Homebrew installation, managed service registration, and full App Server integration described here are the **intended product lifecycle**, not current shipping behavior.
+> **Status:** target design with an implemented transactional Codex setup slice. Active implementation is tracked by the [Roadmap](roadmap.md) and native GitHub Milestones.
+> `spotter setup|teardown codex`, versioned ownership manifests, managed `launchd`/`systemd --user` registration, portable startup, and legacy Hook/plugin migration exist. Homebrew installation, App Server event ingestion, runtime-aware diagnostics, and transparent plain-`codex` launch remain target behavior.
 
 ---
 
@@ -312,6 +312,11 @@ spotter setup codex
 
 It must be **idempotent** and **transactional**.
 
+The implemented command supports `--dry-run` and `--portable`. Managed mode registers `spotterd`
+as a login-scoped user service; portable mode starts it without persistent registration. Setup
+mutates only Codex Hook/plugin configuration, keeps fingerprinted backups, verifies daemon health
+and a synthetic Hook round-trip, then atomically commits `~/.spotter/integrations/codex.json`.
+
 ## 4.1 Transaction stages
 
 ```text
@@ -381,7 +386,7 @@ Plan
   Agent config backup/fingerprint: required
 ```
 
-A future dry-run surface is useful:
+The mutation plan is available without writes:
 
 ```bash
 spotter setup codex --dry-run
@@ -419,6 +424,10 @@ Spotter ↔ App Server initialized
 Hook IPC reachable
 ```
 
+The current #83 implementation verifies Codex's `app-server --listen` and `--remote` capability and
+records the selected explicit endpoint, but does not create or stop a shared App Server. Live
+App Server initialize/event verification joins the ingestion and diagnostic work in #85/#84.
+
 ## 4.7 VERIFY
 
 A synthetic E2E verification should check at least:
@@ -450,8 +459,9 @@ Example manifest:
   "agent_version": "...",
   "app_server_strategy": "codex-managed-external",
   "runtime_mode": "managed",
-  "hooks_added": ["PreToolUse"],
-  "legacy_hooks_removed": ["PostToolUse"],
+  "service_owned": true,
+  "owned_hook": {"event": "PreToolUse", "matcher": ".*", "hook": {"type": "command"}},
+  "legacy_hooks_removed": [{"event": "PostToolUse"}],
   "config_fingerprint_before": "...",
   "created_at": "..."
 }
@@ -1316,8 +1326,8 @@ The lifecycle implies concrete components rather than one monolithic CLI.
 The target lifecycle is not complete until all of these work end-to-end:
 
 - [ ] clean package install does not modify Codex;
-- [ ] `spotter setup codex` is idempotent;
-- [ ] interrupted setup can be resumed/reconciled;
+- [x] `spotter setup codex` is idempotent;
+- [x] interrupted setup can be resumed/reconciled;
 - [ ] ordinary `codex` requires no manual Spotter/App Server startup in managed mode;
 - [ ] `status` distinguishes daemon, observation, control, enforcement, storage health;
 - [ ] `doctor` performs a real synthetic round-trip;
@@ -1325,11 +1335,11 @@ The target lifecycle is not complete until all of these work end-to-end:
 - [ ] daemon crash recovers without corrupting journal/live state;
 - [ ] Codex upgrade degrades by capability rather than silently breaking;
 - [ ] Spotter upgrade handles a running old daemon and schema migration;
-- [ ] `teardown codex` removes only Spotter-owned integration changes;
+- [x] `teardown codex` removes only Spotter-owned integration changes;
 - [ ] uninstall without teardown does not break Codex;
 - [ ] user data survives normal uninstall;
 - [ ] purge can enumerate and safely clean repository resources;
 - [ ] reinstall can reuse/migrate retained data;
-- [ ] legacy plugin users migrate without duplicate events.
+- [x] legacy plugin users migrate without duplicate events.
 
 For runtime component boundaries, see [Architecture](architecture.md). For implementation sequencing, see [Roadmap](roadmap.md). For current implementation state, see [Status](status.md).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -78,7 +78,7 @@ The Runtime milestone is now decomposed into concrete boundaries rather than one
 | [#81](https://github.com/spotter-agent/spotter/issues/81) | Thread / Turn / Runtime Attachment identity lifecycle (provisional foundation; integration in #85) |
 | [#82](https://github.com/spotter-agent/spotter/issues/82) | bounded Hook ↔ daemon IPC for deterministic `PreToolUse` enforcement (implemented) |
 | [#31](https://github.com/spotter-agent/spotter/issues/31) | independent live supervision state owned by `spotterd` |
-| [#83](https://github.com/spotter-agent/spotter/issues/83) | transactional `setup|teardown codex`, Integration Manifest, legacy migration |
+| [#83](https://github.com/spotter-agent/spotter/issues/83) | transactional `setup|teardown codex`, Integration Manifest, legacy migration (implemented) |
 | [#84](https://github.com/spotter-agent/spotter/issues/84) | runtime-aware `status` / `doctor` and degraded capability reporting |
 | [#87](https://github.com/spotter-agent/spotter/issues/87) | daemon/App Server reconnect and thread reconciliation |
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -58,10 +58,11 @@ local control handshake, explicit health states, manual lifecycle commands, and 
 `ServiceManager` boundary. It deliberately does not own or stop a shared Codex App Server.
 [#82](https://github.com/spotter-agent/spotter/issues/82) adds bounded deterministic gate requests,
 local enforcement fallback on unavailable/timeout, and separate Hook/IPC timing telemetry.
+[#83](https://github.com/spotter-agent/spotter/issues/83) adds versioned integration manifests,
+transactional Codex Hook/plugin migration, and managed `launchd`/`systemd --user` registration.
 
 The remaining implementation boundaries are split into native GitHub issues:
 
-- [#83](https://github.com/spotter-agent/spotter/issues/83) — transactional Codex setup/teardown and integration ownership;
 - [#84](https://github.com/spotter-agent/spotter/issues/84) — runtime-aware status/doctor;
 - [#87](https://github.com/spotter-agent/spotter/issues/87) — daemon/App Server reconnect and identity reconciliation.
 
@@ -69,8 +70,9 @@ The remaining implementation boundaries are split into native GitHub issues:
 
 The assumption that merely starting the external server would make plain `codex` reuse it was
 rejected by the [2026-08-13 validation](app-server-validation.md). The explicit `--remote` path
-subsequently passed the same-thread/same-turn PoC. Multi-TUI concurrency, reconnect, managed setup,
-and the embedded-server degraded baseline remain unresolved productization boundaries.
+subsequently passed the same-thread/same-turn PoC. Multi-TUI concurrency, reconnect, and the
+embedded-server degraded baseline remain unresolved productization boundaries. Setup records
+and prints the explicit remote endpoint; it does not claim ownership of or stop a shared App Server.
 
 In parallel, the highest-value evidence foundations remain:
 
@@ -96,10 +98,10 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Audit ledger | 🟡 | Claim/evidence state and stale propagation where outcomes are observable | Move independent state into `spotterd` (#31) |
 | Evaluation labels / metrics | ✅ | Coverage-aware labeling and precision/FP metrics | Broader cost/miss/harm metrics (#33, #38, #34) |
 | Counterfactual harness | ✅ | Control/guidance same-prefix pairs can be prepared/run | Add mechanically scored tasks (#21) |
-| Standalone runtime | 🟡 | Long-lived process, versioned control/gate IPC, health states, manual lifecycle, service abstraction | Register managed startup in #83; add runtime consumers in #31/#85 |
+| Standalone runtime | 🟡 | Long-lived process, versioned control/gate IPC, health states, manual and managed user-service lifecycle | Add runtime consumers in #31/#85 |
 | Runtime identity | 🟡 | Provisional lifecycle registry and explicit legacy unknowns; no production consumer | Validate and refine it while routing normalized App Server events in #85 |
 | App Server primary observation | 🟡 | Async client, raw events, thread queries, controls, capability degradation | Normalize, identity-route, and journal events in #85 |
-| Managed Codex lifecycle | ❌ | Current path is source/plugin installation | transactional setup/teardown in #83; diagnostics in #84 |
+| Managed Codex lifecycle | 🟡 | Transactional setup/teardown, versioned ownership manifest, legacy migration, launchd/systemd-user service | Surface integration drift and capability consequences in #84 |
 | Runtime reconnect/recovery | ❌ | No long-lived App Server connection to recover | #87 after runtime/state boundaries exist |
 | Event-driven detection | ❌ | Reviewer is still cadence-based | #28 after Runtime/Observe |
 | Live `VERIFY` / `NUDGE` | ❌ | Reviewer decisions stop at the journal | #22 via `turn/steer` |

--- a/docs/status.md
+++ b/docs/status.md
@@ -71,8 +71,8 @@ The remaining implementation boundaries are split into native GitHub issues:
 The assumption that merely starting the external server would make plain `codex` reuse it was
 rejected by the [2026-08-13 validation](app-server-validation.md). The explicit `--remote` path
 subsequently passed the same-thread/same-turn PoC. Multi-TUI concurrency, reconnect, and the
-embedded-server degraded baseline remain unresolved productization boundaries. Setup records
-and prints the explicit remote endpoint; it does not claim ownership of or stop a shared App Server.
+embedded-server degraded baseline remain unresolved productization boundaries. Setup records the
+App Server strategy as pending; it does not invent an endpoint or claim ownership of a shared server.
 
 In parallel, the highest-value evidence foundations remain:
 

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -26,13 +26,19 @@ from spotter.budget import (
 from spotter.codex import CodexAdapter
 from spotter.config import ConfigurationError, MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.core import SpotterRuntime
-from spotter.daemon import DaemonStatus, ManualServiceManager, RuntimeHealth, ServiceManager
+from spotter.daemon import (
+    DaemonStatus,
+    ManagedServiceManager,
+    ManualServiceManager,
+    RuntimeHealth,
+    ServiceManager,
+)
 from spotter.doctor import FAIL, OK, WARN, worst
 from spotter.doctor import run as run_doctor
 from spotter.experiment import list_forks, results_path, run_experiment, summarize
 from spotter.gates import Gate
 from spotter.hook import journal_path, run_hook
-from spotter.integration import IntegrationError, IntegrationManager
+from spotter.integration import IntegrationError, IntegrationManager, IntegrationManifest
 from spotter.labels import LabelError, add_label, valid_session
 from spotter.metrics import Tally, merge, tally_session
 from spotter.paths import secure_dir, spotter_home
@@ -185,8 +191,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command in {"setup", "teardown"}:
         if args.target != "codex":
             parser.error(f"{args.command} requires the codex target")
-        if args.command == "teardown" and args.dry_run:
-            parser.error("--dry-run is only supported by setup")
+        if args.command == "teardown" and (args.dry_run or args.portable):
+            parser.error("--dry-run and --portable are only supported by setup")
         return _integration_main(
             args.command,
             config_path=args.config,
@@ -567,7 +573,19 @@ def _doctor_main(config_path: Path | None) -> int:
 
 
 def _daemon_main(action: str, manager: ServiceManager | None = None) -> int:
-    service = manager or ManualServiceManager()
+    if manager is not None:
+        service = manager
+    else:
+        try:
+            manifest = IntegrationManifest.load(spotter_home() / "integrations" / "codex.json")
+        except IntegrationError as error:
+            print(f"spotterd: unavailable ({error})", file=sys.stderr)
+            return 1
+        service = (
+            ManagedServiceManager()
+            if manifest is not None and manifest.runtime_mode == "managed"
+            else ManualServiceManager()
+        )
 
     async def run() -> DaemonStatus:
         operations = {
@@ -613,10 +631,7 @@ def _integration_main(
                 return 0
             manifest = integration.setup()
             print(f"Codex integration: {manifest.state} ({integration.manifest_path})")
-            print(
-                "launch with the selected external App Server: "
-                f"codex --remote {manifest.app_server_endpoint}"
-            )
+            print("App Server endpoint: pending runtime integration (#85/#87)")
             return 0
         removed = integration.teardown()
         print("Codex integration removed" if removed else "Codex integration not configured")

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -32,6 +32,7 @@ from spotter.doctor import run as run_doctor
 from spotter.experiment import list_forks, results_path, run_experiment, summarize
 from spotter.gates import Gate
 from spotter.hook import journal_path, run_hook
+from spotter.integration import IntegrationError, IntegrationManager
 from spotter.labels import LabelError, add_label, valid_session
 from spotter.metrics import Tally, merge, tally_session
 from spotter.paths import secure_dir, spotter_home
@@ -68,6 +69,8 @@ def build_parser() -> argparse.ArgumentParser:
             "status",
             "doctor",
             "daemon",
+            "setup",
+            "teardown",
         ],
         default="observe",
         help=(
@@ -80,14 +83,15 @@ def build_parser() -> argparse.ArgumentParser:
             "metrics: gate FP rate, reviewer precision and observability ceiling from labels; "
             "status: what Spotter is storing, and whether it is actually running; "
             "doctor: verify supervision end to end (non-zero exit when broken); "
-            "daemon: manually start, stop, restart, or inspect spotterd"
+            "daemon: manually start, stop, restart, or inspect spotterd; "
+            "setup/teardown: manage the owned Codex integration"
         ),
     )
     parser.add_argument(
-        "daemon_action",
+        "target",
         nargs="?",
-        choices=["start", "stop", "restart", "status"],
-        help="daemon lifecycle action",
+        choices=["start", "stop", "restart", "status", "codex"],
+        help="daemon lifecycle action or integration target",
     )
     parser.add_argument("--config", type=Path, help="path to Spotter TOML config")
     parser.add_argument("--session", help="session id (fork; analyze filters to it)")
@@ -142,6 +146,14 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="experiment: keep forked worktrees (rollouts are always retained)",
     )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="setup: inspect and print the mutation plan"
+    )
+    parser.add_argument(
+        "--portable",
+        action="store_true",
+        help="setup: start spotterd without registering a login service",
+    )
     return parser
 
 
@@ -167,11 +179,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _hook_main(None, args.config)
 
     if args.command == "daemon":
-        if args.daemon_action is None:
+        if args.target is None or args.target == "codex":
             parser.error("daemon requires start, stop, restart, or status")
-        return _daemon_main(args.daemon_action)
-    if args.daemon_action is not None:
-        parser.error("daemon lifecycle actions require the daemon command")
+        return _daemon_main(args.target)
+    if args.command in {"setup", "teardown"}:
+        if args.target != "codex":
+            parser.error(f"{args.command} requires the codex target")
+        if args.command == "teardown" and args.dry_run:
+            parser.error("--dry-run is only supported by setup")
+        return _integration_main(
+            args.command,
+            config_path=args.config,
+            portable=args.portable,
+            dry_run=args.dry_run,
+        )
+    if args.target is not None:
+        parser.error("the second positional argument requires daemon, setup, or teardown")
+    if args.dry_run or args.portable:
+        parser.error("--dry-run and --portable require setup")
 
     config = _load_config(parser, args.config)
     # One boundary check for every command that names a session: sanitizing
@@ -566,6 +591,39 @@ def _daemon_main(action: str, manager: ServiceManager | None = None) -> int:
     if action == "stop":
         return 0 if status.health == RuntimeHealth.UNAVAILABLE else 1
     return 0 if status.health == RuntimeHealth.HEALTHY else 1
+
+
+def _integration_main(
+    action: str,
+    *,
+    config_path: Path | None,
+    portable: bool,
+    dry_run: bool,
+    manager: IntegrationManager | None = None,
+) -> int:
+    """Install or remove the owned Codex integration transactionally."""
+    try:
+        integration = manager or IntegrationManager(portable=portable, config_path=config_path)
+        if action == "setup":
+            plan = integration.plan()
+            for line in plan.lines():
+                print(line)
+            if dry_run:
+                print("dry-run: no changes made")
+                return 0
+            manifest = integration.setup()
+            print(f"Codex integration: {manifest.state} ({integration.manifest_path})")
+            print(
+                "launch with the selected external App Server: "
+                f"codex --remote {manifest.app_server_endpoint}"
+            )
+            return 0
+        removed = integration.teardown()
+        print("Codex integration removed" if removed else "Codex integration not configured")
+        return 0
+    except IntegrationError as error:
+        print(f"Codex integration failed: {error}", file=sys.stderr)
+        return 1
 
 
 def _status_main() -> int:

--- a/src/spotter/daemon.py
+++ b/src/spotter/daemon.py
@@ -473,12 +473,15 @@ class ManagedServiceManager:
                     "StandardErrorPath": str(logs / "spotterd.log"),
                 }
             )
-        command = " ".join(json.dumps(part) for part in self._program())
+        # ponytail: this handles systemd specifier expansion for ordinary paths; use a
+        # dedicated systemd escaping helper if arbitrary control characters are supported.
+        command = " ".join(json.dumps(part.replace("%", "%%")) for part in self._program())
+        environment = json.dumps(f"SPOTTER_HOME={home}".replace("%", "%%"))
         return (
             "[Unit]\nDescription=Spotter supervision runtime\n\n"
             "[Service]\nType=simple\n"
             f"ExecStart={command}\n"
-            f"Environment={json.dumps(f'SPOTTER_HOME={home}')}\n"
+            f"Environment={environment}\n"
             "Restart=on-failure\n\n"
             "[Install]\nWantedBy=default.target\n"
         ).encode()

--- a/src/spotter/daemon.py
+++ b/src/spotter/daemon.py
@@ -5,6 +5,8 @@ import asyncio
 import hashlib
 import json
 import os
+import plistlib
+import shutil
 import stat
 import subprocess
 import sys
@@ -353,6 +355,8 @@ class ServiceManager(Protocol):
 
     async def status(self) -> DaemonStatus: ...
 
+    async def uninstall(self) -> DaemonStatus: ...
+
 
 class ManualServiceManager:
     """Portable process lifecycle used by explicit CLI escape hatches."""
@@ -418,6 +422,172 @@ class ManualServiceManager:
         if stopped.available:
             return stopped
         return await self.start()
+
+    async def uninstall(self) -> DaemonStatus:
+        return await self.stop()
+
+
+class ManagedServiceManager:
+    """Install and control a login-scoped launchd or systemd user service."""
+
+    LABEL = "dev.spotter.runtime"
+
+    def __init__(
+        self,
+        socket_path: Path | None = None,
+        *,
+        platform: str | None = None,
+        registration_path: Path | None = None,
+        executable: str | None = None,
+    ) -> None:
+        self.socket_path = socket_path or runtime_socket()
+        self.client = DaemonClient(self.socket_path)
+        self.platform = platform or sys.platform
+        self.executable = executable or shutil.which("spotterd")
+        if registration_path is not None:
+            self.registration_path = registration_path
+        elif self.platform == "darwin":
+            self.registration_path = Path.home() / "Library/LaunchAgents" / f"{self.LABEL}.plist"
+        elif self.platform.startswith("linux"):
+            self.registration_path = Path.home() / ".config/systemd/user" / "spotterd.service"
+        else:
+            raise DaemonError(f"managed services are unsupported on {self.platform}")
+
+    def _program(self) -> list[str]:
+        if self.executable:
+            return [self.executable]
+        return [sys.executable, "-m", "spotter.daemon"]
+
+    def _definition(self) -> bytes:
+        home = secure_dir(spotter_home())
+        logs = secure_dir(home / "logs")
+        if self.platform == "darwin":
+            return plistlib.dumps(
+                {
+                    "Label": self.LABEL,
+                    "ProgramArguments": self._program(),
+                    "RunAtLoad": True,
+                    "KeepAlive": True,
+                    "EnvironmentVariables": {"SPOTTER_HOME": str(home)},
+                    "StandardOutPath": str(logs / "spotterd.log"),
+                    "StandardErrorPath": str(logs / "spotterd.log"),
+                }
+            )
+        command = " ".join(json.dumps(part) for part in self._program())
+        return (
+            "[Unit]\nDescription=Spotter supervision runtime\n\n"
+            "[Service]\nType=simple\n"
+            f"ExecStart={command}\n"
+            f"Environment={json.dumps(f'SPOTTER_HOME={home}')}\n"
+            "Restart=on-failure\n\n"
+            "[Install]\nWantedBy=default.target\n"
+        ).encode()
+
+    def _install_definition(self) -> bool:
+        content = self._definition()
+        if self.registration_path.exists() and self.registration_path.read_bytes() == content:
+            return False
+        self.registration_path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.registration_path.with_suffix(self.registration_path.suffix + ".tmp")
+        temporary.write_bytes(content)
+        temporary.chmod(0o600)
+        os.replace(temporary, self.registration_path)
+        return True
+
+    @staticmethod
+    def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(command, capture_output=True, text=True, check=False)
+
+    def _service_error(self, result: subprocess.CompletedProcess[str]) -> DaemonStatus:
+        detail = (result.stderr or result.stdout or "service command failed").strip()[:300]
+        return DaemonStatus(RuntimeHealth.UNAVAILABLE, detail=detail)
+
+    async def _wait_ready(self) -> DaemonStatus:
+        deadline = asyncio.get_running_loop().time() + START_TIMEOUT
+        while asyncio.get_running_loop().time() < deadline:
+            status = await self.status()
+            if status.available:
+                return status
+            await asyncio.sleep(0.05)
+        return DaemonStatus(
+            RuntimeHealth.UNAVAILABLE, detail="managed spotterd did not become ready"
+        )
+
+    async def status(self) -> DaemonStatus:
+        return await self.client.status()
+
+    async def start(self) -> DaemonStatus:
+        current = await self.status()
+        if self.platform == "darwin":
+            domain = f"gui/{os.getuid()}"
+            loaded = self._run(["launchctl", "print", f"{domain}/{self.LABEL}"]).returncode == 0
+            if current.available and not loaded:
+                return DaemonStatus(
+                    RuntimeHealth.DEGRADED,
+                    pid=current.pid,
+                    detail="spotterd is running outside the managed launchd service; stop it first",
+                )
+            changed = self._install_definition()
+            if loaded and changed:
+                self._run(["launchctl", "bootout", f"{domain}/{self.LABEL}"])
+                loaded = False
+            if not loaded:
+                result = self._run(["launchctl", "bootstrap", domain, str(self.registration_path)])
+            else:
+                if current.available:
+                    return current
+                result = self._run(["launchctl", "kickstart", "-k", f"{domain}/{self.LABEL}"])
+        else:
+            active = (
+                self._run(["systemctl", "--user", "is-active", "spotterd.service"]).returncode == 0
+            )
+            if current.available and not active:
+                return DaemonStatus(
+                    RuntimeHealth.DEGRADED,
+                    pid=current.pid,
+                    detail="spotterd is running outside the managed systemd service; stop it first",
+                )
+            changed = self._install_definition()
+            if changed:
+                result = self._run(["systemctl", "--user", "daemon-reload"])
+                if result.returncode != 0:
+                    return self._service_error(result)
+            if active:
+                if current.available and not changed:
+                    return current
+                result = self._run(["systemctl", "--user", "restart", "spotterd.service"])
+            else:
+                result = self._run(["systemctl", "--user", "enable", "--now", "spotterd.service"])
+        if result.returncode != 0:
+            return self._service_error(result)
+        return await self._wait_ready()
+
+    async def stop(self) -> DaemonStatus:
+        if self.platform == "darwin":
+            result = self._run(["launchctl", "bootout", f"gui/{os.getuid()}/{self.LABEL}"])
+        else:
+            result = self._run(["systemctl", "--user", "stop", "spotterd.service"])
+        if result.returncode != 0 and (await self.status()).available:
+            return self._service_error(result)
+        return DaemonStatus(RuntimeHealth.UNAVAILABLE, detail="stopped")
+
+    async def restart(self) -> DaemonStatus:
+        await self.stop()
+        return await self.start()
+
+    async def uninstall(self) -> DaemonStatus:
+        if self.platform.startswith("linux"):
+            stopped = self._run(["systemctl", "--user", "disable", "--now", "spotterd.service"])
+            if stopped.returncode != 0 and (await self.status()).available:
+                return self._service_error(stopped)
+        else:
+            status = await self.stop()
+            if status.health != RuntimeHealth.UNAVAILABLE:
+                return status
+        self.registration_path.unlink(missing_ok=True)
+        if self.platform.startswith("linux"):
+            self._run(["systemctl", "--user", "daemon-reload"])
+        return DaemonStatus(RuntimeHealth.UNAVAILABLE, detail="service removed")
 
 
 def _secure_runtime_dir(path: Path) -> None:

--- a/src/spotter/integration.py
+++ b/src/spotter/integration.py
@@ -1,0 +1,575 @@
+"""Transactional Codex integration ownership and migration."""
+
+import asyncio
+import copy
+import hashlib
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tomllib
+from collections.abc import Callable
+from contextlib import suppress
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from fcntl import LOCK_EX, LOCK_UN, flock
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, cast
+
+from spotter.config import ConfigurationError, SpotterConfig
+from spotter.daemon import (
+    ManagedServiceManager,
+    ManualServiceManager,
+    RuntimeHealth,
+    ServiceManager,
+    runtime_socket,
+)
+from spotter.doctor import OK, check_roundtrip
+from spotter.paths import secure_dir, spotter_home
+
+MANIFEST_SCHEMA = 1
+
+
+class IntegrationError(RuntimeError):
+    """The requested integration transaction could not complete safely."""
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _fingerprint(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _package_version() -> str:
+    try:
+        return version("spotter-agent")
+    except PackageNotFoundError:
+        return "0+source"
+
+
+def _atomic_write(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_bytes(content)
+    temporary.chmod(0o600)
+    os.replace(temporary, path)
+
+
+@dataclass(frozen=True)
+class CodexInstall:
+    path: str
+    version: str
+    supports_remote: bool
+    supports_app_server: bool
+
+    @classmethod
+    def detect(cls, path: str | None = None) -> "CodexInstall":
+        executable = path or shutil.which("codex")
+        if executable is None:
+            raise IntegrationError("Codex is not installed or is not on PATH")
+
+        def output(arguments: list[str]) -> str:
+            try:
+                result = subprocess.run(
+                    [executable, *arguments],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    check=False,
+                )
+            except (OSError, subprocess.SubprocessError) as error:
+                raise IntegrationError(f"could not inspect Codex: {error}") from error
+            if result.returncode != 0:
+                raise IntegrationError((result.stderr or "Codex inspection failed").strip())
+            return result.stdout
+
+        detected_version = output(["--version"]).strip()
+        root_help = output(["--help"])
+        app_server_help = output(["app-server", "--help"])
+        return cls(
+            path=executable,
+            version=detected_version,
+            supports_remote="--remote" in root_help,
+            supports_app_server="--listen" in app_server_help,
+        )
+
+    def remove_plugin(self, selector: str, codex_home: Path) -> None:
+        result = subprocess.run(
+            [self.path, "plugin", "remove", selector, "--json"],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "CODEX_HOME": str(codex_home)},
+            timeout=30,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise IntegrationError(
+                f"could not remove legacy plugin {selector}: "
+                f"{(result.stderr or result.stdout).strip()[:300]}"
+            )
+
+    def add_plugin(self, selector: str, codex_home: Path) -> None:
+        try:
+            result = subprocess.run(
+                [self.path, "plugin", "add", selector, "--json"],
+                capture_output=True,
+                text=True,
+                env={**os.environ, "CODEX_HOME": str(codex_home)},
+                timeout=30,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as error:
+            raise IntegrationError(
+                f"could not restore legacy plugin {selector}: {error}"
+            ) from error
+        if result.returncode != 0:
+            raise IntegrationError(
+                f"could not restore legacy plugin {selector}: "
+                f"{(result.stderr or result.stdout).strip()[:300]}"
+            )
+
+
+@dataclass(frozen=True)
+class IntegrationManifest:
+    schema: int
+    state: str
+    agent: str
+    setup_by: str
+    agent_path: str
+    agent_version: str
+    codex_home: str
+    app_server_strategy: str
+    app_server_endpoint: str
+    runtime_mode: str
+    service_registration: str | None
+    service_owned: bool
+    hooks_file: str
+    hooks_file_created: bool
+    owned_hook: dict[str, Any]
+    legacy_hooks_removed: list[dict[str, Any]] = field(default_factory=list)
+    legacy_plugins_removed: list[str] = field(default_factory=list)
+    config_fingerprint_before: str | None = None
+    config_fingerprint_after: str | None = None
+    hooks_fingerprint_before: str | None = None
+    hooks_fingerprint_after: str | None = None
+    backup_paths: list[str] = field(default_factory=list)
+    created_at: str = field(default_factory=_now)
+    updated_at: str = field(default_factory=_now)
+    error: str | None = None
+
+    @classmethod
+    def load(cls, path: Path) -> "IntegrationManifest | None":
+        if not path.exists():
+            return None
+        try:
+            raw = json.loads(path.read_bytes())
+        except (OSError, ValueError) as error:
+            raise IntegrationError(f"integration manifest is unreadable: {error}") from error
+        if not isinstance(raw, dict):
+            raise IntegrationError("integration manifest must be a JSON object")
+        if raw.get("schema") != MANIFEST_SCHEMA:
+            raise IntegrationError(f"unsupported integration manifest schema {raw.get('schema')!r}")
+        try:
+            return cls(**raw)
+        except TypeError as error:
+            raise IntegrationError(f"integration manifest is invalid: {error}") from error
+
+    def save(self, path: Path) -> None:
+        _atomic_write(path, (json.dumps(asdict(self), indent=2, sort_keys=True) + "\n").encode())
+
+
+@dataclass(frozen=True)
+class IntegrationPlan:
+    hooks_file: Path
+    hooks_changed: bool
+    legacy_hooks: int
+    legacy_plugins: tuple[str, ...]
+    runtime_mode: str
+    service_registration: str | None
+    app_server_endpoint: str
+
+    def lines(self) -> list[str]:
+        return [
+            "Codex hooks: "
+            f"{'update' if self.hooks_changed else 'already current'} {self.hooks_file}",
+            f"Legacy Spotter hooks to migrate: {self.legacy_hooks}",
+            f"Legacy Spotter plugins to remove: {len(self.legacy_plugins)}",
+            f"Runtime: {self.runtime_mode}",
+            f"App Server: explicit remote ({self.app_server_endpoint})",
+        ]
+
+
+class IntegrationManager:
+    """Own exactly the Codex fragments recorded in the integration manifest."""
+
+    def __init__(
+        self,
+        *,
+        codex_home: Path | None = None,
+        codex: CodexInstall | None = None,
+        service: ServiceManager | None = None,
+        portable: bool = False,
+        spotter_executable: str | None = None,
+        config_path: Path | None = None,
+        verifier: Callable[[Path | None], bool] | None = None,
+    ) -> None:
+        self.codex_home = codex_home or Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+        self.codex = codex or CodexInstall.detect()
+        self._service_explicit = service is not None
+        self.service = service or (ManualServiceManager() if portable else ManagedServiceManager())
+        self.portable = portable
+        self.spotter_executable = spotter_executable or shutil.which("spotter")
+        default_config = spotter_home() / "spotter.toml"
+        self.config_path = config_path or (default_config if default_config.exists() else None)
+        self.verifier = verifier or (lambda path: check_roundtrip(path).status == OK)
+        integrations = spotter_home() / "integrations"
+        self.manifest_path = integrations / "codex.json"
+        self.lock_path = integrations / "codex.lock"
+        self.hooks_path = self.codex_home / "hooks.json"
+        self.codex_config_path = self.codex_home / "config.toml"
+
+    def _hook_command(self) -> str:
+        if self.spotter_executable:
+            executable = shlex.quote(self.spotter_executable)
+            command = f"[ -x {executable} ] && {executable} hook"
+        else:
+            python = shlex.quote(sys.executable)
+            command = f"[ -x {python} ] && {python} -m spotter hook"
+        if self.config_path is not None:
+            command += f" --config {shlex.quote(str(self.config_path))}"
+        return command + " || true"
+
+    def _owned_hook(self) -> dict[str, Any]:
+        return {
+            "event": "PreToolUse",
+            "matcher": ".*",
+            "hook": {"type": "command", "command": self._hook_command()},
+        }
+
+    @staticmethod
+    def _is_spotter_hook(hook: object) -> bool:
+        if not isinstance(hook, dict) or not isinstance(hook.get("command"), str):
+            return False
+        command = cast(str, hook["command"])
+        try:
+            tokens = shlex.split(command)
+        except ValueError:
+            return False
+        for index, token in enumerate(tokens):
+            name = Path(token).name
+            if name == "spotter-hook":
+                return True
+            if name == "spotter" and index + 1 < len(tokens) and tokens[index + 1] == "hook":
+                return True
+        return False
+
+    def _read_hooks(self) -> tuple[dict[str, Any], bytes | None]:
+        if not self.hooks_path.exists():
+            return {"hooks": {}}, None
+        content = self.hooks_path.read_bytes()
+        try:
+            raw = json.loads(content)
+        except ValueError as error:
+            raise IntegrationError(f"Codex hooks file is invalid JSON: {error}") from error
+        if not isinstance(raw, dict) or not isinstance(raw.get("hooks", {}), dict):
+            raise IntegrationError("Codex hooks file has an unsupported shape")
+        for event, groups in cast(dict[str, object], raw.get("hooks", {})).items():
+            if not isinstance(event, str) or not isinstance(groups, list):
+                raise IntegrationError("Codex hooks file has an unsupported event shape")
+            for group in groups:
+                if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
+                    raise IntegrationError("Codex hooks file has an unsupported hook group")
+        return cast(dict[str, Any], raw), content
+
+    def _migrate_hooks(self, raw: dict[str, Any]) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        updated = copy.deepcopy(raw)
+        events = cast(dict[str, list[dict[str, Any]]], updated.setdefault("hooks", {}))
+        removed: list[dict[str, Any]] = []
+        owned = self._owned_hook()
+        for event, groups in list(events.items()):
+            kept_groups: list[dict[str, Any]] = []
+            for group in groups:
+                kept_hooks = []
+                for hook in cast(list[dict[str, Any]], group["hooks"]):
+                    if self._is_spotter_hook(hook):
+                        if (event, group.get("matcher"), hook) != (
+                            owned["event"],
+                            owned["matcher"],
+                            owned["hook"],
+                        ):
+                            removed.append(
+                                {"event": event, "matcher": group.get("matcher"), "hook": hook}
+                            )
+                    else:
+                        kept_hooks.append(hook)
+                if kept_hooks:
+                    group["hooks"] = kept_hooks
+                    kept_groups.append(group)
+            if kept_groups:
+                events[event] = kept_groups
+            else:
+                events.pop(event, None)
+
+        events.setdefault("PreToolUse", []).append(
+            {"matcher": owned["matcher"], "hooks": [owned["hook"]]}
+        )
+        return updated, removed
+
+    def _legacy_plugins(self) -> tuple[str, ...]:
+        if not self.codex_config_path.exists():
+            return ()
+        try:
+            raw = tomllib.loads(self.codex_config_path.read_text())
+        except (OSError, tomllib.TOMLDecodeError) as error:
+            raise IntegrationError(f"Codex config is unreadable: {error}") from error
+        plugins = raw.get("plugins", {})
+        if not isinstance(plugins, dict):
+            raise IntegrationError("Codex plugin config has an unsupported shape")
+        return tuple(
+            sorted(name for name in plugins if name == "spotter" or name.startswith("spotter@"))
+        )
+
+    def _service_registration(self) -> str | None:
+        path = getattr(self.service, "registration_path", None)
+        return str(path) if isinstance(path, Path) else None
+
+    def inspect(
+        self,
+    ) -> tuple[IntegrationPlan, dict[str, Any], bytes | None, list[dict[str, Any]]]:
+        if not self.codex.supports_remote or not self.codex.supports_app_server:
+            raise IntegrationError("Codex lacks the required app-server/--remote capability")
+        if self.config_path is not None:
+            try:
+                SpotterConfig.from_toml(self.config_path)
+            except (OSError, tomllib.TOMLDecodeError, ConfigurationError) as error:
+                raise IntegrationError(f"Spotter config is unusable: {error}") from error
+        hooks, before = self._read_hooks()
+        migrated, removed = self._migrate_hooks(hooks)
+        after = (json.dumps(migrated, indent=2, sort_keys=True) + "\n").encode()
+        endpoint = f"unix://{runtime_socket().with_name('codex-app-server.sock')}"
+        plan = IntegrationPlan(
+            hooks_file=self.hooks_path,
+            hooks_changed=before != after,
+            legacy_hooks=len(removed),
+            legacy_plugins=self._legacy_plugins(),
+            runtime_mode="portable" if self.portable else "managed",
+            service_registration=self._service_registration(),
+            app_server_endpoint=endpoint,
+        )
+        return plan, migrated, before, removed
+
+    def plan(self) -> IntegrationPlan:
+        return self.inspect()[0]
+
+    def _backup(self, name: str, content: bytes | None) -> Path | None:
+        if content is None:
+            return None
+        backups = secure_dir(spotter_home() / "backups")
+        path = backups / f"{name}-{_fingerprint(content)[:12]}.bak"
+        if not path.exists():
+            _atomic_write(path, content)
+        return path
+
+    def _write_hooks(self, hooks: dict[str, Any]) -> bytes:
+        content = (json.dumps(hooks, indent=2, sort_keys=True) + "\n").encode()
+        _atomic_write(self.hooks_path, content)
+        return content
+
+    def _verify(self, owned: dict[str, Any]) -> None:
+        status = asyncio.run(self.service.status())
+        if status.health != RuntimeHealth.HEALTHY:
+            raise IntegrationError(
+                f"spotterd verification failed: {status.detail or status.health}"
+            )
+        current, _ = self._read_hooks()
+        matches = []
+        for event, groups in cast(dict[str, list[dict[str, Any]]], current["hooks"]).items():
+            for group in groups:
+                for hook in cast(list[dict[str, Any]], group["hooks"]):
+                    if self._is_spotter_hook(hook):
+                        matches.append((event, group.get("matcher"), hook))
+        if matches != [(owned["event"], owned["matcher"], owned["hook"])]:
+            raise IntegrationError(
+                "Codex Hook verification found duplicate or drifted Spotter hooks"
+            )
+        if not self.verifier(self.config_path):
+            raise IntegrationError("synthetic Hook round-trip failed")
+
+    def setup(self) -> IntegrationManifest:
+        secure_dir(self.lock_path.parent)
+        lock = self.lock_path.open("a+")
+        flock(lock, LOCK_EX)
+        try:
+            existing = IntegrationManifest.load(self.manifest_path)
+            plan, hooks, hooks_before, removed_hooks = self.inspect()
+            hooks_after = (json.dumps(hooks, indent=2, sort_keys=True) + "\n").encode()
+            config_before = (
+                self.codex_config_path.read_bytes() if self.codex_config_path.exists() else None
+            )
+            backups = [
+                path
+                for path in (
+                    self._backup("codex-hooks", hooks_before),
+                    self._backup("codex-config", config_before) if plan.legacy_plugins else None,
+                )
+                if path is not None
+            ]
+            service_preexisting = existing is not None and existing.state == "ready"
+            service_was_running = asyncio.run(self.service.status()).available
+            config_after = config_before
+            removed_plugins: list[str] = []
+
+            def rollback() -> None:
+                if hooks_before is None:
+                    self.hooks_path.unlink(missing_ok=True)
+                else:
+                    _atomic_write(self.hooks_path, hooks_before)
+                for selector in reversed(removed_plugins):
+                    with suppress(Exception):
+                        self.codex.add_plugin(selector, self.codex_home)
+                if config_before is not None:
+                    _atomic_write(self.codex_config_path, config_before)
+                if not service_preexisting and not service_was_running:
+                    with suppress(Exception):
+                        asyncio.run(self.service.uninstall())
+
+            try:
+                if hooks_before != hooks_after:
+                    self._write_hooks(hooks)
+                for selector in plan.legacy_plugins:
+                    self.codex.remove_plugin(selector, self.codex_home)
+                    removed_plugins.append(selector)
+                config_after = (
+                    self.codex_config_path.read_bytes() if self.codex_config_path.exists() else None
+                )
+                started = asyncio.run(self.service.start())
+                if started.health != RuntimeHealth.HEALTHY:
+                    raise IntegrationError(
+                        f"spotterd failed to start: {started.detail or started.health}"
+                    )
+                owned = self._owned_hook()
+                self._verify(owned)
+            except Exception as error:
+                rollback()
+                raise IntegrationError(f"setup rolled back: {error}") from error
+
+            previous_hooks = existing.legacy_hooks_removed if existing else []
+            previous_plugins = existing.legacy_plugins_removed if existing else []
+            manifest = IntegrationManifest(
+                schema=MANIFEST_SCHEMA,
+                state="ready",
+                agent="codex",
+                setup_by=_package_version(),
+                agent_path=self.codex.path,
+                agent_version=self.codex.version,
+                codex_home=str(self.codex_home),
+                app_server_strategy="explicit-remote",
+                app_server_endpoint=plan.app_server_endpoint,
+                runtime_mode=plan.runtime_mode,
+                service_registration=plan.service_registration,
+                service_owned=(
+                    existing.service_owned
+                    if existing
+                    else (not service_was_running or not self.portable)
+                ),
+                hooks_file=str(self.hooks_path),
+                hooks_file_created=(
+                    hooks_before is None if existing is None else existing.hooks_file_created
+                ),
+                owned_hook=self._owned_hook(),
+                legacy_hooks_removed=previous_hooks + removed_hooks,
+                legacy_plugins_removed=list(
+                    dict.fromkeys([*previous_plugins, *plan.legacy_plugins])
+                ),
+                config_fingerprint_before=(
+                    existing.config_fingerprint_before
+                    if existing
+                    else (_fingerprint(config_before) if config_before is not None else None)
+                ),
+                config_fingerprint_after=(
+                    _fingerprint(config_after) if config_after is not None else None
+                ),
+                hooks_fingerprint_before=(
+                    existing.hooks_fingerprint_before
+                    if existing
+                    else (_fingerprint(hooks_before) if hooks_before is not None else None)
+                ),
+                hooks_fingerprint_after=_fingerprint(hooks_after),
+                backup_paths=list(
+                    dict.fromkeys(
+                        [
+                            *(existing.backup_paths if existing else []),
+                            *(str(path) for path in backups),
+                        ]
+                    )
+                ),
+                created_at=existing.created_at if existing else _now(),
+                updated_at=_now(),
+            )
+            try:
+                manifest.save(self.manifest_path)
+            except Exception as error:
+                rollback()
+                raise IntegrationError(f"setup rolled back: {error}") from error
+            return manifest
+        finally:
+            flock(lock, LOCK_UN)
+            lock.close()
+
+    def teardown(self) -> bool:
+        if not self.manifest_path.exists():
+            return False
+        secure_dir(self.lock_path.parent)
+        lock = self.lock_path.open("a+")
+        flock(lock, LOCK_EX)
+        try:
+            manifest = IntegrationManifest.load(self.manifest_path)
+            if manifest is None:
+                return False
+            if not self._service_explicit:
+                self.service = (
+                    ManualServiceManager()
+                    if manifest.runtime_mode == "portable"
+                    else ManagedServiceManager()
+                )
+            hooks, before = self._read_hooks()
+            owned = manifest.owned_hook
+            events = cast(dict[str, list[dict[str, Any]]], hooks["hooks"])
+            groups = events.get(cast(str, owned["event"]), [])
+            kept_groups = []
+            for group in groups:
+                kept = [hook for hook in group["hooks"] if hook != owned["hook"]]
+                if kept:
+                    group["hooks"] = kept
+                    kept_groups.append(group)
+            if kept_groups:
+                events[cast(str, owned["event"])] = kept_groups
+            else:
+                events.pop(cast(str, owned["event"]), None)
+            try:
+                if manifest.hooks_file_created and hooks == {"hooks": {}}:
+                    self.hooks_path.unlink(missing_ok=True)
+                else:
+                    self._write_hooks(hooks)
+                if manifest.service_owned:
+                    stopped = asyncio.run(self.service.uninstall())
+                    if stopped.health != RuntimeHealth.UNAVAILABLE:
+                        raise IntegrationError(
+                            f"managed service removal failed: {stopped.detail or stopped.health}"
+                        )
+            except Exception as error:
+                if before is None:
+                    self.hooks_path.unlink(missing_ok=True)
+                else:
+                    _atomic_write(self.hooks_path, before)
+                raise IntegrationError(f"teardown rolled back: {error}") from error
+            self.manifest_path.unlink()
+            return True
+        finally:
+            flock(lock, LOCK_UN)
+            lock.close()

--- a/src/spotter/integration.py
+++ b/src/spotter/integration.py
@@ -25,7 +25,6 @@ from spotter.daemon import (
     ManualServiceManager,
     RuntimeHealth,
     ServiceManager,
-    runtime_socket,
 )
 from spotter.doctor import OK, check_roundtrip
 from spotter.paths import secure_dir, spotter_home
@@ -144,7 +143,7 @@ class IntegrationManifest:
     agent_version: str
     codex_home: str
     app_server_strategy: str
-    app_server_endpoint: str
+    app_server_endpoint: str | None
     runtime_mode: str
     service_registration: str | None
     service_owned: bool
@@ -191,7 +190,7 @@ class IntegrationPlan:
     legacy_plugins: tuple[str, ...]
     runtime_mode: str
     service_registration: str | None
-    app_server_endpoint: str
+    app_server_endpoint: str | None
 
     def lines(self) -> list[str]:
         return [
@@ -200,7 +199,7 @@ class IntegrationPlan:
             f"Legacy Spotter hooks to migrate: {self.legacy_hooks}",
             f"Legacy Spotter plugins to remove: {len(self.legacy_plugins)}",
             f"Runtime: {self.runtime_mode}",
-            f"App Server: explicit remote ({self.app_server_endpoint})",
+            "App Server: pending external endpoint (#85/#87)",
         ]
 
 
@@ -219,7 +218,7 @@ class IntegrationManager:
         verifier: Callable[[Path | None], bool] | None = None,
     ) -> None:
         self.codex_home = codex_home or Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
-        self.codex = codex or CodexInstall.detect()
+        self.codex = codex
         self._service_explicit = service is not None
         self.service = service or (ManualServiceManager() if portable else ManagedServiceManager())
         self.portable = portable
@@ -232,6 +231,11 @@ class IntegrationManager:
         self.lock_path = integrations / "codex.lock"
         self.hooks_path = self.codex_home / "hooks.json"
         self.codex_config_path = self.codex_home / "config.toml"
+
+    def _codex_install(self) -> CodexInstall:
+        if self.codex is None:
+            self.codex = CodexInstall.detect()
+        return self.codex
 
     def _hook_command(self) -> str:
         if self.spotter_executable:
@@ -341,7 +345,8 @@ class IntegrationManager:
     def inspect(
         self,
     ) -> tuple[IntegrationPlan, dict[str, Any], bytes | None, list[dict[str, Any]]]:
-        if not self.codex.supports_remote or not self.codex.supports_app_server:
+        codex = self._codex_install()
+        if not codex.supports_remote or not codex.supports_app_server:
             raise IntegrationError("Codex lacks the required app-server/--remote capability")
         if self.config_path is not None:
             try:
@@ -351,7 +356,6 @@ class IntegrationManager:
         hooks, before = self._read_hooks()
         migrated, removed = self._migrate_hooks(hooks)
         after = (json.dumps(migrated, indent=2, sort_keys=True) + "\n").encode()
-        endpoint = f"unix://{runtime_socket().with_name('codex-app-server.sock')}"
         plan = IntegrationPlan(
             hooks_file=self.hooks_path,
             hooks_changed=before != after,
@@ -359,7 +363,7 @@ class IntegrationManager:
             legacy_plugins=self._legacy_plugins(),
             runtime_mode="portable" if self.portable else "managed",
             service_registration=self._service_registration(),
-            app_server_endpoint=endpoint,
+            app_server_endpoint=None,
         )
         return plan, migrated, before, removed
 
@@ -407,6 +411,7 @@ class IntegrationManager:
         try:
             existing = IntegrationManifest.load(self.manifest_path)
             plan, hooks, hooks_before, removed_hooks = self.inspect()
+            codex = self._codex_install()
             hooks_after = (json.dumps(hooks, indent=2, sort_keys=True) + "\n").encode()
             config_before = (
                 self.codex_config_path.read_bytes() if self.codex_config_path.exists() else None
@@ -431,7 +436,7 @@ class IntegrationManager:
                     _atomic_write(self.hooks_path, hooks_before)
                 for selector in reversed(removed_plugins):
                     with suppress(Exception):
-                        self.codex.add_plugin(selector, self.codex_home)
+                        codex.add_plugin(selector, self.codex_home)
                 if config_before is not None:
                     _atomic_write(self.codex_config_path, config_before)
                 if not service_preexisting and not service_was_running:
@@ -442,7 +447,7 @@ class IntegrationManager:
                 if hooks_before != hooks_after:
                     self._write_hooks(hooks)
                 for selector in plan.legacy_plugins:
-                    self.codex.remove_plugin(selector, self.codex_home)
+                    codex.remove_plugin(selector, self.codex_home)
                     removed_plugins.append(selector)
                 config_after = (
                     self.codex_config_path.read_bytes() if self.codex_config_path.exists() else None
@@ -465,10 +470,10 @@ class IntegrationManager:
                 state="ready",
                 agent="codex",
                 setup_by=_package_version(),
-                agent_path=self.codex.path,
-                agent_version=self.codex.version,
+                agent_path=codex.path,
+                agent_version=codex.version,
                 codex_home=str(self.codex_home),
-                app_server_strategy="explicit-remote",
+                app_server_strategy="pending-external",
                 app_server_endpoint=plan.app_server_endpoint,
                 runtime_mode=plan.runtime_mode,
                 service_registration=plan.service_registration,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,420 @@
+import asyncio
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from spotter.cli import main
+from spotter.daemon import DaemonStatus, ManagedServiceManager, RuntimeHealth
+from spotter.integration import (
+    CodexInstall,
+    IntegrationError,
+    IntegrationManager,
+    IntegrationManifest,
+)
+
+
+class FakeService:
+    def __init__(self, registration_path: Path) -> None:
+        self.registration_path = registration_path
+        self.health = RuntimeHealth.UNAVAILABLE
+        self.starts = 0
+        self.uninstalls = 0
+
+    async def start(self) -> DaemonStatus:
+        self.starts += 1
+        self.health = RuntimeHealth.HEALTHY
+        return await self.status()
+
+    async def stop(self) -> DaemonStatus:
+        self.health = RuntimeHealth.UNAVAILABLE
+        return await self.status()
+
+    async def restart(self) -> DaemonStatus:
+        await self.stop()
+        return await self.start()
+
+    async def status(self) -> DaemonStatus:
+        return DaemonStatus(self.health)
+
+    async def uninstall(self) -> DaemonStatus:
+        self.uninstalls += 1
+        return await self.stop()
+
+
+class FailingUninstallService(FakeService):
+    async def uninstall(self) -> DaemonStatus:
+        raise OSError("service busy")
+
+
+@pytest.fixture()
+def homes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    spotter_home = tmp_path / "spotter"
+    codex_home = tmp_path / "codex"
+    monkeypatch.setenv("SPOTTER_HOME", str(spotter_home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    return spotter_home, codex_home
+
+
+def _manager(
+    homes: tuple[Path, Path], *, verifier: bool = True
+) -> tuple[IntegrationManager, FakeService]:
+    spotter_home, codex_home = homes
+    service = FakeService(spotter_home / "service/spotterd")
+    manager = IntegrationManager(
+        codex_home=codex_home,
+        codex=CodexInstall("/opt/homebrew/bin/codex", "codex 1.0", True, True),
+        service=service,
+        spotter_executable="/opt/homebrew/bin/spotter",
+        verifier=lambda _: verifier,
+    )
+    return manager, service
+
+
+def _legacy_hooks() -> dict[str, object]:
+    other = {"type": "command", "command": "notify-user"}
+    legacy = {"type": "command", "command": "/plugins/spotter/scripts/spotter-hook"}
+    return {
+        "custom": "preserved",
+        "hooks": {
+            "SessionStart": [{"hooks": [other]}],
+            "UserPromptSubmit": [{"hooks": [legacy]}],
+            "PreToolUse": [{"matcher": ".*", "hooks": [legacy]}],
+            "PostToolUse": [{"matcher": ".*", "hooks": [legacy]}],
+        },
+    }
+
+
+def _spotter_hooks(path: Path) -> list[tuple[str, dict[str, object]]]:
+    raw = json.loads(path.read_text())
+    return [
+        (event, hook)
+        for event, groups in raw["hooks"].items()
+        for group in groups
+        for hook in group["hooks"]
+        if "spotter" in hook["command"]
+    ]
+
+
+def test_setup_is_idempotent_and_teardown_preserves_unowned_config(
+    homes: tuple[Path, Path],
+) -> None:
+    _, codex_home = homes
+    codex_home.mkdir()
+    hooks_path = codex_home / "hooks.json"
+    hooks_path.write_text(json.dumps(_legacy_hooks()))
+    manager, service = _manager(homes)
+
+    first = manager.setup()
+    first_hooks = hooks_path.read_bytes()
+    second = manager.setup()
+
+    assert first.state == second.state == "ready"
+    assert first.created_at == second.created_at
+    assert len(second.legacy_hooks_removed) == 3
+    assert [event for event, _ in _spotter_hooks(hooks_path)] == ["PreToolUse"]
+    assert service.starts == 2
+    assert hooks_path.read_bytes() == first_hooks
+
+    assert manager.teardown()
+    remaining = json.loads(hooks_path.read_text())
+    assert remaining["custom"] == "preserved"
+    assert remaining["hooks"] == {
+        "SessionStart": [{"hooks": [{"command": "notify-user", "type": "command"}]}]
+    }
+    assert service.uninstalls == 1
+    assert not manager.manifest_path.exists()
+
+    manager.setup()
+    assert [event for event, _ in _spotter_hooks(hooks_path)] == ["PreToolUse"]
+
+
+def test_setup_and_teardown_remove_a_hooks_file_created_by_spotter(
+    homes: tuple[Path, Path],
+) -> None:
+    manager, _ = _manager(homes)
+    manifest = manager.setup()
+
+    assert manifest.hooks_file_created
+    assert manager.hooks_path.exists()
+    assert manager.teardown()
+    assert not manager.hooks_path.exists()
+
+
+def test_failed_verification_rolls_back_hooks_service_and_manifest(
+    homes: tuple[Path, Path],
+) -> None:
+    _, codex_home = homes
+    codex_home.mkdir()
+    hooks_path = codex_home / "hooks.json"
+    original = json.dumps(_legacy_hooks()).encode()
+    hooks_path.write_bytes(original)
+    manager, service = _manager(homes, verifier=False)
+
+    with pytest.raises(IntegrationError, match="rolled back"):
+        manager.setup()
+
+    assert hooks_path.read_bytes() == original
+    assert service.uninstalls == 1
+    assert not manager.manifest_path.exists()
+
+
+def test_manifest_commit_failure_rolls_back_applied_mutations(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manager, service = _manager(homes)
+
+    def fail_save(self: IntegrationManifest, path: Path) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(IntegrationManifest, "save", fail_save)
+    with pytest.raises(IntegrationError, match="rolled back"):
+        manager.setup()
+
+    assert not manager.hooks_path.exists()
+    assert service.uninstalls == 1
+    assert not manager.manifest_path.exists()
+
+
+def test_legacy_plugin_migration_is_recorded_and_rolled_back_on_failure(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, codex_home = homes
+    codex_home.mkdir()
+    config = codex_home / "config.toml"
+    original = b'[plugins."spotter@spotter"]\nenabled = true\n'
+    config.write_bytes(original)
+    manager, _ = _manager(homes, verifier=False)
+
+    def remove_plugin(self: CodexInstall, selector: str, home: Path) -> None:
+        assert selector == "spotter@spotter"
+        (home / "config.toml").write_text("")
+
+    monkeypatch.setattr(CodexInstall, "remove_plugin", remove_plugin)
+    with pytest.raises(IntegrationError):
+        manager.setup()
+
+    assert config.read_bytes() == original
+
+
+def test_successful_legacy_plugin_migration_is_recorded(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, codex_home = homes
+    codex_home.mkdir()
+    config = codex_home / "config.toml"
+    config.write_text('[plugins."spotter@spotter"]\nenabled = true\n')
+    manager, _ = _manager(homes)
+
+    def remove_plugin(self: CodexInstall, selector: str, home: Path) -> None:
+        (home / "config.toml").write_text("")
+
+    monkeypatch.setattr(CodexInstall, "remove_plugin", remove_plugin)
+    manifest = manager.setup()
+
+    assert manifest.legacy_plugins_removed == ["spotter@spotter"]
+    assert config.read_text() == ""
+
+
+def test_teardown_keeps_a_user_modified_owned_hook(homes: tuple[Path, Path]) -> None:
+    manager, _ = _manager(homes)
+    manager.setup()
+    raw = json.loads(manager.hooks_path.read_text())
+    raw["hooks"]["PreToolUse"][0]["hooks"][0]["command"] = "user replacement"
+    manager.hooks_path.write_text(json.dumps(raw))
+
+    assert manager.teardown()
+    assert "user replacement" in manager.hooks_path.read_text()
+
+
+def test_setup_preserves_unrelated_commands_that_only_mention_spotter_hook(
+    homes: tuple[Path, Path],
+) -> None:
+    _, codex_home = homes
+    codex_home.mkdir()
+    hooks = {
+        "hooks": {
+            "SessionStart": [
+                {"hooks": [{"type": "command", "command": 'echo "run spotter hook later"'}]}
+            ]
+        }
+    }
+    (codex_home / "hooks.json").write_text(json.dumps(hooks))
+    manager, _ = _manager(homes)
+
+    manager.setup()
+
+    assert "run spotter hook later" in manager.hooks_path.read_text()
+
+
+def test_portable_setup_does_not_claim_a_preexisting_daemon(
+    homes: tuple[Path, Path],
+) -> None:
+    spotter_home, codex_home = homes
+    service = FakeService(spotter_home / "unused")
+    service.health = RuntimeHealth.HEALTHY
+    manager = IntegrationManager(
+        codex_home=codex_home,
+        codex=CodexInstall("/bin/codex", "codex 1.0", True, True),
+        service=service,
+        portable=True,
+        spotter_executable="/bin/spotter",
+        verifier=lambda _: True,
+    )
+
+    manifest = manager.setup()
+    assert not manifest.service_owned
+    assert manager.teardown()
+    assert service.uninstalls == 0
+
+
+def test_teardown_failure_restores_the_owned_hook_and_manifest(
+    homes: tuple[Path, Path],
+) -> None:
+    spotter_home, codex_home = homes
+    service = FailingUninstallService(spotter_home / "service")
+    manager = IntegrationManager(
+        codex_home=codex_home,
+        codex=CodexInstall("/bin/codex", "codex 1.0", True, True),
+        service=service,
+        spotter_executable="/bin/spotter",
+        verifier=lambda _: True,
+    )
+    manager.setup()
+    before = manager.hooks_path.read_bytes()
+
+    with pytest.raises(IntegrationError, match="teardown rolled back"):
+        manager.teardown()
+
+    assert manager.hooks_path.read_bytes() == before
+    assert manager.manifest_path.exists()
+
+
+def test_newer_manifest_schema_is_refused(homes: tuple[Path, Path]) -> None:
+    manager, _ = _manager(homes)
+    manager.manifest_path.parent.mkdir(parents=True)
+    manager.manifest_path.write_text('{"schema": 999}')
+
+    with pytest.raises(IntegrationError, match="unsupported"):
+        IntegrationManifest.load(manager.manifest_path)
+
+
+def test_invalid_spotter_config_fails_before_external_mutation(
+    homes: tuple[Path, Path],
+) -> None:
+    spotter_home, codex_home = homes
+    spotter_home.mkdir()
+    config = spotter_home / "spotter.toml"
+    config.write_text("not valid toml")
+    service = FakeService(spotter_home / "service")
+    manager = IntegrationManager(
+        codex_home=codex_home,
+        codex=CodexInstall("/bin/codex", "codex 1.0", True, True),
+        service=service,
+        spotter_executable="/bin/spotter",
+        config_path=config,
+        verifier=lambda _: True,
+    )
+
+    with pytest.raises(IntegrationError, match="config is unusable"):
+        manager.setup()
+    assert not (codex_home / "hooks.json").exists()
+    assert service.starts == 0
+
+
+@pytest.mark.parametrize("platform,suffix", [("darwin", ".plist"), ("linux", ".service")])
+def test_managed_service_definition_is_private_and_idempotent(
+    homes: tuple[Path, Path], platform: str, suffix: str
+) -> None:
+    spotter_home, _ = homes
+    path = spotter_home / f"service{suffix}"
+    service = ManagedServiceManager(
+        platform=platform,
+        registration_path=path,
+        executable="/opt/homebrew/bin/spotterd",
+    )
+
+    assert service._install_definition()  # noqa: SLF001 - verifies the service artifact contract
+    assert not service._install_definition()  # noqa: SLF001
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert b"spotterd" in path.read_bytes()
+
+
+@pytest.mark.parametrize(
+    "platform,expected",
+    [
+        ("darwin", ["launchctl", "bootstrap"]),
+        ("linux", ["systemctl", "--user", "enable", "--now"]),
+    ],
+)
+def test_managed_service_start_registers_and_verifies(
+    homes: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    platform: str,
+    expected: list[str],
+) -> None:
+    spotter_home, _ = homes
+    service = ManagedServiceManager(
+        platform=platform,
+        registration_path=spotter_home / "service",
+        executable="/bin/spotterd",
+    )
+    commands: list[list[str]] = []
+    statuses = iter([RuntimeHealth.UNAVAILABLE, RuntimeHealth.HEALTHY])
+
+    def run(command: list[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        inactive = command[:2] == ["launchctl", "print"] or command[-2:] == [
+            "is-active",
+            "spotterd.service",
+        ]
+        return subprocess.CompletedProcess(command, 1 if inactive else 0, "", "")
+
+    async def healthy() -> DaemonStatus:
+        return DaemonStatus(next(statuses, RuntimeHealth.HEALTHY))
+
+    monkeypatch.setattr(service, "_run", run)
+    monkeypatch.setattr(service, "status", healthy)
+
+    assert asyncio.run(service.start()).health == RuntimeHealth.HEALTHY
+    assert any(command[: len(expected)] == expected for command in commands)
+
+
+@pytest.mark.parametrize("platform", ["darwin", "linux"])
+def test_managed_service_refuses_to_claim_an_unmanaged_running_daemon(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch, platform: str
+) -> None:
+    spotter_home, _ = homes
+    path = spotter_home / "service"
+    service = ManagedServiceManager(
+        platform=platform, registration_path=path, executable="/bin/spotterd"
+    )
+
+    def inactive(command: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 1, "", "")
+
+    async def healthy() -> DaemonStatus:
+        return DaemonStatus(RuntimeHealth.HEALTHY, pid=123)
+
+    monkeypatch.setattr(service, "_run", inactive)
+    monkeypatch.setattr(service, "status", healthy)
+
+    status = asyncio.run(service.start())
+    assert status.health == RuntimeHealth.DEGRADED
+    assert "outside the managed" in (status.detail or "")
+    assert not path.exists()
+
+
+def test_setup_dry_run_makes_no_external_changes(
+    homes: tuple[Path, Path],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spotter_home, codex_home = homes
+    manager, _ = _manager(homes)
+    monkeypatch.setattr("spotter.cli.IntegrationManager", lambda **_: manager)
+    assert main(["setup", "codex", "--dry-run"]) == 0
+    assert "dry-run: no changes made" in capsys.readouterr().out
+    assert not (codex_home / "hooks.json").exists()
+    assert not (spotter_home / "integrations").exists()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,6 +20,7 @@ class FakeService:
         self.registration_path = registration_path
         self.health = RuntimeHealth.UNAVAILABLE
         self.starts = 0
+        self.stops = 0
         self.uninstalls = 0
 
     async def start(self) -> DaemonStatus:
@@ -28,6 +29,7 @@ class FakeService:
         return await self.status()
 
     async def stop(self) -> DaemonStatus:
+        self.stops += 1
         self.health = RuntimeHealth.UNAVAILABLE
         return await self.status()
 
@@ -140,6 +142,17 @@ def test_setup_and_teardown_remove_a_hooks_file_created_by_spotter(
     assert manager.hooks_path.exists()
     assert manager.teardown()
     assert not manager.hooks_path.exists()
+
+
+def test_setup_records_app_server_endpoint_as_pending(
+    homes: tuple[Path, Path],
+) -> None:
+    manager, _ = _manager(homes)
+
+    manifest = manager.setup()
+
+    assert manifest.app_server_strategy == "pending-external"
+    assert manifest.app_server_endpoint is None
 
 
 def test_failed_verification_rolls_back_hooks_service_and_manifest(
@@ -291,6 +304,27 @@ def test_teardown_failure_restores_the_owned_hook_and_manifest(
     assert manager.manifest_path.exists()
 
 
+def test_teardown_does_not_require_codex_to_still_be_installed(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manager, service = _manager(homes)
+    manager.setup()
+
+    def missing() -> CodexInstall:
+        raise IntegrationError("Codex is not installed")
+
+    monkeypatch.setattr(CodexInstall, "detect", missing)
+    teardown = IntegrationManager(
+        codex_home=homes[1],
+        service=service,
+        spotter_executable="/bin/spotter",
+        verifier=lambda _: True,
+    )
+
+    assert teardown.teardown()
+    assert not teardown.manifest_path.exists()
+
+
 def test_newer_manifest_schema_is_refused(homes: tuple[Path, Path]) -> None:
     manager, _ = _manager(homes)
     manager.manifest_path.parent.mkdir(parents=True)
@@ -339,6 +373,17 @@ def test_managed_service_definition_is_private_and_idempotent(
     assert not service._install_definition()  # noqa: SLF001
     assert path.stat().st_mode & 0o777 == 0o600
     assert b"spotterd" in path.read_bytes()
+
+
+def test_systemd_definition_escapes_percent_specifiers(homes: tuple[Path, Path]) -> None:
+    spotter_home, _ = homes
+    service = ManagedServiceManager(
+        platform="linux",
+        registration_path=spotter_home / "service",
+        executable="/opt/100%/spotterd",
+    )
+
+    assert b"/opt/100%%/spotterd" in service._definition()  # noqa: SLF001
 
 
 @pytest.mark.parametrize(
@@ -418,3 +463,36 @@ def test_setup_dry_run_makes_no_external_changes(
     assert "dry-run: no changes made" in capsys.readouterr().out
     assert not (codex_home / "hooks.json").exists()
     assert not (spotter_home / "integrations").exists()
+
+
+def test_setup_cli_does_not_print_an_unverified_remote_command(
+    homes: tuple[Path, Path],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, _ = _manager(homes)
+    monkeypatch.setattr("spotter.cli.IntegrationManager", lambda **_: manager)
+
+    assert main(["setup", "codex"]) == 0
+
+    output = capsys.readouterr().out
+    assert "endpoint: pending" in output
+    assert "codex --remote" not in output
+
+
+def test_managed_manifest_routes_daemon_stop_through_the_service_manager(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manager, _ = _manager(homes)
+    manager.setup()
+    managed = FakeService(homes[0] / "service")
+    managed.health = RuntimeHealth.HEALTHY
+    monkeypatch.setattr("spotter.cli.ManagedServiceManager", lambda: managed)
+
+    assert main(["daemon", "stop"]) == 0
+    assert managed.stops == 1
+
+
+def test_portable_is_rejected_for_teardown() -> None:
+    with pytest.raises(SystemExit, match="2"):
+        main(["teardown", "codex", "--portable"])


### PR DESCRIPTION
## Summary

- add versioned, atomic integration ownership manifests for `spotter setup|teardown codex`
- migrate legacy Spotter hooks/plugins transactionally with backup, verification, and rollback
- add managed launchd/systemd-user service registration plus portable mode
- document the App Server ownership boundary and lifecycle status

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest -q`
- `git diff --check`

Closes #83