### PR TITLE
feat(runtime): add daemon-owned ThreadState

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Claim/evidence audit ledger | 🟡 | Works where observable outcomes exist |
 | Evaluation labels / metrics | ✅ | Coverage-aware evaluation and precision/FP metrics |
 | Counterfactual experiment harness | ✅ | Control/guidance same-prefix pairs |
-| Standalone `spotterd` runtime | 🟡 | Process, versioned gate/control IPC, and managed user-service startup implemented; runtime consumers remain |
-| App Server primary observation | 🟡 | Client, identity-rich Trace IR normalization, and durable ingestion implemented; daemon routing remains |
+| Standalone `spotterd` runtime | 🟡 | Process, gate/control IPC, managed startup, and per-thread immutable live state implemented; App Server connection ownership remains |
+| App Server primary observation | 🟡 | Client, identity-rich Trace IR, durable ingestion, and incremental ThreadState reducer implemented; daemon connection routing remains |
 | Event-driven signal engine | ❌ | Current reviewer trigger is periodic |
 | Live `VERIFY / NUDGE` | ❌ | Target: `turn/steer` |
 | `INTERRUPT` | ❌ | Target: `turn/interrupt` |
@@ -95,6 +95,9 @@ adds a thread/turn/attachment registry. [#85](https://github.com/spotter-agent/s
 uses it to normalize authoritative lifecycle, message, plan, reasoning-summary, command, file-change,
 MCP, search, diff, and token events into durable Trace IR. Exact replays are deduplicated across
 restarts, operation outcomes correlate by item ID, and unknown notification families remain explicit.
+[#31](https://github.com/spotter-agent/spotter/issues/31) reduces that Trace IR into isolated,
+immutable, versioned ThreadState snapshots owned by `spotterd`; restart hydration deliberately
+requires live turn reconciliation before control becomes ready again.
 [#79](https://github.com/spotter-agent/spotter/issues/79)
 adds the `spotterd` process, versioned local control handshake, manual lifecycle commands, and a
 platform-neutral service boundary. [#83](https://github.com/spotter-agent/spotter/issues/83) adds

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,8 +115,8 @@ concurrent clients, reports `healthy` / `degraded` / `recovering`, and makes abs
 
 Manual process management implements the `ServiceManager` boundary used by the CLI. Managed
 `launchd` / `systemd --user` registration belongs to setup lifecycle work. This daemon currently
-owns no App Server, semantic `ThreadState`, Hook IPC, or event routing, so stopping it cannot stop a
-shared Codex App Server and existing Hook behavior remains independent.
+owns semantic `ThreadState` and bounded Hook gate IPC, but no App Server connection or event routing,
+so stopping it cannot stop a shared Codex App Server and existing Hook behavior remains independent.
 
 ## 1.3 Target runtime
 
@@ -582,6 +582,17 @@ ThreadState
   connection/capability state
 ```
 
+The implemented `ThreadStateStore` is the daemon-owned, single-event-loop hot-state boundary.
+`ThreadStateReducer` consumes only normalized `TraceEvent` values and returns deeply immutable,
+versioned snapshots. It keeps task, evidence/verification, workspace, execution, supervision, and
+coverage as distinct typed sub-state; reasoning summaries remain hypotheses, and verified facts can
+only be created by an explicit verification-satisfied event. Duplicate event IDs are idempotent,
+out-of-order lifecycle is recorded as partial coverage, and thread identities remain isolated.
+
+Journal hydration deterministically replays Trace IR but clears active-turn/control readiness. A
+recovered daemon must receive a live `runtime_reconciled` event before control can be considered
+safe; #87 owns that connection and reconciliation loop.
+
 ## 8.2 Durable journal
 
 The journal exists for:
@@ -664,8 +675,8 @@ State scope:
 - Hook-era `session_id` becomes a `RuntimeIdentity` with unknown thread/turn/attachment fields rather
   than being promoted into an identity it cannot prove.
 
-The registry owns identity and lifecycle only; App Server Trace normalization and journal recovery
-consume it without promoting it into semantic state. Semantic `ThreadState` remains #31, and daemon
+The registry owns identity and lifecycle only. App Server Trace normalization and the daemon's
+semantic `ThreadState` consume those identities without importing Codex wire shapes. Daemon
 connection reconciliation remains #87.
 
 ---

--- a/docs/status.md
+++ b/docs/status.md
@@ -7,7 +7,7 @@
 
 ## 30-second summary
 
-Spotter is currently a **Hook-based research prototype** with a standalone runtime foundation. It already has real trajectory journals, daemon-backed deterministic gates, Git snapshots, fork/replay, a shadow reviewer, an audit ledger, labeling/metrics, a counterfactual experiment harness, and a manually managed `spotterd` process with versioned local IPC.
+Spotter is currently a **Hook-based research prototype** with a standalone runtime foundation. It already has real trajectory journals, daemon-backed deterministic gates, Git snapshots, fork/replay, a shadow reviewer, an audit ledger, labeling/metrics, a counterfactual experiment harness, identity-rich App Server ingestion, and daemon-owned per-thread live state.
 
 The target product is a standalone runtime:
 
@@ -30,7 +30,7 @@ PreToolUse Hook only
 (deterministic synchronous enforcement)
 ```
 
-The shared App Server gate is resolved: an explicitly connected TUI and Spotter can observe and steer the same real turn. The Hook now uses bounded daemon IPC for deterministic enforcement. The immediate work is wiring the remaining process foundations into a managed lifecycle: App Server event routing, setup registration, and reconnect behavior remain separate issues. See [App Server connection validation](app-server-validation.md).
+The shared App Server gate is resolved: an explicitly connected TUI and Spotter can observe and steer the same real turn. The Hook now uses bounded daemon IPC for deterministic enforcement. The immediate work is long-lived App Server event routing and reconnect/reconciliation in #87. See [App Server connection validation](app-server-validation.md).
 The roadmap no longer uses `P0–P9` / `E0–E5`. It is organized by named outcomes:
 
 ```text
@@ -39,9 +39,9 @@ Runtime → Observe → Detect → Intervene → Recover → Harden
 
 The shared-server gate in [#78](https://github.com/spotter-agent/spotter/issues/78) passed for the
 Spotter-managed external App Server path. Spotter now has a production WebSocket client and a
-provisional Thread/Turn/Runtime Attachment registry with no production event consumer yet. It also
-has a standalone daemon process and versioned local control/gate handshake; managed startup and
-runtime consumers remain next.
+Thread/Turn/Runtime Attachment registry, durable normalized ingestion, and an incremental immutable
+ThreadState reducer. The standalone daemon owns isolated state snapshots and a versioned local
+control/gate handshake; App Server connection ownership and reconnect remain next.
 
 ---
 
@@ -64,11 +64,14 @@ transactional Codex Hook/plugin migration, and managed `launchd`/`systemd --user
 manifest and Hook ownership checks, App Server probing when an endpoint exists, and explicit
 degraded consequences when observation/control are unavailable but Hook enforcement remains.
 
-The remaining implementation boundaries are split into native GitHub issues:
+The remaining runtime boundary is tracked in:
 
 - [#87](https://github.com/spotter-agent/spotter/issues/87) — daemon/App Server reconnect and identity reconciliation.
 
-[#31](https://github.com/spotter-agent/spotter/issues/31) then moves independent supervision state into that runtime, fed by the App Server ingestion path in [#85](https://github.com/spotter-agent/spotter/issues/85).
+[#31](https://github.com/spotter-agent/spotter/issues/31) adds daemon-owned immutable ThreadState,
+deterministic Trace IR reduction, durable replay hydration, explicit coverage gaps, and conservative
+control readiness after restart. [#87](https://github.com/spotter-agent/spotter/issues/87) will connect
+that state owner to the long-lived App Server recovery loop.
 
 The assumption that merely starting the external server would make plain `codex` reuse it was
 rejected by the [2026-08-13 validation](app-server-validation.md). The explicit `--remote` path
@@ -91,20 +94,20 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 
 | Area | Status | What exists now | Next concrete step |
 | --- | --- | --- | --- |
-| Hook ingestion | ✅ | `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse` are journaled | App Server ingestion #85, then remove redundant Hooks in #86 |
+| Hook ingestion | ✅ | `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse` are journaled | Measure App Server parity in #37, then remove redundant Hooks in #86 |
 | Deterministic gate | ✅ | Shell-aware daemon evaluation over bounded local IPC; unavailable/timeout uses the local Gate, while incompatible responses fail open | Continue policy precision/miss-rate measurement |
-| Journal | ✅ | Crash-tolerant JSONL, locking, fsync, torn-tail recovery | Feed it from identity-rich App Server Trace IR in #85 |
+| Journal | ✅ | Crash-tolerant JSONL stores identity-rich App Server Trace IR with locking, fsync, and torn-tail recovery | Add bounded retention/checkpoint lifecycle in #87/#89 |
 | Snapshot | ✅ | Git-backed snapshots, deduplication, pruning, detached restore | Preserve lineage through runtime/retention migration (#89) |
 | Fork / replay | ✅ | Continue Codex from a shared prefix in a detached worktree | Measure fidelity/noise floor in #42 |
 | Shadow reviewer | ✅ | Produces `CONTINUE`, `VERIFY`, `NUDGE`; verdicts are recorded only | Move to event-driven candidates, then live delivery |
-| Audit ledger | 🟡 | Claim/evidence state and stale propagation where outcomes are observable | Move independent state into `spotterd` (#31) |
+| Audit / live state | 🟡 | Daemon-owned typed ThreadState distinguishes constraints, hypotheses, observations, verified facts, summaries, interventions, and coverage | Feed reviewer jobs and signals from immutable snapshots |
 | Evaluation labels / metrics | ✅ | Coverage-aware labeling and precision/FP metrics | Broader cost/miss/harm metrics (#33, #38, #34) |
 | Counterfactual harness | ✅ | Control/guidance same-prefix pairs can be prepared/run | Add mechanically scored tasks (#21) |
-| Standalone runtime | 🟡 | Long-lived process, versioned control/gate IPC, health states, manual and managed user-service lifecycle | Add runtime consumers in #31/#85 |
-| Runtime identity | 🟡 | Provisional lifecycle registry and explicit legacy unknowns; no production consumer | Validate and refine it while routing normalized App Server events in #85 |
-| App Server primary observation | 🟡 | Async client, raw events, thread queries, controls, capability degradation | Normalize, identity-route, and journal events in #85 |
-| Managed Codex lifecycle | 🟡 | Transactional setup/teardown, versioned ownership manifest, legacy migration, launchd/systemd-user service, runtime diagnostics | Connect and ingest the external App Server in #85/#87 |
-| Runtime reconnect/recovery | ❌ | No long-lived App Server connection to recover | #87 after runtime/state boundaries exist |
+| Standalone runtime | 🟡 | Long-lived process, IPC, lifecycle, and isolated per-thread hot-state ownership | Add App Server connection/reconciliation in #87 |
+| Runtime identity | 🟡 | Lifecycle registry feeds normalized journals and ThreadState while legacy dimensions remain explicit unknowns | Add connection epochs and attachment reconciliation in #87 |
+| App Server primary observation | 🟡 | Async client, normalized durable Trace IR, and incremental ThreadState reduction | Route the long-lived connection through `spotterd` in #87 |
+| Managed Codex lifecycle | 🟡 | Transactional setup/teardown, versioned ownership manifest, legacy migration, launchd/systemd-user service, runtime diagnostics | Connect and reconcile the external App Server in #87 |
+| Runtime reconnect/recovery | ❌ | Durable hydration is conservative, but no long-lived App Server reconnect owner exists | Implement #87 on the daemon/state boundaries |
 | Event-driven detection | ❌ | Reviewer is still cadence-based | #28 after Runtime/Observe |
 | Live `VERIFY` / `NUDGE` | ❌ | Reviewer decisions stop at the journal | #22 via `turn/steer` |
 | `INTERRUPT` / `RESTART` | ❌ | No live recovery path | #26 + #30 after soft intervention is understood |

--- a/src/spotter/daemon.py
+++ b/src/spotter/daemon.py
@@ -21,7 +21,10 @@ from typing import Any, Protocol, cast
 
 from spotter.config import GatesConfig
 from spotter.gates import Gate, GateDecision
+from spotter.identity import ThreadId
 from spotter.paths import secure_dir, spotter_home
+from spotter.snapshot import StepRecord
+from spotter.thread_state import ThreadState, ThreadStateStore
 from spotter.trace import TraceEvent
 
 PROTOCOL_VERSION = 1
@@ -190,6 +193,22 @@ class DaemonServer:
         self._shutdown = asyncio.Event()
         self._socket_inode: int | None = None
         self._lock: TextIOWrapper | None = None
+        self.thread_states = ThreadStateStore()
+
+    def observe_trace(self, event: TraceEvent) -> ThreadState:
+        """Increment daemon-owned hot state after adapter normalization and journaling."""
+
+        return self.thread_states.observe(event)
+
+    def thread_state(self, thread_id: ThreadId) -> ThreadState:
+        """Immutable reviewer/signal snapshot for one logical thread."""
+
+        return self.thread_states.snapshot(thread_id)
+
+    def hydrate_thread_state(self, records: list[StepRecord]) -> tuple[ThreadState, ...]:
+        """Restore history without claiming the old active turn is control-ready."""
+
+        return self.thread_states.hydrate(records)
 
     async def start(self) -> None:
         _secure_runtime_dir(self.socket_path.parent)

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -222,6 +222,7 @@ class StepJournal:
                     operation_id=event.operation_id,
                     item_id=event.item_id,
                     provenance=event.provenance,
+                    connection_epoch=event.connection_epoch,
                 )
                 record = StepRecord(step, stored_event, snapshot, time.time(), SCHEMA_VERSION)
                 line = json.dumps(
@@ -326,7 +327,7 @@ class StepJournal:
 
 def _trace_metadata(event: TraceEvent) -> dict[str, Any]:
     metadata: dict[str, Any] = {}
-    for name in ("event_id", "occurred_at", "operation_id", "item_id"):
+    for name in ("event_id", "occurred_at", "operation_id", "item_id", "connection_epoch"):
         value = getattr(event, name)
         if value is not None:
             metadata[name] = value
@@ -399,6 +400,12 @@ def _trace_event(raw: dict[str, Any]) -> TraceEvent:
         operation_id=_optional_string(metadata.get("operation_id")),
         item_id=_optional_string(metadata.get("item_id")),
         provenance=provenance,
+        connection_epoch=(
+            metadata["connection_epoch"]
+            if isinstance(metadata.get("connection_epoch"), int)
+            and not isinstance(metadata.get("connection_epoch"), bool)
+            else None
+        ),
     )
 
 

--- a/src/spotter/thread_state.py
+++ b/src/spotter/thread_state.py
@@ -1,0 +1,709 @@
+"""Immutable live supervision state reduced from runtime-neutral Trace IR."""
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field, replace
+from enum import StrEnum
+from typing import Any
+
+from spotter.identity import RuntimeIdentity, ThreadId, TurnId
+from spotter.snapshot import StepRecord
+from spotter.trace import TraceEvent
+
+_RECENT_LIMIT = 50
+
+
+class StateItemKind(StrEnum):
+    GOAL = "goal"
+    CONSTRAINT = "constraint"
+    OBSERVATION = "observation"
+    HYPOTHESIS = "hypothesis"
+    VERIFIED_FACT = "verified_fact"
+    SUMMARY = "summary"
+    INTERVENTION = "intervention"
+
+
+class StateItemStatus(StrEnum):
+    ACTIVE = "active"
+    STALE = "stale"
+    SUPERSEDED = "superseded"
+    UNKNOWN = "unknown"
+
+
+class HistoryStatus(StrEnum):
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    UNKNOWN = "unknown"
+
+
+class ConditionStatus(StrEnum):
+    UNMET = "unmet"
+    SATISFIED = "satisfied"
+    INVALIDATED = "invalidated"
+    UNKNOWN = "unknown"
+
+
+class ValidationStatus(StrEnum):
+    UNKNOWN = "unknown"
+    PASSED = "passed"
+    FAILED = "failed"
+    STALE = "stale"
+
+
+@dataclass(frozen=True)
+class StateProvenance:
+    event_id: str | None
+    created_at: float | None
+    thread_id: ThreadId
+    turn_id: TurnId | None
+    connection_epoch: int | None
+    source: str | None
+
+
+@dataclass(frozen=True)
+class StateItem:
+    id: str
+    kind: StateItemKind
+    text: str
+    provenance: StateProvenance
+    status: StateItemStatus = StateItemStatus.ACTIVE
+    confidence: float | None = None
+    depends_on: tuple[str, ...] = ()
+    evidence_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class VerificationCondition:
+    id: str
+    kind: str
+    scope: str | None
+    required_evidence: tuple[str, ...]
+    status: ConditionStatus
+    satisfied_by: tuple[str, ...]
+    created_from: str
+    provenance: StateProvenance
+
+
+@dataclass(frozen=True)
+class ObservationGap:
+    started_at: float | None
+    ended_at: float | None
+    epoch_before: int | None
+    epoch_after: int | None
+    backfill_status: str
+    source_event_id: str | None
+
+
+@dataclass(frozen=True)
+class TaskState:
+    goal: StateItem | None = None
+    constraints: tuple[StateItem, ...] = ()
+
+
+@dataclass(frozen=True)
+class EvidenceState:
+    items: tuple[StateItem, ...] = ()
+    conditions: tuple[VerificationCondition, ...] = ()
+
+
+@dataclass(frozen=True)
+class WorkspaceState:
+    repository: str | None = None
+    worktree: str | None = None
+    touched_files: frozenset[str] = field(default_factory=frozenset)
+    edits_since_validation: frozenset[str] = field(default_factory=frozenset)
+    checkpoint: str | None = None
+
+
+@dataclass(frozen=True)
+class ExecutionState:
+    plan_summary: StateItem | None = None
+    active_items: frozenset[str] = field(default_factory=frozenset)
+    completed_turns: frozenset[TurnId] = field(default_factory=frozenset)
+    recent_outcomes: tuple[StateItem, ...] = ()
+    recent_failures: tuple[StateItem, ...] = ()
+    validation: ValidationStatus = ValidationStatus.UNKNOWN
+
+
+@dataclass(frozen=True)
+class SupervisionState:
+    interventions: tuple[StateItem, ...] = ()
+
+
+@dataclass(frozen=True)
+class CoverageState:
+    history: HistoryStatus = HistoryStatus.UNKNOWN
+    gaps: tuple[ObservationGap, ...] = ()
+    unknown_event_count: int = 0
+    last_trustworthy_event_id: str | None = None
+    trajectory_complete_since: float | None = None
+    inconsistencies: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ThreadState:
+    identity: RuntimeIdentity
+    version: int = 0
+    last_trace_event_id: str | None = None
+    last_arrival_seq: int = 0
+    connection_epoch: int | None = None
+    active_turn_id: TurnId | None = None
+    capabilities: tuple[str, ...] = ()
+    control_ready: bool = False
+    task: TaskState = field(default_factory=TaskState)
+    evidence: EvidenceState = field(default_factory=EvidenceState)
+    workspace: WorkspaceState = field(default_factory=WorkspaceState)
+    execution: ExecutionState = field(default_factory=ExecutionState)
+    supervision: SupervisionState = field(default_factory=SupervisionState)
+    coverage: CoverageState = field(default_factory=CoverageState)
+    # ponytail: exact dedupe retains IDs for the thread lifetime; #87 checkpoints and
+    # #89 retention should compact only with an explicit durable replay boundary.
+    applied_event_ids: frozenset[str] = field(default_factory=frozenset, repr=False)
+
+    @property
+    def thread_id(self) -> ThreadId:
+        assert self.identity.thread_id is not None
+        return self.identity.thread_id
+
+
+class ThreadStateError(ValueError):
+    """A Trace event cannot be routed or reduced without inventing identity."""
+
+
+class ThreadStateReducer:
+    """Pure deterministic reducer; transport callbacks never mutate state directly."""
+
+    def reduce(self, state: ThreadState | None, event: TraceEvent, arrival_seq: int) -> ThreadState:
+        identity = event.identity
+        if identity is None or identity.thread_id is None:
+            raise ThreadStateError("Trace event has no logical thread identity")
+        if state is not None and state.thread_id != identity.thread_id:
+            raise ThreadStateError("Trace event belongs to another thread")
+        if state is not None and event.event_id and event.event_id in state.applied_event_ids:
+            return state
+        if arrival_seq <= 0 or (state is not None and arrival_seq <= state.last_arrival_seq):
+            raise ThreadStateError("arrival sequence must increase monotonically")
+
+        current = state or ThreadState(identity=identity)
+        epoch_changed = (
+            event.connection_epoch is not None
+            and current.connection_epoch is not None
+            and event.connection_epoch != current.connection_epoch
+        )
+        applied = current.applied_event_ids
+        if event.event_id:
+            applied = applied | {event.event_id}
+        current = replace(
+            current,
+            identity=identity,
+            version=current.version + 1,
+            last_trace_event_id=event.event_id,
+            last_arrival_seq=arrival_seq,
+            connection_epoch=(
+                event.connection_epoch
+                if event.connection_epoch is not None
+                else current.connection_epoch
+            ),
+            active_turn_id=None if epoch_changed else current.active_turn_id,
+            control_ready=False if epoch_changed else current.control_ready,
+            applied_event_ids=applied,
+        )
+        current = self._lifecycle(current, event)
+        current = self._semantic(current, event)
+        return self._coverage(current, event)
+
+    def _lifecycle(self, state: ThreadState, event: TraceEvent) -> ThreadState:
+        turn_id = event.identity.turn_id if event.identity else None
+        if event.kind == "turn_started" and turn_id is not None:
+            if turn_id in state.execution.completed_turns:
+                return _inconsistent(state, f"late_start_for_completed_turn:{turn_id.value}")
+            if state.active_turn_id is not None and state.active_turn_id != turn_id:
+                state = _inconsistent(
+                    state,
+                    f"turn_started_while_active:{state.active_turn_id.value}:{turn_id.value}",
+                )
+            return replace(state, active_turn_id=turn_id)
+        if event.kind == "turn_completed" and turn_id is not None:
+            if state.active_turn_id != turn_id:
+                state = _inconsistent(state, f"turn_completed_without_start:{turn_id.value}")
+            execution = replace(
+                state.execution,
+                active_items=frozenset(),
+                completed_turns=state.execution.completed_turns | {turn_id},
+            )
+            return replace(state, active_turn_id=None, control_ready=False, execution=execution)
+        if event.kind in {"thread_archived", "thread_closed", "thread_deleted"}:
+            return replace(state, active_turn_id=None, control_ready=False)
+        if event.kind == "runtime_reconciled":
+            capabilities = event.payload.get("capabilities")
+            active_turn = (
+                turn_id if event.payload.get("active_turn") is True else state.active_turn_id
+            )
+            return replace(
+                state,
+                capabilities=(
+                    tuple(sorted(value for value in capabilities if isinstance(value, str)))
+                    if isinstance(capabilities, list)
+                    else state.capabilities
+                ),
+                active_turn_id=active_turn,
+                control_ready=active_turn is not None,
+            )
+        return state
+
+    def _semantic(self, state: ThreadState, event: TraceEvent) -> ThreadState:
+        provenance = _provenance(state.thread_id, event)
+        item_id = event.event_id or f"arrival:{state.last_arrival_seq}"
+        state = replace(
+            state,
+            workspace=_workspace(state.workspace, event, state.workspace.edits_since_validation),
+        )
+        if event.kind == "user_prompt":
+            text = _user_text(event.payload)
+            if text:
+                goal = StateItem(item_id, StateItemKind.GOAL, text, provenance)
+                previous = state.task.goal
+                evidence = state.evidence
+                if previous is not None:
+                    evidence = replace(
+                        evidence,
+                        items=_bounded(
+                            evidence.items + (replace(previous, status=StateItemStatus.SUPERSEDED),)
+                        ),
+                    )
+                return replace(state, task=replace(state.task, goal=goal), evidence=evidence)
+        if event.kind == "constraint":
+            text = _optional_text(event.payload.get("text"))
+            if text:
+                constraint = StateItem(item_id, StateItemKind.CONSTRAINT, text, provenance)
+                return replace(
+                    state,
+                    task=replace(state.task, constraints=state.task.constraints + (constraint,)),
+                )
+        if event.kind in {"reasoning_summary", "hypothesis"}:
+            text = _summary_text(event.payload)
+            if text:
+                hypothesis = StateItem(
+                    item_id,
+                    StateItemKind.HYPOTHESIS,
+                    text,
+                    provenance,
+                    depends_on=_string_tuple(event.payload.get("depends_on")),
+                    evidence_ids=_string_tuple(event.payload.get("evidence_ids")),
+                )
+                return replace(
+                    state,
+                    evidence=replace(
+                        state.evidence, items=_bounded(state.evidence.items + (hypothesis,))
+                    ),
+                )
+        if event.kind == "plan":
+            text = _summary_text(event.payload)
+            if text:
+                summary = StateItem(item_id, StateItemKind.SUMMARY, text, provenance)
+                return replace(state, execution=replace(state.execution, plan_summary=summary))
+        if event.kind == "verification_condition":
+            condition_id = _optional_text(event.payload.get("condition_id"))
+            kind = _optional_text(event.payload.get("kind"))
+            if condition_id and kind:
+                condition = VerificationCondition(
+                    condition_id,
+                    kind,
+                    _optional_text(event.payload.get("scope")),
+                    _string_tuple(event.payload.get("required_evidence")),
+                    ConditionStatus.UNMET,
+                    (),
+                    _optional_text(event.payload.get("created_from")) or "unknown",
+                    provenance,
+                )
+                existing = next(
+                    (item for item in state.evidence.conditions if item.id == condition_id),
+                    None,
+                )
+                if existing is not None:
+                    return (
+                        state
+                        if existing == condition
+                        else _inconsistent(
+                            state, f"conflicting_verification_condition:{condition_id}"
+                        )
+                    )
+                return replace(
+                    state,
+                    evidence=replace(
+                        state.evidence, conditions=state.evidence.conditions + (condition,)
+                    ),
+                )
+        if event.kind == "verification_satisfied":
+            return _satisfy_condition(state, event, provenance, item_id)
+        if event.kind == "evidence_invalidated":
+            return _invalidate_evidence(state, event.payload.get("evidence_id"))
+
+        active = state.execution.active_items
+        operation_id = event.operation_id or event.item_id
+        if event.kind in {"command_started", "tool_started", "file_change_started"}:
+            if operation_id:
+                active = active | {operation_id}
+            return replace(state, execution=replace(state.execution, active_items=active))
+        if event.kind in {
+            "command_result",
+            "tool_result",
+            "file_edit",
+            "diff_updated",
+            "search",
+            "test_result",
+        }:
+            text = _outcome_text(event)
+            observation = StateItem(item_id, StateItemKind.OBSERVATION, text, provenance)
+            if operation_id:
+                active = active - {operation_id}
+            outcomes = _bounded(state.execution.recent_outcomes + (observation,))
+            failures = state.execution.recent_failures
+            if _failed(event.payload):
+                failures = _bounded(failures + (observation,))
+            validation = state.execution.validation
+            edits = state.workspace.edits_since_validation
+            if (
+                event.kind in {"file_edit", "diff_updated"}
+                and validation == ValidationStatus.PASSED
+            ):
+                validation = ValidationStatus.STALE
+            if event.kind == "test_result":
+                validation = _validation_status(event.payload)
+                if validation == ValidationStatus.PASSED:
+                    edits = frozenset()
+            workspace = _workspace(state.workspace, event, edits)
+            return replace(
+                state,
+                evidence=replace(
+                    state.evidence, items=_bounded(state.evidence.items + (observation,))
+                ),
+                workspace=workspace,
+                execution=replace(
+                    state.execution,
+                    active_items=active,
+                    recent_outcomes=outcomes,
+                    recent_failures=failures,
+                    validation=validation,
+                ),
+            )
+        if event.kind in {"reviewer_decision", "intervention", "gate_block"}:
+            intervention = StateItem(
+                item_id,
+                StateItemKind.INTERVENTION,
+                _outcome_text(event),
+                provenance,
+            )
+            return replace(
+                state,
+                supervision=replace(
+                    state.supervision,
+                    interventions=_bounded(state.supervision.interventions + (intervention,)),
+                ),
+            )
+        return state
+
+    def _coverage(self, state: ThreadState, event: TraceEvent) -> ThreadState:
+        coverage = state.coverage
+        if event.kind == "observation_gap":
+            gap = ObservationGap(
+                _number(event.payload.get("started_at")),
+                _number(event.payload.get("ended_at")),
+                _integer(event.payload.get("epoch_before")),
+                _integer(event.payload.get("epoch_after")),
+                _optional_text(event.payload.get("backfill_status")) or "none",
+                event.event_id,
+            )
+            return replace(
+                state,
+                control_ready=False,
+                coverage=replace(
+                    coverage, history=HistoryStatus.PARTIAL, gaps=coverage.gaps + (gap,)
+                ),
+            )
+        if event.kind == "runtime_event_unknown":
+            coverage = replace(coverage, unknown_event_count=coverage.unknown_event_count + 1)
+        if event.payload.get("out_of_order") is True:
+            state = _inconsistent(state, f"out_of_order:{event.event_id or state.last_arrival_seq}")
+            coverage = state.coverage
+        if event.kind == "thread_started" and coverage.history == HistoryStatus.UNKNOWN:
+            coverage = replace(
+                state.coverage,
+                history=HistoryStatus.COMPLETE,
+                trajectory_complete_since=event.occurred_at,
+            )
+        if event.event_id is not None and event.payload.get("out_of_order") is not True:
+            coverage = replace(coverage, last_trustworthy_event_id=event.event_id)
+        return replace(state, coverage=coverage)
+
+
+class ThreadStateStore:
+    """Single-owner in-memory store intended to live inside the daemon event loop."""
+
+    def __init__(self, reducer: ThreadStateReducer | None = None) -> None:
+        self.reducer = reducer or ThreadStateReducer()
+        self._states: dict[ThreadId, ThreadState] = {}
+        self._arrival_seq = 0
+
+    def observe(self, event: TraceEvent) -> ThreadState:
+        if event.identity is None or event.identity.thread_id is None:
+            raise ThreadStateError("Trace event has no logical thread identity")
+        thread_id = event.identity.thread_id
+        self._arrival_seq += 1
+        state = self.reducer.reduce(self._states.get(thread_id), event, self._arrival_seq)
+        self._states[thread_id] = state
+        return state
+
+    def snapshot(self, thread_id: ThreadId) -> ThreadState:
+        try:
+            return self._states[thread_id]
+        except KeyError as error:
+            raise ThreadStateError(f"unknown thread: {thread_id.value}") from error
+
+    def snapshots(self) -> tuple[ThreadState, ...]:
+        return tuple(self._states.values())
+
+    def replay(self, events: Iterable[TraceEvent]) -> tuple[ThreadState, ...]:
+        for event in events:
+            self.observe(event)
+        return self.snapshots()
+
+    def hydrate(self, records: Iterable[StepRecord]) -> tuple[ThreadState, ...]:
+        """Replay durable history but never claim old live control identity is ready."""
+
+        self.replay(
+            record.event
+            for record in records
+            if record.event.identity is not None and record.event.identity.thread_id is not None
+        )
+        for thread_id, state in self._states.items():
+            self._states[thread_id] = replace(state, active_turn_id=None, control_ready=False)
+        return self.snapshots()
+
+
+def _provenance(thread_id: ThreadId, event: TraceEvent) -> StateProvenance:
+    source = event.provenance.source if event.provenance else None
+    turn_id = event.identity.turn_id if event.identity else None
+    return StateProvenance(
+        event.event_id,
+        event.occurred_at,
+        thread_id,
+        turn_id,
+        event.connection_epoch,
+        source,
+    )
+
+
+def _bounded(items: tuple[StateItem, ...]) -> tuple[StateItem, ...]:
+    return items[-_RECENT_LIMIT:]
+
+
+def _inconsistent(state: ThreadState, message: str) -> ThreadState:
+    if message in state.coverage.inconsistencies:
+        return state
+    return replace(
+        state,
+        coverage=replace(
+            state.coverage,
+            history=HistoryStatus.PARTIAL,
+            inconsistencies=state.coverage.inconsistencies + (message,),
+        ),
+    )
+
+
+def _workspace(
+    workspace: WorkspaceState, event: TraceEvent, edits: frozenset[str]
+) -> WorkspaceState:
+    files = event.payload.get("files")
+    observed_files = (
+        frozenset(value for value in files if isinstance(value, str))
+        if isinstance(files, list)
+        else frozenset()
+    )
+    if event.kind in {"file_edit", "diff_updated"}:
+        edits = edits | observed_files
+    return replace(
+        workspace,
+        repository=_optional_text(event.payload.get("repository")) or workspace.repository,
+        worktree=(
+            _optional_text(event.payload.get("worktree"))
+            or _optional_text(event.payload.get("cwd"))
+            or workspace.worktree
+        ),
+        touched_files=workspace.touched_files | observed_files,
+        edits_since_validation=edits,
+        checkpoint=_optional_text(event.payload.get("checkpoint")) or workspace.checkpoint,
+    )
+
+
+def _satisfy_condition(
+    state: ThreadState,
+    event: TraceEvent,
+    provenance: StateProvenance,
+    item_id: str,
+) -> ThreadState:
+    condition_id = _optional_text(event.payload.get("condition_id"))
+    evidence_id = _optional_text(event.payload.get("evidence_id"))
+    if condition_id is None or evidence_id is None:
+        return _inconsistent(state, "verification_satisfied_without_identity")
+    evidence = next(
+        (
+            item
+            for item in state.evidence.items
+            if item.id == evidence_id
+            and item.kind == StateItemKind.OBSERVATION
+            and item.status == StateItemStatus.ACTIVE
+        ),
+        None,
+    )
+    if evidence is None:
+        return _inconsistent(state, f"unknown_verification_evidence:{evidence_id}")
+    conditions = []
+    matched = False
+    for condition in state.evidence.conditions:
+        if condition.id == condition_id:
+            matched = True
+            condition = replace(
+                condition,
+                status=ConditionStatus.SATISFIED,
+                satisfied_by=tuple(dict.fromkeys(condition.satisfied_by + (evidence_id,))),
+            )
+        conditions.append(condition)
+    if not matched:
+        return _inconsistent(state, f"unknown_verification_condition:{condition_id}")
+    fact = StateItem(
+        item_id,
+        StateItemKind.VERIFIED_FACT,
+        _optional_text(event.payload.get("text")) or condition_id,
+        provenance,
+        evidence_ids=(evidence_id,),
+    )
+    return replace(
+        state,
+        evidence=replace(
+            state.evidence,
+            items=_bounded(state.evidence.items + (fact,)),
+            conditions=tuple(conditions),
+        ),
+    )
+
+
+def _invalidate_evidence(state: ThreadState, raw_evidence_id: object) -> ThreadState:
+    evidence_id = _optional_text(raw_evidence_id)
+    if evidence_id is None:
+        return _inconsistent(state, "evidence_invalidated_without_identity")
+    if not any(item.id == evidence_id for item in state.evidence.items):
+        return _inconsistent(state, f"unknown_evidence:{evidence_id}")
+    stale_ids = {evidence_id}
+    changed = True
+    while changed:
+        changed = False
+        for item in state.evidence.items:
+            if item.id not in stale_ids and (
+                set(item.evidence_ids) & stale_ids or set(item.depends_on) & stale_ids
+            ):
+                stale_ids.add(item.id)
+                changed = True
+    items = tuple(
+        replace(item, status=StateItemStatus.STALE) if item.id in stale_ids else item
+        for item in state.evidence.items
+    )
+    conditions = tuple(
+        replace(condition, status=ConditionStatus.INVALIDATED)
+        if set(condition.satisfied_by) & stale_ids
+        else condition
+        for condition in state.evidence.conditions
+    )
+    return replace(state, evidence=replace(state.evidence, items=items, conditions=conditions))
+
+
+def _user_text(payload: Mapping[str, Any]) -> str | None:
+    prompt = _optional_text(payload.get("prompt"))
+    if prompt:
+        return prompt
+    content = payload.get("content")
+    if not isinstance(content, list):
+        return None
+    parts = [
+        str(part["text"])
+        for part in content
+        if isinstance(part, Mapping) and isinstance(part.get("text"), str)
+    ]
+    return "\n".join(parts) or None
+
+
+def _summary_text(payload: Mapping[str, Any]) -> str | None:
+    for key in ("text", "summary", "explanation"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, list):
+            text = "\n".join(part for part in value if isinstance(part, str) and part.strip())
+            if text:
+                return text
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        text = "\n".join(
+            step["step"]
+            for step in steps
+            if isinstance(step, Mapping) and isinstance(step.get("step"), str) and step["step"]
+        )
+        return text or None
+    return None
+
+
+def _outcome_text(event: TraceEvent) -> str:
+    details = [
+        f"{key}={value}"
+        for key in ("command", "tool", "status", "exitCode", "exit_code", "success", "rule")
+        if isinstance((value := event.payload.get(key)), str | int | bool)
+    ]
+    text = event.payload.get("text") or event.payload.get("diff")
+    if isinstance(text, str) and text:
+        details.append(text)
+    return f"{event.kind}: {' '.join(details)}" if details else event.kind
+
+
+def _failed(payload: Mapping[str, Any]) -> bool:
+    status = payload.get("status")
+    exit_code = payload.get("exitCode", payload.get("exit_code"))
+    success = payload.get("success")
+    return (
+        status in {"failed", "error", "declined"}
+        or (isinstance(exit_code, int) and not isinstance(exit_code, bool) and exit_code != 0)
+        or success is False
+    )
+
+
+def _validation_status(payload: Mapping[str, Any]) -> ValidationStatus:
+    status = payload.get("status")
+    success = payload.get("success")
+    exit_code = payload.get("exitCode", payload.get("exit_code"))
+    if (
+        status in {"failed", "error"}
+        or success is False
+        or (isinstance(exit_code, int) and not isinstance(exit_code, bool) and exit_code != 0)
+    ):
+        return ValidationStatus.FAILED
+    if (
+        status in {"passed", "completed"}
+        or success is True
+        or (isinstance(exit_code, int) and not isinstance(exit_code, bool) and exit_code == 0)
+    ):
+        return ValidationStatus.PASSED
+    return ValidationStatus.UNKNOWN
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    return tuple(item for item in value if isinstance(item, str)) if isinstance(value, list) else ()
+
+
+def _optional_text(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _number(value: object) -> float | None:
+    return float(value) if isinstance(value, int | float) and not isinstance(value, bool) else None
+
+
+def _integer(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None

--- a/src/spotter/trace.py
+++ b/src/spotter/trace.py
@@ -25,6 +25,7 @@ class TraceEvent:
     operation_id: str | None = None
     item_id: str | None = None
     provenance: TraceProvenance | None = None
+    connection_epoch: int | None = None
 
 
 # Judgment happens on semantic segments, enforcement on tool boundaries (plan Q8).

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -21,6 +21,8 @@ from spotter.daemon import (
     runtime_socket,
 )
 from spotter.gates import Gate
+from spotter.identity import IdentityProvenance, RuntimeIdentity, ThreadId, TurnId
+from spotter.snapshot import StepRecord
 from spotter.trace import TraceEvent
 
 
@@ -57,6 +59,40 @@ def test_control_socket_handles_concurrent_clients_and_health_states(socket_path
         assert not socket_path.exists()
 
     asyncio.run(scenario())
+
+
+def test_daemon_owns_incremental_thread_state_and_conservative_hydration(
+    socket_path: Path,
+) -> None:
+    identity = RuntimeIdentity(
+        ThreadId("thread-1"),
+        TurnId("turn-1"),
+        None,
+        IdentityProvenance("codex", "external-thread", "external-turn"),
+    )
+    events = [
+        TraceEvent("thread_started", event_id="thread", identity=identity),
+        TraceEvent("turn_started", event_id="turn", identity=identity),
+        TraceEvent("runtime_reconciled", event_id="ready", identity=identity),
+    ]
+    server = DaemonServer(socket_path)
+
+    for event in events:
+        server.observe_trace(event)
+    assert identity.thread_id is not None
+    live = server.thread_state(identity.thread_id)
+
+    recovered = DaemonServer(socket_path)
+    hydrated = recovered.hydrate_thread_state(
+        [StepRecord(index, event, None) for index, event in enumerate(events)]
+    )[0]
+
+    assert live.version == 3
+    assert live.active_turn_id == TurnId("turn-1")
+    assert live.control_ready is True
+    assert hydrated.version == live.version
+    assert hydrated.active_turn_id is None
+    assert hydrated.control_ready is False
 
 
 def test_bad_protocol_does_not_break_later_clients(socket_path: Path) -> None:

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -84,6 +84,13 @@ def test_journal_roundtrip_prefix_and_resume(tmp_path: Path) -> None:
     assert [r.step for r in StepJournal.load(path)] == [0, 1, 2]
 
 
+def test_journal_roundtrips_connection_epoch(tmp_path: Path) -> None:
+    path = tmp_path / "journal.jsonl"
+    StepJournal(path).record(TraceEvent("thread_started", connection_epoch=7))
+
+    assert StepJournal.load(path)[0].event.connection_epoch == 7
+
+
 def test_proposal_number_does_not_mutate_input_event(tmp_path: Path) -> None:
     journal = StepJournal(tmp_path / "journal.jsonl")
     event = TraceEvent("tool_proposal", {"tool": "Bash"})

--- a/tests/test_thread_state.py
+++ b/tests/test_thread_state.py
@@ -1,0 +1,312 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from spotter.identity import IdentityProvenance, RuntimeIdentity, ThreadId, TurnId
+from spotter.snapshot import StepRecord
+from spotter.thread_state import (
+    ConditionStatus,
+    HistoryStatus,
+    StateItemKind,
+    StateItemStatus,
+    ThreadStateError,
+    ThreadStateStore,
+    ValidationStatus,
+)
+from spotter.trace import TraceEvent, TraceProvenance
+
+
+def _identity(thread: str = "thread-1", turn: str | None = "turn-1") -> RuntimeIdentity:
+    return RuntimeIdentity(
+        ThreadId(thread),
+        TurnId(turn) if turn else None,
+        None,
+        IdentityProvenance("codex", thread, turn),
+    )
+
+
+def _event(
+    kind: str,
+    payload: dict[str, object] | None = None,
+    *,
+    event_id: str | None = None,
+    thread: str = "thread-1",
+    turn: str | None = "turn-1",
+    operation_id: str | None = None,
+    epoch: int | None = 1,
+) -> TraceEvent:
+    return TraceEvent(
+        kind,
+        payload or {},
+        event_id=event_id,
+        occurred_at=100,
+        identity=_identity(thread, turn),
+        operation_id=operation_id,
+        provenance=TraceProvenance("codex_app_server", kind),
+        connection_epoch=epoch,
+    )
+
+
+def test_reduces_normal_trace_incrementally_into_typed_state() -> None:
+    store = ThreadStateStore()
+    store.observe(_event("thread_started", {"cwd": "/repo"}, event_id="thread"))
+    store.observe(
+        _event(
+            "user_prompt",
+            {"content": [{"type": "text", "text": "Fix login timeout"}]},
+            event_id="goal",
+        )
+    )
+    store.observe(_event("constraint", {"text": "Do not change the API"}, event_id="c1"))
+    store.observe(
+        _event(
+            "reasoning_summary",
+            {"summary": ["The retry loop may be wrong"]},
+            event_id="h1",
+        )
+    )
+    store.observe(_event("plan", {"text": "Inspect then patch"}, event_id="plan"))
+    store.observe(_event("turn_started", event_id="turn-start"))
+    store.observe(
+        _event(
+            "command_started",
+            {"command": "pytest"},
+            event_id="cmd-start",
+            operation_id="cmd-1",
+        )
+    )
+    store.observe(
+        _event(
+            "command_result",
+            {"command": "pytest", "status": "failed", "exitCode": 1},
+            event_id="cmd-done",
+            operation_id="cmd-1",
+        )
+    )
+    state = store.observe(
+        _event(
+            "reviewer_decision",
+            {"status": "nudge", "text": "Verify the timeout path"},
+            event_id="review",
+        )
+    )
+
+    assert state.version == 9
+    assert state.task.goal is not None and state.task.goal.text == "Fix login timeout"
+    assert state.task.constraints[0].kind == StateItemKind.CONSTRAINT
+    assert state.execution.plan_summary is not None
+    assert state.active_turn_id == TurnId("turn-1")
+    assert state.execution.active_items == frozenset()
+    assert state.execution.recent_failures[-1].provenance.event_id == "cmd-done"
+    assert state.execution.recent_failures[-1].provenance.created_at == 100
+    assert state.supervision.interventions[-1].kind == StateItemKind.INTERVENTION
+    assert {item.kind for item in state.evidence.items} == {
+        StateItemKind.HYPOTHESIS,
+        StateItemKind.OBSERVATION,
+    }
+    assert state.coverage.history == HistoryStatus.COMPLETE
+
+
+def test_duplicate_event_id_is_idempotent() -> None:
+    store = ThreadStateStore()
+    event = _event("file_edit", {"files": ["src/a.py"], "status": "completed"}, event_id="edit-1")
+
+    first = store.observe(event)
+    duplicate = store.observe(event)
+
+    assert duplicate is first
+    assert duplicate.version == 1
+    assert duplicate.workspace.touched_files == {"src/a.py"}
+    assert len(duplicate.execution.recent_outcomes) == 1
+
+
+def test_out_of_order_turn_lifecycle_is_explicit_and_does_not_regress() -> None:
+    store = ThreadStateStore()
+    completed = store.observe(_event("turn_completed", event_id="done"))
+    late_start = store.observe(_event("turn_started", event_id="start"))
+
+    assert completed.active_turn_id is None
+    assert late_start.active_turn_id is None
+    assert late_start.coverage.history == HistoryStatus.PARTIAL
+    assert late_start.coverage.inconsistencies == (
+        "turn_completed_without_start:turn-1",
+        "late_start_for_completed_turn:turn-1",
+    )
+
+
+def test_interleaved_threads_remain_isolated() -> None:
+    store = ThreadStateStore()
+    first = store.observe(_event("user_prompt", {"prompt": "First"}, event_id="a"))
+    second = store.observe(
+        _event("user_prompt", {"prompt": "Second"}, event_id="b", thread="thread-2")
+    )
+
+    assert first.thread_id != second.thread_id
+    assert store.snapshot(ThreadId("thread-1")).task.goal.text == "First"  # type: ignore[union-attr]
+    assert store.snapshot(ThreadId("thread-2")).task.goal.text == "Second"  # type: ignore[union-attr]
+
+    store.observe(
+        _event(
+            "reasoning_summary",
+            {"summary": ["Child-only context"], "parent_thread_id": "thread-1"},
+            event_id="child",
+            thread="child-thread",
+        )
+    )
+    assert all(
+        item.text != "Child-only context"
+        for item in store.snapshot(ThreadId("thread-1")).evidence.items
+    )
+
+
+def test_snapshot_is_deeply_immutable_and_version_anchored() -> None:
+    store = ThreadStateStore()
+    snapshot = store.observe(_event("user_prompt", {"prompt": "Goal"}, event_id="goal"))
+    store.observe(_event("constraint", {"text": "Keep API"}, event_id="constraint"))
+
+    assert snapshot.version == 1
+    assert snapshot.task.constraints == ()
+    with pytest.raises(FrozenInstanceError):
+        snapshot.version = 9  # type: ignore[misc]
+
+
+def test_replay_is_deterministic_and_hydration_is_not_control_ready() -> None:
+    events = [
+        _event("thread_started", event_id="thread"),
+        _event("turn_started", event_id="turn"),
+        _event("runtime_reconciled", {"capabilities": ["steer"]}, event_id="ready"),
+    ]
+    uninterrupted = ThreadStateStore().replay(events)
+    replayed = ThreadStateStore().replay(events)
+    records = [StepRecord(index, event, None) for index, event in enumerate(events)]
+    hydrated = ThreadStateStore().hydrate(records)
+
+    assert replayed == uninterrupted
+    assert uninterrupted[0].control_ready is True
+    assert hydrated[0].control_ready is False
+    assert hydrated[0].active_turn_id is None
+
+
+def test_connection_epoch_and_gap_require_live_reconciliation() -> None:
+    store = ThreadStateStore()
+    store.observe(_event("runtime_reconciled", {"capabilities": ["steer"]}, event_id="r1"))
+    changed = store.observe(
+        _event(
+            "observation_gap",
+            {
+                "started_at": 100,
+                "ended_at": 110,
+                "epoch_before": 1,
+                "epoch_after": 2,
+                "backfill_status": "partial",
+            },
+            event_id="gap",
+            epoch=2,
+        )
+    )
+    reconciled = store.observe(
+        _event(
+            "runtime_reconciled",
+            {"capabilities": ["interrupt", "steer"], "active_turn": True},
+            epoch=2,
+        )
+    )
+
+    assert changed.thread_id == ThreadId("thread-1")
+    assert changed.connection_epoch == 2
+    assert changed.control_ready is False
+    assert changed.coverage.history == HistoryStatus.PARTIAL
+    assert changed.coverage.gaps[0].backfill_status == "partial"
+    assert reconciled.control_ready is True
+    assert reconciled.active_turn_id == TurnId("turn-1")
+    assert reconciled.capabilities == ("interrupt", "steer")
+
+
+def test_verification_and_invalidation_keep_fact_types_distinct() -> None:
+    store = ThreadStateStore()
+    store.observe(
+        _event(
+            "test_result",
+            {"status": "passed", "text": "login tests passed"},
+            event_id="e1",
+        )
+    )
+    store.observe(
+        _event(
+            "verification_condition",
+            {
+                "condition_id": "vc1",
+                "kind": "test_passes",
+                "scope": "tests/login.py",
+                "required_evidence": ["test_result"],
+                "created_from": "constraint",
+            },
+            event_id="condition",
+        )
+    )
+    store.observe(
+        _event(
+            "verification_satisfied",
+            {"condition_id": "vc1", "evidence_id": "e1", "text": "login tests pass"},
+            event_id="fact",
+        )
+    )
+    store.observe(
+        _event(
+            "hypothesis",
+            {"text": "The fix is safe", "evidence_ids": ["e1"]},
+            event_id="h1",
+        )
+    )
+    invalidated = store.observe(
+        _event("evidence_invalidated", {"evidence_id": "e1"}, event_id="invalidate")
+    )
+
+    assert invalidated.evidence.conditions[0].status == ConditionStatus.INVALIDATED
+    fact = next(
+        item for item in invalidated.evidence.items if item.kind == StateItemKind.VERIFIED_FACT
+    )
+    hypothesis = next(
+        item for item in invalidated.evidence.items if item.kind == StateItemKind.HYPOTHESIS
+    )
+    assert fact.status == StateItemStatus.STALE
+    assert hypothesis.status == StateItemStatus.STALE
+
+
+def test_validation_and_unknown_coverage_never_infer_missing_outcomes() -> None:
+    store = ThreadStateStore()
+    state = store.observe(_event("runtime_event_unknown", {"method": "future"}))
+    state = store.observe(
+        _event("file_edit", {"files": ["src/a.py"]}, event_id="edit", operation_id="edit")
+    )
+    unknown = store.observe(_event("test_result", {}, event_id="test-unknown"))
+    failed = store.observe(_event("test_result", {"status": "failed"}, event_id="test-failed"))
+    passed = store.observe(_event("test_result", {"status": "passed"}, event_id="test-passed"))
+    edited_after_validation = store.observe(
+        _event("file_edit", {"files": ["src/b.py"]}, event_id="edit-after-pass")
+    )
+
+    assert state.coverage.unknown_event_count == 1
+    assert unknown.execution.validation == ValidationStatus.UNKNOWN
+    assert unknown.workspace.edits_since_validation == {"src/a.py"}
+    assert failed.execution.validation == ValidationStatus.FAILED
+    assert passed.execution.validation == ValidationStatus.PASSED
+    assert edited_after_validation.execution.validation == ValidationStatus.STALE
+
+
+def test_hydration_skips_legacy_records_without_inventing_thread_identity() -> None:
+    app_event = _event("thread_started", event_id="thread")
+    records = [
+        StepRecord(0, TraceEvent("tool_result", {"session_id": "legacy"}), None),
+        StepRecord(1, app_event, None),
+    ]
+
+    states = ThreadStateStore().hydrate(records)
+
+    assert len(states) == 1
+    assert states[0].thread_id == ThreadId("thread-1")
+
+
+def test_missing_thread_identity_is_rejected() -> None:
+    with pytest.raises(ThreadStateError, match="no logical thread identity"):
+        ThreadStateStore().observe(TraceEvent("thread_started"))


### PR DESCRIPTION
## Why

App Server Trace IR needs one long-lived, thread-isolated owner of judgment-ready state. Rebuilding audit context from the journal on every Hook cannot support incremental signals or freshness-safe reviewer snapshots.

## What changed

- add a deterministic reducer for immutable, versioned task/evidence/workspace/execution/supervision/coverage state
- keep hypotheses, observations, verified facts, summaries, constraints, and interventions provenance-distinct
- make duplicate IDs idempotent and lifecycle gaps, ordering conflicts, unknown events, and evidence invalidation explicit
- let `spotterd` own per-thread snapshots and conservatively hydrate durable Trace history without restoring stale control readiness
- persist connection epochs in Trace journals for later reconnect reconciliation

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (347 passed)

Closes #31