### PR TITLE
feat(observation): ingest App Server events into Trace IR

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Evaluation labels / metrics | ✅ | Coverage-aware evaluation and precision/FP metrics |
 | Counterfactual experiment harness | ✅ | Control/guidance same-prefix pairs |
 | Standalone `spotterd` runtime | 🟡 | Process, versioned gate/control IPC, and managed user-service startup implemented; runtime consumers remain |
-| App Server primary observation | 🟡 | Client/capabilities implemented; Trace IR ingestion remains (#85) |
+| App Server primary observation | 🟡 | Client, identity-rich Trace IR normalization, and durable ingestion implemented; daemon routing remains |
 | Event-driven signal engine | ❌ | Current reviewer trigger is periodic |
 | Live `VERIFY / NUDGE` | ❌ | Target: `turn/steer` |
 | `INTERRUPT` | ❌ | Target: `turn/interrupt` |
@@ -91,8 +91,11 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 App Server can share the TUI's real thread and steer its active turn. The production client in
 [#80](https://github.com/spotter-agent/spotter/issues/80) now exposes events, thread queries,
 control methods, and per-capability degraded state. [#81](https://github.com/spotter-agent/spotter/issues/81)
-adds a provisional thread/turn/attachment registry; it remains unconsumed until App Server event
-routing in [#85](https://github.com/spotter-agent/spotter/issues/85). [#79](https://github.com/spotter-agent/spotter/issues/79)
+adds a thread/turn/attachment registry. [#85](https://github.com/spotter-agent/spotter/issues/85)
+uses it to normalize authoritative lifecycle, message, plan, reasoning-summary, command, file-change,
+MCP, search, diff, and token events into durable Trace IR. Exact replays are deduplicated across
+restarts, operation outcomes correlate by item ID, and unknown notification families remain explicit.
+[#79](https://github.com/spotter-agent/spotter/issues/79)
 adds the `spotterd` process, versioned local control handshake, manual lifecycle commands, and a
 platform-neutral service boundary. [#83](https://github.com/spotter-agent/spotter/issues/83) adds
 transactional Codex setup/teardown, managed user-service registration, and integration ownership.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
 > **Status:** this document describes both the current hook-based prototype and the target architecture. Active implementation is tracked by the [Roadmap](roadmap.md) and native GitHub Milestones.
-> The `spotterd` process/control foundation, bounded Hook gate IPC, shared-server PoC, and production App Server transport are implemented. App Server primary Trace IR observation and live supervision delivery remain **target behavior**.
+> The `spotterd` process/control foundation, bounded Hook gate IPC, shared-server PoC, production App Server transport, and durable Trace IR ingestion are implemented. Daemon event routing and live supervision delivery remain **target behavior**.
 
 ---
 
@@ -467,6 +467,23 @@ side-effect class
 
 Normalization must not discard provenance. Live control, replay, and causal analysis must be able to reconnect normalized records to the underlying runtime item/turn.
 
+## Implemented App Server ingestion
+
+`CodexTraceNormalizer` is the transport boundary. It maps App Server lifecycle and authoritative
+completed-item records into the runtime-neutral fields above. Raw reasoning content is not copied;
+only the App Server's exposed reasoning summary enters Trace IR. Unknown notification methods become
+`runtime_event_unknown` records containing the method and any proven identity, rather than silently
+disappearing or leaking a new wire shape into core consumers.
+
+`AppServerTraceIngestor` writes one journal per Spotter thread identity, separately named from
+Hook-era session journals. Its recovery scan rebuilds deduplication and lifecycle state after a
+restart. Item starts and outcomes correlate by App Server item ID, not journal adjacency. A terminal
+event seen before its start is retained with `observed_start=false`; a later start cannot regress it.
+Timestamp regressions are accepted but marked `out_of_order`, and conflicting terminal outcomes fail
+explicitly. Hook records carry legacy-session provenance with unknown thread, turn, and attachment
+dimensions, so consumers never need Codex transport objects and never infer that a Hook session is an
+App Server thread.
+
 ---
 
 # 7. Reviewer jobs and freshness
@@ -647,9 +664,9 @@ State scope:
 - Hook-era `session_id` becomes a `RuntimeIdentity` with unknown thread/turn/attachment fields rather
   than being promoted into an identity it cannot prove.
 
-The registry owns identity and lifecycle only and has no production consumer yet. Semantic
-`ThreadState` remains #31; App Server event normalization/routing in #85 must validate and may
-reshape this interface.
+The registry owns identity and lifecycle only; App Server Trace normalization and journal recovery
+consume it without promoting it into semantic state. Semantic `ThreadState` remains #31, and daemon
+connection reconciliation remains #87.
 
 ---
 

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import time
 from contextlib import suppress
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -29,20 +30,30 @@ from spotter.daemon import (
 )
 from spotter.effects import classify
 from spotter.gates import Gate, GateDecision
+from spotter.identity import RuntimeIdentity
 from spotter.paths import sanitize_session, secure_dir, spotter_home
 from spotter.snapshot import SnapshotError, StepJournal, global_lock, snapshot_worktree
-from spotter.trace import TraceEvent
+from spotter.trace import TraceEvent, TraceProvenance
 
 _PATCH_PATH = re.compile(r"^\*\*\* (?:(?:Add|Update|Delete) File|Move to): (.+)$", re.MULTILINE)
 
 
 class JournalAdapter:
-    def __init__(self, journal: StepJournal) -> None:
+    def __init__(
+        self,
+        journal: StepJournal,
+        identity: RuntimeIdentity | None = None,
+        provenance: TraceProvenance | None = None,
+    ) -> None:
         self.journal = journal
+        self.identity = identity
+        self.provenance = provenance
         self.next_snapshot: str | None = None
         self.last_proposal_number = 0
 
     def record(self, event: TraceEvent) -> None:
+        if event.identity is None:
+            event = replace(event, identity=self.identity, provenance=self.provenance)
         record = self.journal.record(event, snapshot=self.next_snapshot)
         if event.kind == "tool_proposal":
             self.last_proposal_number = int(record.event.payload["proposal_number"])
@@ -207,7 +218,17 @@ def run_hook(
     )
     journal_file = journal_path(payload)
     journal = StepJournal(journal_file)
-    adapter = JournalAdapter(journal)
+    session_id = payload.get("session_id")
+    identity = RuntimeIdentity.legacy_hook(
+        config.main_agent.adapter,
+        session_id if isinstance(session_id, str) else None,
+    )
+    method = payload.get("hook_event_name")
+    adapter = JournalAdapter(
+        journal,
+        identity,
+        TraceProvenance("codex_hook", method if isinstance(method, str) else None),
+    )
     runtime = SpotterRuntime(config, adapter, gate)
     event = event_from_hook(payload)
     gate_decision: GateDecision | None = None

--- a/src/spotter/identity.py
+++ b/src/spotter/identity.py
@@ -205,6 +205,7 @@ class RuntimeIdentityRegistry:
         agent_turn_id: str,
         *,
         attachment_id: AttachmentId | None = None,
+        observed_start: bool = True,
     ) -> Turn:
         thread = self.thread(thread_id)
         agent_turn_id = _required(agent_turn_id, "agent turn id")
@@ -228,7 +229,7 @@ class RuntimeIdentityRegistry:
             turn = replace(
                 turn,
                 attachment_id=turn.attachment_id or attachment_id,
-                observed_start=True,
+                observed_start=turn.observed_start or observed_start,
             )
             self._turns[turn_id] = turn
             return turn
@@ -239,7 +240,7 @@ class RuntimeIdentityRegistry:
             thread_id=thread_id,
             attachment_id=attachment_id,
             status=TurnStatus.ACTIVE,
-            observed_start=True,
+            observed_start=observed_start,
             provenance=IdentityProvenance(
                 agent=thread.provenance.agent,
                 agent_thread_id=thread.provenance.agent_thread_id,

--- a/src/spotter/ingestion.py
+++ b/src/spotter/ingestion.py
@@ -1,0 +1,470 @@
+"""Normalize Codex App Server notifications into durable, runtime-neutral traces."""
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from spotter.app_server import AppServerEvent
+from spotter.identity import (
+    IdentityProvenance,
+    RuntimeIdentity,
+    RuntimeIdentityRegistry,
+    TurnStatus,
+)
+from spotter.snapshot import StepJournal, StepRecord
+from spotter.trace import TraceEvent, TraceProvenance
+
+_AGENT = "codex"
+_SOURCE = "codex_app_server"
+
+
+class IngestionError(ValueError):
+    """An App Server event cannot be normalized without guessing or conflicts with history."""
+
+
+class CodexTraceNormalizer:
+    """The only layer allowed to know Codex notification and ThreadItem shapes."""
+
+    def __init__(self, identities: RuntimeIdentityRegistry | None = None) -> None:
+        self.identities = identities or RuntimeIdentityRegistry()
+
+    def normalize(self, event: AppServerEvent) -> TraceEvent:
+        params = event.raw.get("params")
+        if not isinstance(params, Mapping):
+            raise IngestionError(f"{event.method} notification has no object params")
+        params = dict(params)
+        event_id = _event_id(event.method, params)
+        provenance = TraceProvenance(_SOURCE, event.method)
+
+        if event.method == "thread/started":
+            thread = _object(params.get("thread"), "thread")
+            started_thread_id = _string(thread.get("id"), "thread.id")
+            identity = self._identity(started_thread_id)
+            return TraceEvent(
+                "thread_started",
+                _known(thread, "cwd", "sessionId", "status", "name"),
+                event_id,
+                _seconds(thread.get("createdAt")),
+                identity,
+                provenance=provenance,
+            )
+
+        external_thread_id = _optional_string(params.get("threadId"))
+        turn_raw = params.get("turn")
+        external_turn_id = _optional_string(params.get("turnId"))
+        if isinstance(turn_raw, Mapping):
+            external_turn_id = _optional_string(turn_raw.get("id")) or external_turn_id
+
+        if event.method == "turn/completed":
+            if external_thread_id is None or external_turn_id is None:
+                raise IngestionError("turn/completed omitted thread or turn identity")
+            completed_turn = _object(turn_raw, "turn")
+            outcome = _optional_string(completed_turn.get("status"))
+            status = TurnStatus.INTERRUPTED if outcome == "interrupted" else TurnStatus.COMPLETED
+            identity, observed_start = self._finish_turn(
+                external_thread_id, external_turn_id, status
+            )
+            payload = _known(completed_turn, "status", "durationMs", "error")
+            payload["observed_start"] = observed_start
+            return TraceEvent(
+                "turn_completed",
+                payload,
+                event_id,
+                _seconds(completed_turn.get("completedAt")),
+                identity,
+                provenance=provenance,
+            )
+
+        identity = self._identity(
+            external_thread_id,
+            external_turn_id,
+            observed_turn_start=event.method == "turn/started",
+        )
+
+        if event.method == "turn/started":
+            if not isinstance(turn_raw, Mapping):
+                raise IngestionError("turn/started omitted turn")
+            return TraceEvent(
+                "turn_started",
+                _known(turn_raw, "status"),
+                event_id,
+                _seconds(turn_raw.get("startedAt")),
+                identity,
+                provenance=provenance,
+            )
+        if event.method == "thread/status/changed":
+            return TraceEvent(
+                "thread_status",
+                _known(params, "status"),
+                event_id,
+                identity=identity,
+                provenance=provenance,
+            )
+        if event.method in {
+            "thread/archived",
+            "thread/unarchived",
+            "thread/closed",
+            "thread/deleted",
+        }:
+            return TraceEvent(
+                event.method.replace("/", "_"),
+                {},
+                event_id,
+                identity=identity,
+                provenance=provenance,
+            )
+        if event.method in {"item/started", "item/completed"}:
+            item = _object(params.get("item"), "item")
+            item_id = _string(item.get("id"), "item.id")
+            completed = event.method == "item/completed"
+            kind, payload = _normalize_item(item, completed)
+            payload["lifecycle"] = "completed" if completed else "started"
+            timestamp = _milliseconds(
+                params.get("completedAtMs") if completed else params.get("startedAtMs")
+            )
+            return TraceEvent(
+                kind,
+                payload,
+                event_id,
+                timestamp,
+                identity,
+                operation_id=item_id,
+                item_id=item_id,
+                provenance=provenance,
+            )
+        if event.method == "turn/diff/updated":
+            return TraceEvent(
+                "diff_updated",
+                _known(params, "diff"),
+                event_id,
+                identity=identity,
+                provenance=provenance,
+            )
+        if event.method == "turn/plan/updated":
+            plan = params.get("plan")
+            plan_payload: dict[str, Any] = {}
+            if isinstance(plan, list):
+                plan_payload["steps"] = [
+                    _known(step, "step", "status") for step in plan if isinstance(step, Mapping)
+                ]
+            if isinstance(params.get("explanation"), str):
+                plan_payload["explanation"] = params["explanation"]
+            return TraceEvent(
+                "plan",
+                plan_payload,
+                event_id,
+                identity=identity,
+                provenance=provenance,
+            )
+        if event.method == "thread/tokenUsage/updated":
+            return TraceEvent(
+                "token_usage",
+                _token_usage(params.get("tokenUsage")),
+                event_id,
+                identity=identity,
+                provenance=provenance,
+            )
+        if event.method == "error":
+            return TraceEvent(
+                "runtime_error",
+                _known(params, "error", "willRetry"),
+                event_id,
+                identity=identity,
+                provenance=provenance,
+            )
+
+        # Unknown notifications remain visible without copying an unstable wire payload into IR.
+        return TraceEvent(
+            "runtime_event_unknown",
+            {"method": event.method},
+            event_id,
+            identity=identity,
+            item_id=_optional_string(params.get("itemId")),
+            provenance=provenance,
+        )
+
+    def _identity(
+        self,
+        external_thread_id: str | None,
+        external_turn_id: str | None = None,
+        *,
+        observed_turn_start: bool = False,
+    ) -> RuntimeIdentity:
+        if external_thread_id is None:
+            return RuntimeIdentity(None, None, None, IdentityProvenance(agent=_AGENT))
+        thread = self.identities.observe_thread(_AGENT, external_thread_id)
+        if external_turn_id is None:
+            return RuntimeIdentity(thread.id, None, None, thread.provenance)
+        turn = self.identities.start_turn(
+            thread.id, external_turn_id, observed_start=observed_turn_start
+        )
+        return self.identities.address_turn(turn.id)
+
+    def _finish_turn(
+        self, external_thread_id: str, external_turn_id: str, status: TurnStatus
+    ) -> tuple[RuntimeIdentity, bool]:
+        thread = self.identities.observe_thread(_AGENT, external_thread_id)
+        turn = self.identities.finish_turn(thread.id, external_turn_id, status)
+        return self.identities.address_turn(turn.id), turn.observed_start
+
+
+class AppServerTraceIngestor:
+    """Append normalized events once, with restart-safe lifecycle reconciliation."""
+
+    def __init__(self, journals_dir: Path) -> None:
+        self.journals_dir = journals_dir
+        self.journals_dir.mkdir(parents=True, exist_ok=True)
+        self.normalizer = CodexTraceNormalizer()
+        self._seen: set[str] = set()
+        self._operations: dict[tuple[str, str, str], tuple[str, str | None]] = {}
+        self._terminal_turns: set[str] = set()
+        self._last_at: dict[tuple[str, str], float] = {}
+        self._recover()
+
+    def ingest(self, raw_event: AppServerEvent) -> StepRecord | None:
+        event = self.normalizer.normalize(raw_event)
+        if event.event_id is not None and event.event_id in self._seen:
+            return None
+        route = _route(event)
+        turn_key = (
+            event.identity.turn_id.value if event.identity and event.identity.turn_id else None
+        )
+        if event.kind == "turn_started" and turn_key in self._terminal_turns:
+            return None
+
+        if event.operation_id is not None:
+            operation_key = _operation_key(event, route)
+            lifecycle = _optional_string(event.payload.get("lifecycle"))
+            previous = self._operations.get(operation_key)
+            if lifecycle == "started" and previous and previous[0] == "completed":
+                return None
+            if lifecycle == "completed":
+                outcome = _optional_string(event.payload.get("status"))
+                if previous and previous[0] == "completed":
+                    if previous[1] != outcome:
+                        raise IngestionError(
+                            f"operation {event.operation_id} changed terminal outcome "
+                            f"from {previous[1]!r} to {outcome!r}"
+                        )
+                    return None
+                payload = dict(event.payload)
+                payload["observed_start"] = previous is not None
+                event = replace(event, payload=payload)
+
+        if event.occurred_at is not None:
+            ordering_key = _ordering_key(event, route)
+            last_at = self._last_at.get(ordering_key)
+            if last_at is not None and event.occurred_at < last_at:
+                event = replace(event, payload={**event.payload, "out_of_order": True})
+
+        record = StepJournal(self.journals_dir / route).record(event)
+        self._remember(record.event, route)
+        return record
+
+    def _recover(self) -> None:
+        for path in sorted(self.journals_dir.glob("app-server-*.jsonl")):
+            for record in StepJournal.load(path, strict=True):
+                event = record.event
+                self._restore_identity(event)
+                self._remember(event, path.name)
+
+    def _restore_identity(self, event: TraceEvent) -> None:
+        identity = event.identity
+        if identity is None or identity.provenance.agent_thread_id is None:
+            return
+        thread = self.normalizer.identities.observe_thread(
+            identity.provenance.agent, identity.provenance.agent_thread_id
+        )
+        external_turn_id = identity.provenance.agent_turn_id
+        if external_turn_id is None:
+            return
+        if event.kind == "turn_completed":
+            outcome = event.payload.get("status")
+            status = TurnStatus.INTERRUPTED if outcome == "interrupted" else TurnStatus.COMPLETED
+            self.normalizer.identities.finish_turn(thread.id, external_turn_id, status)
+        else:
+            self.normalizer.identities.start_turn(
+                thread.id,
+                external_turn_id,
+                observed_start=event.kind == "turn_started",
+            )
+
+    def _remember(self, event: TraceEvent, route: str) -> None:
+        if event.event_id is not None:
+            self._seen.add(event.event_id)
+        if event.operation_id is not None:
+            lifecycle = _optional_string(event.payload.get("lifecycle"))
+            if lifecycle is not None:
+                self._operations[_operation_key(event, route)] = (
+                    lifecycle,
+                    _optional_string(event.payload.get("status")),
+                )
+        if event.kind == "turn_completed" and event.identity and event.identity.turn_id:
+            self._terminal_turns.add(event.identity.turn_id.value)
+        if event.occurred_at is not None:
+            ordering_key = _ordering_key(event, route)
+            self._last_at[ordering_key] = max(
+                self._last_at.get(ordering_key, event.occurred_at), event.occurred_at
+            )
+
+
+def _normalize_item(item: Mapping[str, Any], completed: bool) -> tuple[str, dict[str, Any]]:
+    item_type = _optional_string(item.get("type")) or "unknown"
+    if item_type == "userMessage":
+        return "user_prompt", {"content": _user_content(item.get("content"))}
+    if item_type == "agentMessage":
+        return "agent_message", _known(item, "text", "phase")
+    if item_type == "plan":
+        return "plan", _known(item, "text")
+    if item_type == "reasoning":
+        # App Server exposes both summary and raw reasoning content. Only the summary is Trace IR.
+        summary = item.get("summary")
+        return "reasoning_summary", {"summary": summary if isinstance(summary, list) else []}
+    if item_type == "commandExecution":
+        kind = "command_result" if completed else "command_started"
+        return kind, _known(
+            item,
+            "command",
+            "cwd",
+            "status",
+            "aggregatedOutput",
+            "exitCode",
+            "durationMs",
+            "source",
+        )
+    if item_type == "fileChange":
+        changes = item.get("changes")
+        normalized = (
+            [
+                _known(change, "path", "kind", "diff")
+                for change in changes
+                if isinstance(change, Mapping)
+            ]
+            if isinstance(changes, list)
+            else []
+        )
+        return ("file_edit" if completed else "file_change_started"), {
+            "status": item.get("status"),
+            "files": [change["path"] for change in normalized if "path" in change],
+            "changes": normalized,
+        }
+    if item_type == "mcpToolCall":
+        kind = "tool_result" if completed else "tool_started"
+        return kind, _known(
+            item, "server", "tool", "arguments", "status", "result", "error", "durationMs"
+        )
+    if item_type == "dynamicToolCall":
+        kind = "tool_result" if completed else "tool_started"
+        return kind, _known(
+            item,
+            "namespace",
+            "tool",
+            "arguments",
+            "status",
+            "success",
+            "contentItems",
+            "durationMs",
+        )
+    if item_type == "webSearch":
+        return ("search" if completed else "search_started"), _known(
+            item, "query", "action", "results"
+        )
+    return ("item_completed" if completed else "item_started"), {"item_type": item_type}
+
+
+def _event_id(method: str, params: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        {"method": method, "params": params},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode()
+    return f"codex:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _route(event: TraceEvent) -> str:
+    if event.identity is not None and event.identity.thread_id is not None:
+        return f"app-server-{event.identity.thread_id.value}.jsonl"
+    return "app-server-unscoped.jsonl"
+
+
+def _operation_key(event: TraceEvent, route: str) -> tuple[str, str, str]:
+    turn_id = (
+        event.identity.turn_id.value
+        if event.identity is not None and event.identity.turn_id is not None
+        else ""
+    )
+    assert event.operation_id is not None
+    return route, turn_id, event.operation_id
+
+
+def _ordering_key(event: TraceEvent, route: str) -> tuple[str, str]:
+    turn_id = (
+        event.identity.turn_id.value
+        if event.identity is not None and event.identity.turn_id is not None
+        else ""
+    )
+    return route, turn_id
+
+
+def _token_usage(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    payload: dict[str, Any] = {}
+    for group in ("last", "total"):
+        raw_group = value.get(group)
+        if isinstance(raw_group, Mapping):
+            payload[group] = _known(
+                raw_group,
+                "inputTokens",
+                "cachedInputTokens",
+                "cacheWriteInputTokens",
+                "outputTokens",
+                "reasoningOutputTokens",
+                "totalTokens",
+            )
+    if isinstance(value.get("modelContextWindow"), int):
+        payload["modelContextWindow"] = value["modelContextWindow"]
+    return payload
+
+
+def _user_content(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [
+        _known(part, "type", "text", "url", "path") for part in value if isinstance(part, Mapping)
+    ]
+
+
+def _known(value: object, *keys: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {key: value[key] for key in keys if key in value and value[key] is not None}
+
+
+def _object(value: object, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise IngestionError(f"{name} must be an object")
+    return value
+
+
+def _string(value: object, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise IngestionError(f"{name} must be a non-empty string")
+    return value
+
+
+def _optional_string(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _seconds(value: object) -> float | None:
+    return float(value) if isinstance(value, int | float) and not isinstance(value, bool) else None
+
+
+def _milliseconds(value: object) -> float | None:
+    seconds = _seconds(value)
+    return seconds / 1000 if seconds is not None else None

--- a/src/spotter/ingestion.py
+++ b/src/spotter/ingestion.py
@@ -19,6 +19,13 @@ from spotter.trace import TraceEvent, TraceProvenance
 
 _AGENT = "codex"
 _SOURCE = "codex_app_server"
+_REPLAY_SAFE_METHODS = {
+    "thread/started",
+    "turn/started",
+    "turn/completed",
+    "item/started",
+    "item/completed",
+}
 
 
 class IngestionError(ValueError):
@@ -222,6 +229,8 @@ class AppServerTraceIngestor:
         self._operations: dict[tuple[str, str, str], tuple[str, str | None]] = {}
         self._terminal_turns: set[str] = set()
         self._last_at: dict[tuple[str, str], float] = {}
+        # ponytail: recovery is O(all App Server history); #87 should checkpoint per-thread
+        # reconciliation state and apply retention before the daemon owns long-lived ingestion.
         self._recover()
 
     def ingest(self, raw_event: AppServerEvent) -> StepRecord | None:
@@ -239,7 +248,7 @@ class AppServerTraceIngestor:
             operation_key = _operation_key(event, route)
             lifecycle = _optional_string(event.payload.get("lifecycle"))
             previous = self._operations.get(operation_key)
-            if lifecycle == "started" and previous and previous[0] == "completed":
+            if lifecycle == "started" and previous is not None:
                 return None
             if lifecycle == "completed":
                 outcome = _optional_string(event.payload.get("status"))
@@ -266,7 +275,7 @@ class AppServerTraceIngestor:
 
     def _recover(self) -> None:
         for path in sorted(self.journals_dir.glob("app-server-*.jsonl")):
-            for record in StepJournal.load(path, strict=True):
+            for record in StepJournal.load(path, repair_tail=True):
                 event = record.event
                 self._restore_identity(event)
                 self._remember(event, path.name)
@@ -375,7 +384,9 @@ def _normalize_item(item: Mapping[str, Any], completed: bool) -> tuple[str, dict
     return ("item_completed" if completed else "item_started"), {"item_type": item_type}
 
 
-def _event_id(method: str, params: Mapping[str, Any]) -> str:
+def _event_id(method: str, params: Mapping[str, Any]) -> str | None:
+    if method not in _REPLAY_SAFE_METHODS:
+        return None
     encoded = json.dumps(
         {"method": method, "params": params},
         sort_keys=True,

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -20,9 +20,16 @@ from fcntl import LOCK_EX, LOCK_UN, flock
 from pathlib import Path
 from typing import Any
 
+from spotter.identity import (
+    AttachmentId,
+    IdentityProvenance,
+    RuntimeIdentity,
+    ThreadId,
+    TurnId,
+)
 from spotter.paths import secure_dir, spotter_home
 from spotter.redact import redact
-from spotter.trace import TraceEvent
+from spotter.trace import TraceEvent, TraceProvenance
 
 
 class SnapshotError(RuntimeError):
@@ -206,7 +213,16 @@ class StepJournal:
                 if event.kind == "tool_proposal":
                     state["proposals"] = int(state["proposals"]) + 1
                     payload["proposal_number"] = state["proposals"]
-                stored_event = TraceEvent(event.kind, payload)
+                stored_event = TraceEvent(
+                    event.kind,
+                    payload,
+                    event_id=event.event_id,
+                    occurred_at=event.occurred_at,
+                    identity=event.identity,
+                    operation_id=event.operation_id,
+                    item_id=event.item_id,
+                    provenance=event.provenance,
+                )
                 record = StepRecord(step, stored_event, snapshot, time.time(), SCHEMA_VERSION)
                 line = json.dumps(
                     {
@@ -215,6 +231,7 @@ class StepJournal:
                         "at": record.at,
                         "kind": stored_event.kind,
                         "payload": stored_event.payload,
+                        "trace": _trace_metadata(stored_event),
                         "snapshot": snapshot,
                     },
                     ensure_ascii=False,
@@ -293,7 +310,7 @@ class StepJournal:
                 records.append(
                     StepRecord(
                         step=step,
-                        event=TraceEvent(str(raw["kind"]), dict(raw.get("payload") or {})),
+                        event=_trace_event(raw),
                         snapshot=raw.get("snapshot"),
                         at=float(at) if isinstance(at, int | float) else None,
                         version=version,
@@ -305,6 +322,88 @@ class StepJournal:
     def prefix(records: list[StepRecord], upto: int) -> list[StepRecord]:
         """Events before step ``upto`` — the branch point for a future replay."""
         return [r for r in records if r.step < upto]
+
+
+def _trace_metadata(event: TraceEvent) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    for name in ("event_id", "occurred_at", "operation_id", "item_id"):
+        value = getattr(event, name)
+        if value is not None:
+            metadata[name] = value
+    if event.provenance is not None:
+        metadata["provenance"] = {
+            "source": event.provenance.source,
+            "method": event.provenance.method,
+        }
+    if event.identity is not None:
+        provenance = event.identity.provenance
+        metadata["identity"] = {
+            "thread_id": event.identity.thread_id.value if event.identity.thread_id else None,
+            "turn_id": event.identity.turn_id.value if event.identity.turn_id else None,
+            "attachment_id": (
+                event.identity.attachment_id.value if event.identity.attachment_id else None
+            ),
+            "agent": provenance.agent,
+            "agent_thread_id": provenance.agent_thread_id,
+            "agent_turn_id": provenance.agent_turn_id,
+            "agent_attachment_id": provenance.agent_attachment_id,
+            "legacy_session_id": provenance.legacy_session_id,
+        }
+    return metadata
+
+
+def _trace_event(raw: dict[str, Any]) -> TraceEvent:
+    metadata = raw.get("trace")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    identity_raw = metadata.get("identity")
+    identity = None
+    if isinstance(identity_raw, dict) and isinstance(identity_raw.get("agent"), str):
+        identity = RuntimeIdentity(
+            thread_id=(
+                ThreadId(identity_raw["thread_id"])
+                if isinstance(identity_raw.get("thread_id"), str)
+                else None
+            ),
+            turn_id=(
+                TurnId(identity_raw["turn_id"])
+                if isinstance(identity_raw.get("turn_id"), str)
+                else None
+            ),
+            attachment_id=(
+                AttachmentId(identity_raw["attachment_id"])
+                if isinstance(identity_raw.get("attachment_id"), str)
+                else None
+            ),
+            provenance=IdentityProvenance(
+                agent=identity_raw["agent"],
+                agent_thread_id=_optional_string(identity_raw.get("agent_thread_id")),
+                agent_turn_id=_optional_string(identity_raw.get("agent_turn_id")),
+                agent_attachment_id=_optional_string(identity_raw.get("agent_attachment_id")),
+                legacy_session_id=_optional_string(identity_raw.get("legacy_session_id")),
+            ),
+        )
+    provenance_raw = metadata.get("provenance")
+    provenance = None
+    if isinstance(provenance_raw, dict) and isinstance(provenance_raw.get("source"), str):
+        provenance = TraceProvenance(
+            provenance_raw["source"], _optional_string(provenance_raw.get("method"))
+        )
+    occurred_at = metadata.get("occurred_at")
+    return TraceEvent(
+        str(raw["kind"]),
+        dict(raw.get("payload") or {}),
+        event_id=_optional_string(metadata.get("event_id")),
+        occurred_at=float(occurred_at) if isinstance(occurred_at, int | float) else None,
+        identity=identity,
+        operation_id=_optional_string(metadata.get("operation_id")),
+        item_id=_optional_string(metadata.get("item_id")),
+        provenance=provenance,
+    )
+
+
+def _optional_string(value: object) -> str | None:
+    return value if isinstance(value, str) else None
 
 
 def snapshot_references(

--- a/src/spotter/trace.py
+++ b/src/spotter/trace.py
@@ -4,11 +4,27 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
+from spotter.identity import RuntimeIdentity
+
+
+@dataclass(frozen=True)
+class TraceProvenance:
+    """Reference to the transport event without leaking its wire shape into core policy."""
+
+    source: str
+    method: str | None = None
+
 
 @dataclass(frozen=True)
 class TraceEvent:
     kind: str
     payload: dict[str, Any] = field(default_factory=dict)
+    event_id: str | None = None
+    occurred_at: float | None = None
+    identity: RuntimeIdentity | None = None
+    operation_id: str | None = None
+    item_id: str | None = None
+    provenance: TraceProvenance | None = None
 
 
 # Judgment happens on semantic segments, enforcement on tool boundaries (plan Q8).

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -227,6 +227,11 @@ def test_unknown_events_still_journal(spotter_home: Path) -> None:
     assert run_hook(payload, _config(observation_only=True)) is None
     records = StepJournal.load(journal_path(payload))
     assert records[0].event.kind == "sessionstart"
+    assert records[0].event.identity is not None
+    assert records[0].event.identity.thread_id is None
+    assert records[0].event.identity.provenance.legacy_session_id == "s2"
+    assert records[0].event.provenance is not None
+    assert records[0].event.provenance.source == "codex_hook"
 
 
 def test_apply_patch_takes_snapshot_for_fork(

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -153,6 +153,39 @@ def test_duplicate_and_out_of_order_events_reconcile_across_restart(tmp_path: Pa
     assert resumed.ingest(_item_event("item/started", {**command, "status": "inProgress"})) is None
 
 
+def test_recovery_repairs_a_torn_journal_tail(tmp_path: Path) -> None:
+    ingestor = AppServerTraceIngestor(tmp_path)
+    ingestor.ingest(
+        _event(
+            "thread/started",
+            {"thread": {"id": "thread-1", "createdAt": 100, "cwd": "/repo"}},
+        )
+    )
+    journal = next(tmp_path.glob("app-server-*.jsonl"))
+    with journal.open("ab") as handle:
+        handle.write(b'{"step": 1')
+
+    resumed = AppServerTraceIngestor(tmp_path)
+    resumed.ingest(_event("thread/status/changed", {"threadId": "thread-1", "status": "active"}))
+
+    assert [record.event.kind for record in StepJournal.load(journal)] == [
+        "thread_started",
+        "thread_status",
+    ]
+
+
+def test_identical_stateless_notifications_are_not_mistaken_for_replays(tmp_path: Path) -> None:
+    ingestor = AppServerTraceIngestor(tmp_path)
+    status = _event("thread/status/changed", {"threadId": "thread-1", "status": "active"})
+
+    first = ingestor.ingest(status)
+    second = ingestor.ingest(status)
+
+    assert first is not None and second is not None
+    assert first.event.event_id is None
+    assert second.event.event_id is None
+
+
 def test_operation_and_timestamp_state_is_scoped_to_a_turn(tmp_path: Path) -> None:
     ingestor = AppServerTraceIngestor(tmp_path)
     item = {

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,271 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from spotter.app_server import AppServerEvent
+from spotter.ingestion import AppServerTraceIngestor, CodexTraceNormalizer, IngestionError
+from spotter.snapshot import StepJournal
+
+
+def _event(method: str, params: dict[str, Any]) -> AppServerEvent:
+    return AppServerEvent(method, {"method": method, "params": params})
+
+
+def _turn(status: str = "inProgress", **timestamps: int) -> dict[str, Any]:
+    return {
+        "id": "turn-1",
+        "status": status,
+        "items": [],
+        "error": None,
+        **timestamps,
+    }
+
+
+def _item_event(method: str, item: dict[str, Any], timestamp_ms: int = 1_000) -> AppServerEvent:
+    timestamp = "completedAtMs" if method == "item/completed" else "startedAtMs"
+    return _event(
+        method,
+        {"threadId": "thread-1", "turnId": "turn-1", "item": item, timestamp: timestamp_ms},
+    )
+
+
+def test_normalizes_lifecycle_and_authoritative_item_families() -> None:
+    normalizer = CodexTraceNormalizer()
+    thread = normalizer.normalize(
+        _event(
+            "thread/started",
+            {
+                "thread": {
+                    "id": "thread-1",
+                    "createdAt": 100,
+                    "cwd": "/repo",
+                    "status": {"type": "idle"},
+                    "futureField": "must not leak",
+                }
+            },
+        )
+    )
+    turn = normalizer.normalize(
+        _event("turn/started", {"threadId": "thread-1", "turn": _turn(startedAt=101)})
+    )
+    completed_turn = normalizer.normalize(
+        _event(
+            "turn/completed",
+            {"threadId": "thread-1", "turn": _turn("completed", completedAt=103)},
+        )
+    )
+    command = normalizer.normalize(
+        _item_event(
+            "item/completed",
+            {
+                "id": "command-7",
+                "type": "commandExecution",
+                "command": "pytest",
+                "cwd": "/repo",
+                "status": "completed",
+                "aggregatedOutput": "ok",
+                "exitCode": 0,
+                "durationMs": 20,
+                "commandActions": [],
+            },
+            102_000,
+        )
+    )
+    reasoning = normalizer.normalize(
+        _item_event(
+            "item/completed",
+            {
+                "id": "reasoning-1",
+                "type": "reasoning",
+                "summary": ["Check the failing test"],
+                "content": ["private chain of thought"],
+            },
+        )
+    )
+
+    assert thread.kind == "thread_started"
+    assert thread.occurred_at == 100
+    assert thread.payload == {"cwd": "/repo", "status": {"type": "idle"}}
+    assert turn.kind == "turn_started"
+    assert completed_turn.payload["observed_start"] is True
+    assert thread.identity is not None and turn.identity is not None
+    assert thread.identity.thread_id == turn.identity.thread_id
+    assert turn.identity.provenance.agent_turn_id == "turn-1"
+    assert command.kind == "command_result"
+    assert command.operation_id == command.item_id == "command-7"
+    assert command.occurred_at == 102
+    assert command.payload["exitCode"] == 0
+    assert reasoning.payload["summary"] == ["Check the failing test"]
+    assert "content" not in reasoning.payload
+
+
+def test_correlates_operation_by_item_id_not_event_adjacency(tmp_path: Path) -> None:
+    ingestor = AppServerTraceIngestor(tmp_path)
+    command = {
+        "id": "command-7",
+        "type": "commandExecution",
+        "command": "pytest",
+        "cwd": "/repo",
+        "status": "inProgress",
+        "commandActions": [],
+    }
+    started = ingestor.ingest(_item_event("item/started", command, 1_000))
+    ingestor.ingest(
+        _item_event(
+            "item/completed",
+            {"id": "message-1", "type": "agentMessage", "text": "still working"},
+            1_500,
+        )
+    )
+    completed = ingestor.ingest(
+        _item_event(
+            "item/completed",
+            {**command, "status": "completed", "aggregatedOutput": "ok", "exitCode": 0},
+            2_000,
+        )
+    )
+
+    assert started is not None and completed is not None
+    assert started.event.operation_id == completed.event.operation_id == "command-7"
+    assert completed.event.payload["observed_start"] is True
+
+
+def test_duplicate_and_out_of_order_events_reconcile_across_restart(tmp_path: Path) -> None:
+    command = {
+        "id": "command-7",
+        "type": "commandExecution",
+        "command": "pytest",
+        "cwd": "/repo",
+        "status": "completed",
+        "commandActions": [],
+    }
+    completion = _item_event("item/completed", command, 2_000)
+    first = AppServerTraceIngestor(tmp_path)
+    record = first.ingest(completion)
+
+    assert record is not None
+    assert record.event.payload["observed_start"] is False
+    assert first.ingest(completion) is None
+
+    resumed = AppServerTraceIngestor(tmp_path)
+    assert resumed.ingest(completion) is None
+    assert resumed.ingest(_item_event("item/started", {**command, "status": "inProgress"})) is None
+
+
+def test_operation_and_timestamp_state_is_scoped_to_a_turn(tmp_path: Path) -> None:
+    ingestor = AppServerTraceIngestor(tmp_path)
+    item = {
+        "id": "reused-item-id",
+        "type": "commandExecution",
+        "command": "pytest",
+        "cwd": "/repo",
+        "status": "completed",
+        "commandActions": [],
+    }
+    ingestor.ingest(_item_event("item/completed", item, 2_000))
+    second_turn = ingestor.ingest(
+        _event(
+            "item/completed",
+            {
+                "threadId": "thread-1",
+                "turnId": "turn-2",
+                "item": item,
+                "completedAtMs": 1_000,
+            },
+        )
+    )
+
+    assert second_turn is not None
+    assert second_turn.event.payload["observed_start"] is False
+    assert "out_of_order" not in second_turn.event.payload
+
+
+def test_out_of_order_timestamp_is_explicit_and_terminal_conflicts_fail(tmp_path: Path) -> None:
+    ingestor = AppServerTraceIngestor(tmp_path)
+    item = {
+        "id": "command-7",
+        "type": "commandExecution",
+        "command": "pytest",
+        "cwd": "/repo",
+        "status": "inProgress",
+        "commandActions": [],
+    }
+    ingestor.ingest(_item_event("item/started", item, 2_000))
+    completed = ingestor.ingest(
+        _item_event("item/completed", {**item, "status": "completed"}, 1_000)
+    )
+
+    assert completed is not None and completed.event.payload["out_of_order"] is True
+    with pytest.raises(IngestionError, match="changed terminal outcome"):
+        ingestor.ingest(_item_event("item/completed", {**item, "status": "failed"}, 3_000))
+
+
+def test_unknown_and_token_events_keep_identity_without_wire_shapes() -> None:
+    normalizer = CodexTraceNormalizer()
+    unknown = normalizer.normalize(
+        _event(
+            "future/event",
+            {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "itemId": "future-1",
+                "newPayload": {"transport": "shape"},
+            },
+        )
+    )
+    usage = normalizer.normalize(
+        _event(
+            "thread/tokenUsage/updated",
+            {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "tokenUsage": {
+                    "last": {"inputTokens": 10, "outputTokens": 4, "futureCount": 99},
+                    "total": {"totalTokens": 14},
+                    "modelContextWindow": 200_000,
+                },
+            },
+        )
+    )
+
+    assert unknown.kind == "runtime_event_unknown"
+    assert unknown.payload == {"method": "future/event"}
+    assert unknown.item_id == "future-1"
+    assert unknown.identity is not None and unknown.identity.turn_id is not None
+    assert usage.payload == {
+        "last": {"inputTokens": 10, "outputTokens": 4},
+        "total": {"totalTokens": 14},
+        "modelContextWindow": 200_000,
+    }
+
+
+def test_app_server_and_hook_journals_coexist_without_identity_inference(tmp_path: Path) -> None:
+    from spotter.trace import TraceEvent
+
+    hook_path = tmp_path / "hook-session.jsonl"
+    StepJournal(hook_path).record(TraceEvent("tool_result", {"session_id": "legacy"}))
+    ingestor = AppServerTraceIngestor(tmp_path)
+    ingestor.ingest(
+        _event(
+            "thread/started",
+            {"thread": {"id": "thread-1", "createdAt": 100, "cwd": "/repo"}},
+        )
+    )
+
+    hook_event = StepJournal.load(hook_path)[0].event
+    app_journals = list(tmp_path.glob("app-server-*.jsonl"))
+    assert hook_event.identity is None
+    assert len(app_journals) == 1
+    app_event = StepJournal.load(app_journals[0])[0].event
+    assert app_event.identity is not None
+    assert app_event.identity.provenance.agent_thread_id == "thread-1"
+    assert app_event.provenance is not None
+    assert app_event.provenance.method == "thread/started"
+
+
+def test_rejects_missing_required_identity() -> None:
+    with pytest.raises(IngestionError, match="omitted thread or turn"):
+        CodexTraceNormalizer().normalize(
+            _event("turn/completed", {"threadId": "thread-1", "turn": {"status": "failed"}})
+        )


### PR DESCRIPTION
## Summary

- normalize authoritative Codex App Server lifecycle and item families into identity-rich, transport-neutral Trace events
- persist Trace identity, timestamp, operation correlation, and provenance while retaining legacy journal compatibility
- reconcile exact replays, terminal-before-start delivery, timestamp regressions, and conflicting outcomes across restarts
- keep Hook-era sessions explicitly separate and omit raw reasoning content and unknown wire payloads

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (332 passed)

Closes #85