### PR TITLE
feat(operations): add runtime-aware diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Live `VERIFY / NUDGE` | ❌ | Target: `turn/steer` |
 | `INTERRUPT` | ❌ | Target: `turn/interrupt` |
 | `RESTART` | ❌ | Requires verified-state + side-effect-aware recovery |
-| Codex setup lifecycle | 🟡 | Transactional setup/teardown and manifest implemented; packaging and full App Server integration remain |
+| Codex setup lifecycle | 🟡 | Transactional setup/teardown, ownership diagnostics, and degraded capability reporting implemented; packaging and full App Server integration remain |
 
 ### Current runtime work
 
@@ -96,7 +96,9 @@ routing in [#85](https://github.com/spotter-agent/spotter/issues/85). [#79](http
 adds the `spotterd` process, versioned local control handshake, manual lifecycle commands, and a
 platform-neutral service boundary. [#83](https://github.com/spotter-agent/spotter/issues/83) adds
 transactional Codex setup/teardown, managed user-service registration, and integration ownership.
-Event routing and recovery remain separate work.
+[#84](https://github.com/spotter-agent/spotter/issues/84) makes `status` and `doctor` distinguish
+daemon, observation, control, enforcement, integration drift, storage, and reviewer health. Event
+routing and recovery remain separate work.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -685,6 +685,11 @@ Codex integration
 
 This allows a Codex upgrade to degrade one feature without forcing a binary “supported/unsupported” result for the whole integration.
 
+`spotter status` now reports this split without probing external services. `spotter doctor` performs
+the deeper App Server connection/initialize probe when the integration manifest has an endpoint.
+Until #85 wires a persistent runtime consumer, thread counts and reviewer queue state are reported
+as unknown/unavailable instead of being derived from incompatible Hook-era sessions.
+
 ---
 
 # 11. Failure and degraded mode
@@ -712,6 +717,10 @@ PreToolUse gate:      active
 Journal:              writable
 Reviewer:             available
 ```
+
+The aggregate command health is healthy/degraded/broken (`0`/`1`/`2`). In particular, a healthy
+daemon with no App Server observation path is degraded while the independent PreToolUse enforcement
+surface can still be reported active.
 
 ### `spotterd` crash
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -718,9 +718,10 @@ Journal:              writable
 Reviewer:             available
 ```
 
-The aggregate command health is healthy/degraded/broken (`0`/`1`/`2`). In particular, a healthy
-daemon with no App Server observation path is degraded while the independent PreToolUse enforcement
-surface can still be reported active.
+The aggregate command health is healthy/degraded/broken (`0`/`1`/`2`). Known unimplemented or
+optional unconfigured surfaces are informational rather than permanent warnings; absence of every
+runtime registration still warns. In particular, a configured healthy daemon with no App Server
+observation path is degraded while the independent PreToolUse enforcement surface can remain active.
 
 ### `spotterd` crash
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,7 +1,7 @@
 # Lifecycle and Operations
 
 > **Status:** target design with an implemented transactional Codex setup slice. Active implementation is tracked by the [Roadmap](roadmap.md) and native GitHub Milestones.
-> `spotter setup|teardown codex`, versioned ownership manifests, managed `launchd`/`systemd --user` registration, portable startup, and legacy Hook/plugin migration exist. Homebrew installation, App Server event ingestion, runtime-aware diagnostics, and transparent plain-`codex` launch remain target behavior.
+> `spotter setup|teardown codex`, versioned ownership manifests, managed `launchd`/`systemd --user` registration, portable startup, legacy Hook/plugin migration, and runtime-aware diagnostics exist. Homebrew installation, App Server event ingestion, and transparent plain-`codex` launch remain target behavior.
 
 ---
 
@@ -819,6 +819,11 @@ Do not treat experiment machinery as evidence of positive intervention advantage
 
 Designed for a quick operational answer.
 
+The implemented command reports manifest/Hook ownership, daemon RPC, observation, live control,
+enforcement consequences, storage, reviewer errors, and spend-ledger health. Exit `0` is healthy,
+`1` is degraded/warn, and `2` is broken. Until #85 supplies live identity state, active/dormant
+thread counts remain explicitly unknown rather than inferred from Hook sessions.
+
 Example:
 
 ```text
@@ -842,6 +847,11 @@ Sessions
 ## 9.2 `spotter doctor`
 
 Doctor should be diagnostic and synthetic, not just configuration inspection.
+
+The implemented doctor preserves the synthetic Hook round-trip and storage/ledger checks, validates
+the integration manifest against the exact owned Hook and legacy plugin state, checks daemon IPC,
+and probes a configured App Server endpoint. Unavailable optional capabilities warn; broken owned
+integration, daemon, storage, or ledger contracts fail.
 
 Checks:
 
@@ -1332,8 +1342,8 @@ The target lifecycle is not complete until all of these work end-to-end:
 - [x] `spotter setup codex` is idempotent;
 - [x] interrupted setup can heal forward when setup is re-run (pre-manifest teardown cannot infer ownership);
 - [ ] ordinary `codex` requires no manual Spotter/App Server startup in managed mode;
-- [ ] `status` distinguishes daemon, observation, control, enforcement, storage health;
-- [ ] `doctor` performs a real synthetic round-trip;
+- [x] `status` distinguishes daemon, observation, control, enforcement, storage health;
+- [x] `doctor` performs a real synthetic round-trip;
 - [ ] multiple concurrent threads/sessions remain isolated;
 - [ ] daemon crash recovers without corrupting journal/live state;
 - [ ] Codex upgrade degrades by capability rather than silently breaking;

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -821,8 +821,10 @@ Designed for a quick operational answer.
 
 The implemented command reports manifest/Hook ownership, daemon RPC, observation, live control,
 enforcement consequences, storage, reviewer errors, and spend-ledger health. Exit `0` is healthy,
-`1` is degraded/warn, and `2` is broken. Until #85 supplies live identity state, active/dormant
-thread counts remain explicitly unknown rather than inferred from Hook sessions.
+`1` is degraded/warn, and `2` is broken. Expected unavailable surfaces are informational and do not
+affect the verdict; once a configured surface becomes unavailable it warns or fails according to
+its consequence. Until #85 supplies live identity state, active/dormant thread counts remain
+explicitly unknown rather than inferred from Hook sessions.
 
 Example:
 
@@ -850,8 +852,9 @@ Doctor should be diagnostic and synthetic, not just configuration inspection.
 
 The implemented doctor preserves the synthetic Hook round-trip and storage/ledger checks, validates
 the integration manifest against the exact owned Hook and legacy plugin state, checks daemon IPC,
-and probes a configured App Server endpoint. Unavailable optional capabilities warn; broken owned
-integration, daemon, storage, or ledger contracts fail.
+and probes a configured App Server endpoint. Expected unimplemented capabilities are informational,
+configured-but-unavailable capabilities warn, and broken owned integration, daemon, storage, or
+ledger contracts fail.
 
 Checks:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -79,7 +79,7 @@ The Runtime milestone is now decomposed into concrete boundaries rather than one
 | [#82](https://github.com/spotter-agent/spotter/issues/82) | bounded Hook ↔ daemon IPC for deterministic `PreToolUse` enforcement (implemented) |
 | [#31](https://github.com/spotter-agent/spotter/issues/31) | independent live supervision state owned by `spotterd` |
 | [#83](https://github.com/spotter-agent/spotter/issues/83) | transactional `setup|teardown codex`, Integration Manifest, legacy migration (implemented) |
-| [#84](https://github.com/spotter-agent/spotter/issues/84) | runtime-aware `status` / `doctor` and degraded capability reporting |
+| [#84](https://github.com/spotter-agent/spotter/issues/84) | runtime-aware `status` / `doctor` and degraded capability reporting (implemented) |
 | [#87](https://github.com/spotter-agent/spotter/issues/87) | daemon/App Server reconnect and thread reconciliation |
 
 Native GitHub issue dependencies encode the actual order between these issues. The table describes responsibility, not a second dependency system.

--- a/docs/status.md
+++ b/docs/status.md
@@ -60,10 +60,12 @@ local control handshake, explicit health states, manual lifecycle commands, and 
 local enforcement fallback on unavailable/timeout, and separate Hook/IPC timing telemetry.
 [#83](https://github.com/spotter-agent/spotter/issues/83) adds versioned integration manifests,
 transactional Codex Hook/plugin migration, and managed `launchd`/`systemd --user` registration.
+[#84](https://github.com/spotter-agent/spotter/issues/84) adds runtime-aware `status`/`doctor`,
+manifest and Hook ownership checks, App Server probing when an endpoint exists, and explicit
+degraded consequences when observation/control are unavailable but Hook enforcement remains.
 
 The remaining implementation boundaries are split into native GitHub issues:
 
-- [#84](https://github.com/spotter-agent/spotter/issues/84) — runtime-aware status/doctor;
 - [#87](https://github.com/spotter-agent/spotter/issues/87) — daemon/App Server reconnect and identity reconciliation.
 
 [#31](https://github.com/spotter-agent/spotter/issues/31) then moves independent supervision state into that runtime, fed by the App Server ingestion path in [#85](https://github.com/spotter-agent/spotter/issues/85).
@@ -101,7 +103,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Standalone runtime | 🟡 | Long-lived process, versioned control/gate IPC, health states, manual and managed user-service lifecycle | Add runtime consumers in #31/#85 |
 | Runtime identity | 🟡 | Provisional lifecycle registry and explicit legacy unknowns; no production consumer | Validate and refine it while routing normalized App Server events in #85 |
 | App Server primary observation | 🟡 | Async client, raw events, thread queries, controls, capability degradation | Normalize, identity-route, and journal events in #85 |
-| Managed Codex lifecycle | 🟡 | Transactional setup/teardown, versioned ownership manifest, legacy migration, launchd/systemd-user service | Surface integration drift and capability consequences in #84 |
+| Managed Codex lifecycle | 🟡 | Transactional setup/teardown, versioned ownership manifest, legacy migration, launchd/systemd-user service, runtime diagnostics | Connect and ingest the external App Server in #85/#87 |
 | Runtime reconnect/recovery | ❌ | No long-lived App Server connection to recover | #87 after runtime/state boundaries exist |
 | Event-driven detection | ❌ | Reviewer is still cadence-based | #28 after Runtime/Observe |
 | Live `VERIFY` / `NUDGE` | ❌ | Reviewer decisions stop at the journal | #22 via `turn/steer` |

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -33,7 +33,7 @@ from spotter.daemon import (
     RuntimeHealth,
     ServiceManager,
 )
-from spotter.doctor import FAIL, OK, WARN, worst
+from spotter.doctor import FAIL, OK, WARN, check_runtime, worst
 from spotter.doctor import run as run_doctor
 from spotter.experiment import list_forks, results_path, run_experiment, summarize
 from spotter.gates import Gate
@@ -663,45 +663,62 @@ def _status_main() -> int:
     after = home.stat().st_mode & 0o777
     note = f" (tightened from {oct(before)})" if before != after else ""
     print(f"home: {home}  ({total_bytes / 1e6:.1f} MB, mode {oct(after)}{note})")
+    runtime_checks = check_runtime()
+    marks = {OK: "ok", WARN: "WARN", FAIL: "FAIL"}
+    print("runtime:")
+    for check in runtime_checks:
+        print(f"  [{marks[check.status]}] {check.name}: {check.detail}")
     print(f"sessions: {len(journals)}")
+    warned = not journals
     if newest is None:
         print("  last observation: never")
     else:
         age_hours = (time.time() - newest) / 3600
         print(f"  last observation: {age_hours:.1f}h ago")
         if age_hours > 24:
+            warned = True
             print("  WARNING: nothing observed in over a day — is the hook still registered?")
     forks = list_forks()
     if forks:
         print(f"fork worktrees: {len(forks)} (remove with: spotter prune --forks --apply)")
-    errors = 0
+    unreadable = 0
+    reviewer_errors = 0
     exposed = 0
     for journal in journals:
         try:
             records = StepJournal.load(journal)
         except SnapshotError:
             print(f"  UNREADABLE: {journal.name}")
-            errors += 1
+            unreadable += 1
             continue
-        errors += sum(1 for r in records if r.event.kind == "reviewer_error")
+        reviewer_errors += sum(1 for r in records if r.event.kind == "reviewer_error")
         exposed += sum(
             1 for line in journal.read_text(errors="replace").splitlines() if scan_text(line)
         )
-    if errors:
-        print(f"reviewer errors recorded: {errors} (see {home / 'logs'})")
+    if reviewer_errors:
+        warned = True
+        print(f"reviewer errors recorded: {reviewer_errors} (see {home / 'logs'})")
+    ledger_broken = False
     try:
         totals = spend_totals()
     except LedgerCorrupt as error:
+        ledger_broken = True
         # The diagnostic command must survive the corruption it is diagnosing.
         print(f"WARNING: spend ledger unreadable ({error}); ceilings are refusing to spend")
     else:
         if totals is not None:
             print(f"reviews today: {totals['day']}  |  tokens recorded: {totals['tokens']}")
     if exposed:
+        warned = True
         print(
             f"WARNING: {exposed} pre-redaction lines match credential patterns; "
             "these journals predate redaction"
         )
+    verdict = worst(runtime_checks)
+    if verdict == FAIL or unreadable or ledger_broken:
+        return 2
+    if verdict == WARN or warned:
+        return 1
     return 0
 
 

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -33,7 +33,7 @@ from spotter.daemon import (
     RuntimeHealth,
     ServiceManager,
 )
-from spotter.doctor import FAIL, OK, WARN, check_runtime, worst
+from spotter.doctor import FAIL, INFO, OK, WARN, check_runtime, worst
 from spotter.doctor import run as run_doctor
 from spotter.experiment import list_forks, results_path, run_experiment, summarize
 from spotter.gates import Gate
@@ -558,7 +558,7 @@ def _doctor_main(config_path: Path | None) -> int:
     A tool whose normal output is silence needs one command that speaks.
     """
     checks = run_doctor(config_path)
-    marks = {OK: "  ok  ", WARN: " warn ", FAIL: " FAIL "}
+    marks = {OK: "  ok  ", INFO: " info ", WARN: " warn ", FAIL: " FAIL "}
     for check in checks:
         print(f"[{marks[check.status]}] {check.name}: {check.detail}")
     verdict = worst(checks)
@@ -664,12 +664,12 @@ def _status_main() -> int:
     note = f" (tightened from {oct(before)})" if before != after else ""
     print(f"home: {home}  ({total_bytes / 1e6:.1f} MB, mode {oct(after)}{note})")
     runtime_checks = check_runtime()
-    marks = {OK: "ok", WARN: "WARN", FAIL: "FAIL"}
+    marks = {OK: "ok", INFO: "info", WARN: "WARN", FAIL: "FAIL"}
     print("runtime:")
     for check in runtime_checks:
         print(f"  [{marks[check.status]}] {check.name}: {check.detail}")
     print(f"sessions: {len(journals)}")
-    warned = not journals
+    warned = False
     if newest is None:
         print("  last observation: never")
     else:

--- a/src/spotter/doctor.py
+++ b/src/spotter/doctor.py
@@ -10,17 +10,25 @@ This module answers the one question the rest of the tool cannot: if nothing
 was recorded, was there nothing to record, or is nothing running?
 """
 
+import asyncio
+import contextlib
 import json
 import os
 import shutil
 import subprocess
 import sys
 import time
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
 
 from spotter.budget import LedgerCorrupt, spend_totals
+from spotter.daemon import DaemonClient, DaemonStatus, RuntimeHealth
 from spotter.paths import spotter_home
+
+if TYPE_CHECKING:
+    from spotter.integration import IntegrationManifest
 
 OK = "ok"
 WARN = "warn"
@@ -32,6 +40,13 @@ class Check:
     name: str
     status: str
     detail: str
+
+
+@dataclass(frozen=True)
+class IntegrationInspection:
+    manifest: "IntegrationManifest | None"
+    check: Check
+    owned_hook_ready: bool
 
 
 def _codex_hooks_files() -> list[Path]:
@@ -172,8 +187,235 @@ def check_freshness(max_idle_hours: float = 24.0) -> Check:
     return Check("observations", status, f"last recorded {age:.1f}h ago")
 
 
+def _hook_entries(path: Path) -> list[tuple[str, object, dict[str, Any]]]:
+    if not path.exists():
+        return []
+    try:
+        raw = json.loads(path.read_bytes())
+    except (OSError, ValueError) as error:
+        raise ValueError(f"{path} is unreadable: {error}") from error
+    if not isinstance(raw, dict) or not isinstance(raw.get("hooks", {}), dict):
+        raise ValueError(f"{path} has an unsupported shape")
+    entries: list[tuple[str, object, dict[str, Any]]] = []
+    for event, groups in cast(dict[str, object], raw.get("hooks", {})).items():
+        if not isinstance(event, str) or not isinstance(groups, list):
+            raise ValueError(f"{path} has an unsupported event shape")
+        for group in groups:
+            if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
+                raise ValueError(f"{path} has an unsupported hook group")
+            for hook in cast(list[object], group["hooks"]):
+                if isinstance(hook, dict):
+                    entries.append((event, group.get("matcher"), cast(dict[str, Any], hook)))
+    return entries
+
+
+def _legacy_plugins(codex_home: Path) -> tuple[str, ...]:
+    config = codex_home / "config.toml"
+    if not config.exists():
+        return ()
+    try:
+        raw = tomllib.loads(config.read_text())
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise ValueError(f"{config} is unreadable: {error}") from error
+    plugins = raw.get("plugins", {})
+    if not isinstance(plugins, dict):
+        raise ValueError(f"{config} has an unsupported plugin shape")
+    return tuple(name for name in plugins if name == "spotter" or name.startswith("spotter@"))
+
+
+def check_integration() -> IntegrationInspection:
+    """Validate the recorded ownership contract without mutating Codex config."""
+    # Local import avoids integration -> doctor -> integration during setup imports.
+    from spotter.integration import IntegrationError, IntegrationManifest, is_spotter_hook
+
+    manifest_path = spotter_home() / "integrations" / "codex.json"
+    try:
+        manifest = IntegrationManifest.load(manifest_path)
+    except IntegrationError as error:
+        return IntegrationInspection(None, Check("Codex integration", FAIL, str(error)), False)
+
+    try:
+        codex_home = Path(
+            manifest.codex_home
+            if manifest is not None
+            else os.environ.get("CODEX_HOME", Path.home() / ".codex")
+        )
+        hooks_path = (
+            Path(manifest.hooks_file) if manifest is not None else codex_home / "hooks.json"
+        )
+        spotter_hooks = [entry for entry in _hook_entries(hooks_path) if is_spotter_hook(entry[2])]
+        legacy_plugins = _legacy_plugins(codex_home)
+    except (TypeError, ValueError) as error:
+        return IntegrationInspection(manifest, Check("Codex integration", FAIL, str(error)), False)
+
+    if manifest is None:
+        leftovers = len(spotter_hooks) + len(legacy_plugins)
+        detail = (
+            f"not configured; found {leftovers} unowned legacy Spotter registration(s)"
+            if leftovers
+            else "not configured"
+        )
+        return IntegrationInspection(None, Check("Codex integration", WARN, detail), False)
+
+    if manifest.state != "ready":
+        return IntegrationInspection(
+            manifest,
+            Check("Codex integration", FAIL, f"manifest state is {manifest.state!r}"),
+            False,
+        )
+    owned = manifest.owned_hook
+    if not isinstance(owned, dict) or not isinstance(owned.get("hook"), dict):
+        return IntegrationInspection(
+            manifest,
+            Check("Codex integration", FAIL, "manifest owned Hook is invalid"),
+            False,
+        )
+    expected = (owned.get("event"), owned.get("matcher"), owned.get("hook"))
+    if spotter_hooks != [expected]:
+        return IntegrationInspection(
+            manifest,
+            Check(
+                "Codex integration",
+                FAIL,
+                f"owned Hook is missing, drifted, or duplicated ({len(spotter_hooks)} found)",
+            ),
+            False,
+        )
+    if legacy_plugins:
+        return IntegrationInspection(
+            manifest,
+            Check(
+                "Codex integration",
+                FAIL,
+                f"stale legacy plugin registration: {', '.join(legacy_plugins)}",
+            ),
+            True,
+        )
+    try:
+        registration_missing = (
+            manifest.service_registration is None
+            or not Path(manifest.service_registration).exists()
+        )
+    except TypeError:
+        registration_missing = True
+    if manifest.runtime_mode == "managed" and manifest.service_owned and registration_missing:
+        return IntegrationInspection(
+            manifest,
+            Check("Codex integration", FAIL, "managed service registration is missing"),
+            True,
+        )
+    return IntegrationInspection(
+        manifest,
+        Check("Codex integration", OK, f"ready ({manifest.runtime_mode})"),
+        True,
+    )
+
+
+def _daemon_check(status: DaemonStatus, configured: bool) -> Check:
+    if status.health == RuntimeHealth.HEALTHY:
+        detail = f"healthy pid={status.pid} protocol={status.protocol}"
+        return Check("daemon", OK, detail)
+    if status.health == RuntimeHealth.UNAVAILABLE:
+        consequence = (
+            "configured enforcement is using local Hook fallback" if configured else "not running"
+        )
+        return Check("daemon", FAIL if configured else WARN, f"unavailable; {consequence}")
+    return Check("daemon", WARN, f"{status.health.value}: {status.detail or 'reduced health'}")
+
+
+async def _probe_app_server(endpoint: str) -> tuple[Check, Check]:
+    client = None
+    try:
+        # Keep the optional WebSocket dependency off the bundled Hook import path.
+        from spotter.app_server import CapabilityStatus, CodexAppServerClient
+
+        client = CodexAppServerClient(endpoint, request_timeout=2)
+        await client.connect()
+        capabilities = client.capabilities
+        observation = Check(
+            "observation",
+            OK if capabilities.observation == CapabilityStatus.AVAILABLE else WARN,
+            f"App Server {client.state.value}; observation {capabilities.observation.value}",
+        )
+        controls = (capabilities.steer, capabilities.interrupt)
+        control = Check(
+            "live control",
+            OK if all(item == CapabilityStatus.AVAILABLE for item in controls) else WARN,
+            "steer/interrupt " + "/".join(item.value for item in controls),
+        )
+        return observation, control
+    except Exception as error:
+        return (
+            Check("observation", WARN, f"App Server disconnected: {error}"),
+            Check("live control", WARN, "unavailable while App Server is disconnected"),
+        )
+    finally:
+        if client is not None:
+            with contextlib.suppress(Exception):
+                await client.disconnect()
+
+
+def check_runtime(*, deep: bool = False) -> list[Check]:
+    """Summarize process, integration, capability, and enforcement consequences."""
+    integration = check_integration()
+    daemon = asyncio.run(DaemonClient().status())
+    configured = integration.manifest is not None
+    checks = [integration.check, _daemon_check(daemon, configured)]
+
+    endpoint = (
+        integration.manifest.app_server_endpoint if integration.manifest is not None else None
+    )
+    if endpoint is None:
+        checks.extend(
+            [
+                Check(
+                    "observation",
+                    WARN,
+                    "unavailable: App Server endpoint is not configured; "
+                    "Hook enforcement is independent",
+                ),
+                Check("live control", WARN, "unavailable: App Server endpoint is not configured"),
+            ]
+        )
+    elif deep:
+        checks.extend(asyncio.run(_probe_app_server(endpoint)))
+    else:
+        checks.extend(
+            [
+                Check("observation", WARN, f"endpoint configured; run doctor to probe {endpoint}"),
+                Check("live control", WARN, "not probed by status"),
+            ]
+        )
+
+    if integration.owned_hook_ready and daemon.health == RuntimeHealth.HEALTHY:
+        checks.append(Check("enforcement", OK, "PreToolUse Hook and daemon gate RPC available"))
+    elif integration.owned_hook_ready:
+        checks.append(
+            Check(
+                "enforcement",
+                WARN,
+                "PreToolUse Hook active; daemon RPC unavailable, using bounded local fallback",
+            )
+        )
+    else:
+        checks.append(Check("enforcement", FAIL if configured else WARN, "owned Hook unavailable"))
+
+    checks.extend(
+        [
+            Check(
+                "runtime state",
+                WARN,
+                "active/dormant thread counts unknown until App Server ingestion (#85)",
+            ),
+            Check("review queue", WARN, "no durable reviewer queue is implemented"),
+        ]
+    )
+    return checks
+
+
 def run(config_path: Path | None = None) -> list[Check]:
     checks = [check_interpreter()]
+    checks.extend(check_runtime(deep=True))
     checks.extend(check_registration())
     checks.extend(check_storage())
     checks.append(check_roundtrip(config_path))

--- a/src/spotter/doctor.py
+++ b/src/spotter/doctor.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from spotter.integration import IntegrationManifest
 
 OK = "ok"
+INFO = "info"
 WARN = "warn"
 FAIL = "fail"
 
@@ -46,7 +47,7 @@ class Check:
 class IntegrationInspection:
     manifest: "IntegrationManifest | None"
     check: Check
-    owned_hook_ready: bool
+    hook_ready: bool
 
 
 def _codex_hooks_files() -> list[Path]:
@@ -68,22 +69,28 @@ def check_registration() -> list[Check]:
     — but shallow beats the current situation, which is no check at all.
     """
     checks: list[Check] = []
+    any_wired = False
     for label, files in (("codex", _codex_hooks_files()), ("claude", _claude_settings_files())):
         present = [p for p in files if p.exists()]
         if not present:
-            checks.append(Check(f"{label} config", WARN, "no config found; runtime not installed?"))
+            checks.append(Check(f"{label} config", INFO, "no config found; runtime not configured"))
             continue
         wired = [p for p in present if "spotter" in p.read_text(errors="replace")]
         if wired:
+            any_wired = True
             checks.append(Check(f"{label} hook", OK, f"registered in {wired[0].name}"))
         else:
             checks.append(
                 Check(
                     f"{label} hook",
-                    WARN,
+                    INFO,
                     f"not registered in {', '.join(p.name for p in present)}",
                 )
             )
+    if not any_wired:
+        checks.append(
+            Check("runtime registration", WARN, "Spotter is not registered in any runtime")
+        )
     return checks
 
 
@@ -181,7 +188,7 @@ def check_freshness(max_idle_hours: float = 24.0) -> Check:
     journals = sorted(sessions.glob("*.jsonl")) if sessions.exists() else []
     real = [p for p in journals if not p.stem.startswith("doctor-probe")]
     if not real:
-        return Check("observations", WARN, "no session has ever been recorded")
+        return Check("observations", INFO, "no session has been recorded yet")
     age = (time.time() - max(p.stat().st_mtime for p in real)) / 3600
     status = OK if age <= max_idle_hours else WARN
     return Check("observations", status, f"last recorded {age:.1f}h ago")
@@ -250,12 +257,19 @@ def check_integration() -> IntegrationInspection:
 
     if manifest is None:
         leftovers = len(spotter_hooks) + len(legacy_plugins)
-        detail = (
-            f"not configured; found {leftovers} unowned legacy Spotter registration(s)"
-            if leftovers
-            else "not configured"
+        return IntegrationInspection(
+            None,
+            Check(
+                "Codex integration",
+                INFO if leftovers else WARN,
+                (
+                    f"managed setup absent; found {leftovers} legacy Spotter registration(s)"
+                    if leftovers
+                    else "Spotter is not configured for Codex"
+                ),
+            ),
+            bool(spotter_hooks),
         )
-        return IntegrationInspection(None, Check("Codex integration", WARN, detail), False)
 
     if manifest.state != "ready":
         return IntegrationInspection(
@@ -277,7 +291,8 @@ def check_integration() -> IntegrationInspection:
             Check(
                 "Codex integration",
                 FAIL,
-                f"owned Hook is missing, drifted, or duplicated ({len(spotter_hooks)} found)",
+                "owned Hook is missing, user-modified, or duplicated "
+                f"({len(spotter_hooks)} found); run `spotter setup codex` to reconcile",
             ),
             False,
         )
@@ -319,7 +334,7 @@ def _daemon_check(status: DaemonStatus, configured: bool) -> Check:
         consequence = (
             "configured enforcement is using local Hook fallback" if configured else "not running"
         )
-        return Check("daemon", FAIL if configured else WARN, f"unavailable; {consequence}")
+        return Check("daemon", FAIL if configured else INFO, f"unavailable; {consequence}")
     return Check("daemon", WARN, f"{status.health.value}: {status.detail or 'reduced health'}")
 
 
@@ -366,15 +381,20 @@ def check_runtime(*, deep: bool = False) -> list[Check]:
         integration.manifest.app_server_endpoint if integration.manifest is not None else None
     )
     if endpoint is None:
+        capability_status = WARN if configured else INFO
         checks.extend(
             [
                 Check(
                     "observation",
-                    WARN,
+                    capability_status,
                     "unavailable: App Server endpoint is not configured; "
                     "Hook enforcement is independent",
                 ),
-                Check("live control", WARN, "unavailable: App Server endpoint is not configured"),
+                Check(
+                    "live control",
+                    capability_status,
+                    "unavailable: App Server endpoint is not configured",
+                ),
             ]
         )
     elif deep:
@@ -387,9 +407,9 @@ def check_runtime(*, deep: bool = False) -> list[Check]:
             ]
         )
 
-    if integration.owned_hook_ready and daemon.health == RuntimeHealth.HEALTHY:
+    if integration.hook_ready and daemon.health == RuntimeHealth.HEALTHY:
         checks.append(Check("enforcement", OK, "PreToolUse Hook and daemon gate RPC available"))
-    elif integration.owned_hook_ready:
+    elif integration.hook_ready and configured:
         checks.append(
             Check(
                 "enforcement",
@@ -397,17 +417,25 @@ def check_runtime(*, deep: bool = False) -> list[Check]:
                 "PreToolUse Hook active; daemon RPC unavailable, using bounded local fallback",
             )
         )
+    elif integration.hook_ready:
+        checks.append(Check("enforcement", INFO, "legacy Hook local enforcement available"))
     else:
-        checks.append(Check("enforcement", FAIL if configured else WARN, "owned Hook unavailable"))
+        checks.append(
+            Check(
+                "enforcement",
+                FAIL if configured else INFO,
+                "managed owned Hook unavailable",
+            )
+        )
 
     checks.extend(
         [
             Check(
                 "runtime state",
-                WARN,
+                INFO,
                 "active/dormant thread counts unknown until App Server ingestion (#85)",
             ),
-            Check("review queue", WARN, "no durable reviewer queue is implemented"),
+            Check("review queue", INFO, "no durable reviewer queue is implemented"),
         ]
     )
     return checks

--- a/src/spotter/integration.py
+++ b/src/spotter/integration.py
@@ -59,6 +59,24 @@ def _atomic_write(path: Path, content: bytes) -> None:
     os.replace(temporary, path)
 
 
+def is_spotter_hook(hook: object) -> bool:
+    """Recognize executable Spotter Hook commands without matching incidental prose."""
+    if not isinstance(hook, dict) or not isinstance(hook.get("command"), str):
+        return False
+    command = cast(str, hook["command"])
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False
+    for index, token in enumerate(tokens):
+        name = Path(token).name
+        if name == "spotter-hook":
+            return True
+        if name == "spotter" and index + 1 < len(tokens) and tokens[index + 1] == "hook":
+            return True
+    return False
+
+
 @dataclass(frozen=True)
 class CodexInstall:
     path: str
@@ -257,20 +275,7 @@ class IntegrationManager:
 
     @staticmethod
     def _is_spotter_hook(hook: object) -> bool:
-        if not isinstance(hook, dict) or not isinstance(hook.get("command"), str):
-            return False
-        command = cast(str, hook["command"])
-        try:
-            tokens = shlex.split(command)
-        except ValueError:
-            return False
-        for index, token in enumerate(tokens):
-            name = Path(token).name
-            if name == "spotter-hook":
-                return True
-            if name == "spotter" and index + 1 < len(tokens) and tokens[index + 1] == "hook":
-                return True
-        return False
+        return is_spotter_hook(hook)
 
     def _read_hooks(self) -> tuple[dict[str, Any], bytes | None]:
         if not self.hooks_path.exists():

--- a/tests/test_budget_doctor.py
+++ b/tests/test_budget_doctor.py
@@ -17,6 +17,7 @@ from spotter.trace import TraceEvent
 @pytest.fixture(autouse=True)
 def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("SPOTTER_HOME", str(tmp_path / "spotter"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex"))
     return tmp_path / "spotter"
 
 
@@ -162,7 +163,7 @@ def test_doctor_run_covers_every_layer() -> None:
 def test_status_reports_spend(home: Path, capsys: pytest.CaptureFixture[str]) -> None:
     StepJournal(journal_path({"session_id": "s"})).record(TraceEvent("x"))
     charge("s", tokens=1234)
-    assert main(["status"]) == 0
+    assert main(["status"]) == 1
     out = capsys.readouterr().out
     assert "reviews today: 1" in out and "1234" in out
     assert json.loads((home / "review-spend.json").read_text())["sessions"]["s"]["tokens"] == 1234
@@ -206,7 +207,7 @@ def test_status_survives_a_corrupt_ledger(home: Path, capsys: pytest.CaptureFixt
     it exists to diagnose."""
     StepJournal(journal_path({"session_id": "s"})).record(TraceEvent("x"))
     (home / "review-spend.json").write_text("{torn")
-    assert main(["status"]) == 0
+    assert main(["status"]) == 2
     assert "spend ledger unreadable" in capsys.readouterr().out
 
 

--- a/tests/test_budget_doctor.py
+++ b/tests/test_budget_doctor.py
@@ -8,7 +8,17 @@ import pytest
 from spotter.budget import LedgerCorrupt, cancel, charge, exhausted, read, reserve, settle
 from spotter.cli import main
 from spotter.config import GatesConfig, MainAgentConfig, ReviewerConfig, SpotterConfig
-from spotter.doctor import FAIL, OK, WARN, check_freshness, check_roundtrip, run, worst
+from spotter.doctor import (
+    FAIL,
+    INFO,
+    OK,
+    WARN,
+    check_freshness,
+    check_registration,
+    check_roundtrip,
+    run,
+    worst,
+)
 from spotter.hook import journal_path, run_hook
 from spotter.snapshot import StepJournal
 from spotter.trace import TraceEvent
@@ -121,8 +131,8 @@ def test_roundtrip_leaves_no_probe_journal(home: Path) -> None:
 
 
 def test_freshness_reports_never_observed() -> None:
-    assert check_freshness().status == WARN
-    assert "has ever been recorded" in check_freshness().detail
+    assert check_freshness().status == INFO
+    assert "recorded yet" in check_freshness().detail
 
 
 def test_freshness_warns_when_stale(home: Path) -> None:
@@ -158,6 +168,24 @@ def test_doctor_run_covers_every_layer() -> None:
     names = {check.name for check in run(None)}
     assert {"interpreter", "round-trip", "observations"} <= names
     assert any(name.endswith("hook") or name.endswith("config") for name in names)
+
+
+def test_unregistered_optional_runtime_is_informational(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    codex = tmp_path / "codex"
+    claude = tmp_path / "claude"
+    codex.mkdir()
+    claude.mkdir()
+    (codex / "hooks.json").write_text('{"hooks":{"PreToolUse":[{"command":"spotter hook"}]}}')
+    (claude / "settings.json").write_text("{}")
+    monkeypatch.setenv("CODEX_HOME", str(codex))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude))
+
+    checks = check_registration()
+
+    assert worst(checks) == OK
+    assert next(check for check in checks if check.name == "claude hook").status == INFO
 
 
 def test_status_reports_spend(home: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -22,6 +22,7 @@ from spotter.trace import TraceEvent
 @pytest.fixture(autouse=True)
 def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("SPOTTER_HOME", str(tmp_path / "spotter"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex"))
     return tmp_path / "spotter"
 
 
@@ -113,7 +114,7 @@ def test_status_tightens_permissions_it_finds_loose(
 ) -> None:
     StepJournal(journal_path({"session_id": "s"})).record(TraceEvent("x"))
     home.chmod(0o755)
-    assert main(["status"]) == 0
+    assert main(["status"]) == 1
     assert (home.stat().st_mode & 0o077) == 0
     assert "tightened from" in capsys.readouterr().out
 
@@ -129,7 +130,7 @@ def test_status_warns_about_pre_redaction_credentials(
         "snapshot": None,
     }
     journal.write_text(json.dumps(record) + "\n")
-    assert main(["status"]) == 0
+    assert main(["status"]) == 1
     assert "match credential patterns" in capsys.readouterr().out
 
 

--- a/tests/test_runtime_diagnostics.py
+++ b/tests/test_runtime_diagnostics.py
@@ -1,0 +1,171 @@
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from spotter.app_server import AppServerTransportError, CodexAppServerClient
+from spotter.cli import main
+from spotter.daemon import DaemonClient, DaemonStatus, RuntimeHealth
+from spotter.doctor import FAIL, OK, WARN, Check, check_integration, check_runtime, worst
+from spotter.integration import MANIFEST_SCHEMA, IntegrationManifest
+from spotter.snapshot import StepJournal
+from spotter.trace import TraceEvent
+
+
+@pytest.fixture()
+def homes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    spotter = tmp_path / "spotter"
+    codex = tmp_path / "codex"
+    monkeypatch.setenv("SPOTTER_HOME", str(spotter))
+    monkeypatch.setenv("CODEX_HOME", str(codex))
+    return spotter, codex
+
+
+def _ready_manifest(homes: tuple[Path, Path]) -> IntegrationManifest:
+    spotter, codex = homes
+    codex.mkdir(parents=True)
+    owned = {
+        "event": "PreToolUse",
+        "matcher": ".*",
+        "hook": {"type": "command", "command": "/bin/spotter hook || true"},
+    }
+    hooks = {"hooks": {"PreToolUse": [{"matcher": owned["matcher"], "hooks": [owned["hook"]]}]}}
+    hooks_path = codex / "hooks.json"
+    hooks_path.write_text(json.dumps(hooks))
+    registration = spotter / "service/spotterd"
+    registration.parent.mkdir(parents=True)
+    registration.write_text("managed")
+    manifest = IntegrationManifest(
+        schema=MANIFEST_SCHEMA,
+        state="ready",
+        agent="codex",
+        setup_by="test",
+        agent_path="/bin/codex",
+        agent_version="test",
+        codex_home=str(codex),
+        app_server_strategy="pending-external",
+        app_server_endpoint=None,
+        runtime_mode="managed",
+        service_registration=str(registration),
+        service_owned=True,
+        hooks_file=str(hooks_path),
+        hooks_file_created=True,
+        owned_hook=owned,
+    )
+    manifest.save(spotter / "integrations/codex.json")
+    return manifest
+
+
+def _daemon_status(monkeypatch: pytest.MonkeyPatch, health: RuntimeHealth) -> None:
+    async def status(self: DaemonClient) -> DaemonStatus:
+        return DaemonStatus(
+            health, pid=123 if health != RuntimeHealth.UNAVAILABLE else None, protocol=1
+        )
+
+    monkeypatch.setattr(DaemonClient, "status", status)
+
+
+def test_running_daemon_without_app_server_is_degraded_but_enforcement_remains(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _ready_manifest(homes)
+    _daemon_status(monkeypatch, RuntimeHealth.HEALTHY)
+
+    checks = check_runtime()
+    by_name = {check.name: check for check in checks}
+
+    assert by_name["daemon"].status == OK
+    assert by_name["observation"].status == WARN
+    assert "Hook enforcement is independent" in by_name["observation"].detail
+    assert by_name["enforcement"].status == OK
+    assert by_name["runtime state"].status == WARN
+    assert by_name["review queue"].status == WARN
+    assert worst(checks) == WARN
+
+
+def test_configured_integration_with_dead_daemon_is_broken_with_local_fallback(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _ready_manifest(homes)
+    _daemon_status(monkeypatch, RuntimeHealth.UNAVAILABLE)
+
+    by_name = {check.name: check for check in check_runtime()}
+
+    assert by_name["daemon"].status == FAIL
+    assert by_name["enforcement"].status == WARN
+    assert "local fallback" in by_name["enforcement"].detail
+
+
+def test_integration_check_detects_duplicate_owned_hooks(homes: tuple[Path, Path]) -> None:
+    manifest = _ready_manifest(homes)
+    hooks = json.loads(Path(manifest.hooks_file).read_text())
+    hooks["hooks"]["PreToolUse"].append(hooks["hooks"]["PreToolUse"][0])
+    Path(manifest.hooks_file).write_text(json.dumps(hooks))
+
+    check = check_integration().check
+
+    assert check.status == FAIL
+    assert "duplicated" in check.detail
+
+
+def test_integration_check_detects_a_stale_legacy_plugin(homes: tuple[Path, Path]) -> None:
+    manifest = _ready_manifest(homes)
+    (Path(manifest.codex_home) / "config.toml").write_text(
+        '[plugins."spotter@spotter"]\nenabled = true\n'
+    )
+
+    check = check_integration().check
+
+    assert check.status == FAIL
+    assert "stale legacy plugin" in check.detail
+
+
+def test_integration_check_reports_a_malformed_owned_hook(homes: tuple[Path, Path]) -> None:
+    _ready_manifest(homes)
+    path = homes[0] / "integrations/codex.json"
+    raw = json.loads(path.read_text())
+    raw["owned_hook"] = "broken"
+    path.write_text(json.dumps(raw))
+
+    check = check_integration().check
+
+    assert check.status == FAIL
+    assert "owned Hook is invalid" in check.detail
+
+
+def test_doctor_probe_reports_an_unreachable_configured_app_server(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest = replace(_ready_manifest(homes), app_server_endpoint="ws://127.0.0.1:1")
+    manifest.save(homes[0] / "integrations/codex.json")
+    _daemon_status(monkeypatch, RuntimeHealth.HEALTHY)
+
+    async def fail(self: CodexAppServerClient) -> None:
+        raise AppServerTransportError("connection refused")
+
+    monkeypatch.setattr(CodexAppServerClient, "connect", fail)
+
+    by_name = {check.name: check for check in check_runtime(deep=True)}
+
+    assert by_name["observation"].status == WARN
+    assert "disconnected" in by_name["observation"].detail
+    assert by_name["live control"].status == WARN
+
+
+@pytest.mark.parametrize(
+    "health,expected",
+    [(OK, 0), (WARN, 1), (FAIL, 2)],
+)
+def test_status_exit_code_matches_runtime_health(
+    homes: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    health: str,
+    expected: int,
+) -> None:
+    sessions = homes[0] / "sessions"
+    sessions.mkdir(parents=True)
+    StepJournal(sessions / "current.jsonl").record(TraceEvent("x"))
+    monkeypatch.setattr("spotter.cli.check_runtime", lambda: [Check("runtime", health, "test")])
+
+    assert main(["status"]) == expected

--- a/tests/test_runtime_diagnostics.py
+++ b/tests/test_runtime_diagnostics.py
@@ -7,7 +7,7 @@ import pytest
 from spotter.app_server import AppServerTransportError, CodexAppServerClient
 from spotter.cli import main
 from spotter.daemon import DaemonClient, DaemonStatus, RuntimeHealth
-from spotter.doctor import FAIL, OK, WARN, Check, check_integration, check_runtime, worst
+from spotter.doctor import FAIL, INFO, OK, WARN, Check, check_integration, check_runtime, worst
 from spotter.integration import MANIFEST_SCHEMA, IntegrationManifest
 from spotter.snapshot import StepJournal
 from spotter.trace import TraceEvent
@@ -79,8 +79,8 @@ def test_running_daemon_without_app_server_is_degraded_but_enforcement_remains(
     assert by_name["observation"].status == WARN
     assert "Hook enforcement is independent" in by_name["observation"].detail
     assert by_name["enforcement"].status == OK
-    assert by_name["runtime state"].status == WARN
-    assert by_name["review queue"].status == WARN
+    assert by_name["runtime state"].status == INFO
+    assert by_name["review queue"].status == INFO
     assert worst(checks) == WARN
 
 
@@ -155,7 +155,7 @@ def test_doctor_probe_reports_an_unreachable_configured_app_server(
 
 @pytest.mark.parametrize(
     "health,expected",
-    [(OK, 0), (WARN, 1), (FAIL, 2)],
+    [(OK, 0), (INFO, 0), (WARN, 1), (FAIL, 2)],
 )
 def test_status_exit_code_matches_runtime_health(
     homes: tuple[Path, Path],
@@ -169,3 +169,26 @@ def test_status_exit_code_matches_runtime_health(
     monkeypatch.setattr("spotter.cli.check_runtime", lambda: [Check("runtime", health, "test")])
 
     assert main(["status"]) == expected
+
+
+def test_healthy_legacy_hook_without_observations_can_exit_zero(
+    homes: tuple[Path, Path],
+) -> None:
+    spotter, codex = homes
+    spotter.mkdir()
+    codex.mkdir()
+    (codex / "hooks.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": ".*",
+                            "hooks": [{"type": "command", "command": "/bin/spotter hook || true"}],
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    assert main(["status"]) == 0


### PR DESCRIPTION
## Summary

- make `status` and `doctor` report daemon, integration, observation, control, enforcement, runtime-state, and reviewer-queue health separately
- validate exact Hook/manifest ownership, stale legacy plugins, managed service registration, and configured App Server reachability
- return consistent healthy/degraded/broken exit codes while preserving storage, ledger, freshness, and synthetic Hook diagnostics
- keep unavailable #85 runtime state explicit instead of fabricating thread or queue counts

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest -q`
- `git diff --check`

Closes #84