### PR TITLE
Emit tagged release artifacts and packaged build identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build tagged distributions
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Verify embedded release identity
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          python -m pip install --force-reinstall dist/*.whl
+          test "$(spotter --version)" = "spotter ${RELEASE_TAG#v}"
+          test "$(spotterd --version)" = "spotterd ${RELEASE_TAG#v}"
+      - name: Write artifact checksums
+        working-directory: dist
+        run: sha256sum *.whl *.tar.gz > SHA256SUMS
+      - name: Publish immutable tag artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GITHUB_REF_NAME}" dist/* --verify-tag --generate-notes

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ __pycache__/
 .venv/
 build/
 dist/
-
+src/spotter/_version.py

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,18 @@
+# Releases
+
+Spotter releases are built only when an immutable semantic-version tag matching
+`vMAJOR.MINOR.PATCH` is pushed. The tag is the single source of the package
+version; Hatch VCS embeds it into both the wheel and source distribution.
+
+Each GitHub release contains:
+
+- a platform-independent Python wheel containing the `spotter` and `spotterd`
+  entry points and the `spotter hook` bridge;
+- a source distribution;
+- `SHA256SUMS`, with a SHA-256 digest for both distributions.
+
+The wheel uses ordinary Python console-script entry points and contains no
+Homebrew prefix or Cellar path. A package manager may therefore choose its own
+installation prefix. `spotter --version` and `spotterd --version` expose the
+identity embedded at build time; compatibility contracts remain independently
+versioned in `spotter.build`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling>=1.24"]
+requires = ["hatchling>=1.24", "hatch-vcs>=0.4,<0.6"]
 build-backend = "hatchling.build"
 
 [project]
 name = "spotter-agent"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Runtime trajectory supervision for coding agents"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -21,6 +21,16 @@ dev = [
 
 [project.scripts]
 spotter = "spotter.cli:main"
+spotterd = "spotter.daemon:main"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+fallback_version = "0.1.0.dev0"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/spotter/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/spotter"]
@@ -40,4 +50,3 @@ files = ["src", "tests"]
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["tests"]
-

--- a/src/spotter/build.py
+++ b/src/spotter/build.py
@@ -1,0 +1,26 @@
+"""Packaged build identity and independently versioned runtime contracts."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+# These identifiers describe compatibility, not the package release. Bump one
+# only when its corresponding reader/writer contract changes incompatibly.
+IPC_PROTOCOL_VERSION = 1
+CONFIG_SCHEMA_VERSION = 1
+INTEGRATION_MANIFEST_VERSION = 1
+
+
+def package_version() -> str:
+    """Return the identity embedded in the installed distribution."""
+    try:
+        return version("spotter-agent")
+    except PackageNotFoundError:
+        # Source checkouts do not necessarily have generated VCS metadata.
+        try:
+            from spotter._version import __version__
+        except ImportError:
+            return "0.1.0.dev0+source"
+        return __version__
+
+
+def version_banner(program: str) -> str:
+    return f"{program} {package_version()}"

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -22,6 +22,7 @@ from spotter.budget import (
 from spotter.budget import (
     read as read_spend,
 )
+from spotter.build import version_banner
 from spotter.codex import CodexAdapter
 from spotter.config import ConfigurationError, MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.core import SpotterRuntime
@@ -50,6 +51,7 @@ from spotter.trace import TraceEvent
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Observe a coding-agent trajectory")
+    parser.add_argument("--version", action="version", version=version_banner("spotter"))
     parser.add_argument(
         "command",
         nargs="?",

--- a/src/spotter/daemon.py
+++ b/src/spotter/daemon.py
@@ -1,0 +1,13 @@
+"""Entry point for the packaged Spotter daemon."""
+
+import argparse
+from collections.abc import Sequence
+
+from spotter.build import version_banner
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="spotterd", description="Spotter supervision daemon")
+    parser.add_argument("--version", action="version", version=version_banner("spotterd"))
+    parser.parse_args(argv)
+    return 0

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,23 @@
+"""Release identity is exposed by every packaged executable."""
+
+import re
+
+import pytest
+
+from spotter.build import package_version
+from spotter.cli import main as cli_main
+from spotter.daemon import main as daemon_main
+
+
+@pytest.mark.parametrize(
+    ("entrypoint", "program"),
+    [(cli_main, "spotter"), (daemon_main, "spotterd")],
+)
+def test_version_banner(
+    entrypoint: object, program: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit, match="0"):
+        entrypoint(["--version"])  # type: ignore[operator]
+
+    assert capsys.readouterr().out == f"{program} {package_version()}\n"
+    assert re.fullmatch(r"[0-9]+(?:\.[0-9]+)+(?:[^\s]*)?", package_version())


### PR DESCRIPTION
### Motivation
- Produce immutable, tag-derived release artifacts and embed a reproducible packaged identity so downstream packagers can rely on a stable release string.
- Expose the packaged identity at runtime via `spotter --version` and `spotterd --version` while keeping compatibility contracts independently versioned.

### Description
- Switch packaging to Hatch VCS by updating `pyproject.toml` to use `hatch-vcs` and make the package `version` dynamic from VCS, and add a `spotterd` console entry point.
- Add `src/spotter/build.py` to centralize `package_version()` and independent compatibility identifiers (`IPC_PROTOCOL_VERSION`, `CONFIG_SCHEMA_VERSION`, `INTEGRATION_MANIFEST_VERSION`).
- Add `src/spotter/daemon.py` and wire `--version` output for `spotterd`, and add `--version` support to the CLI via `version_banner` so both entry points report the embedded package identity.
- Add a `Release` GitHub Actions workflow to build tag-triggered artifacts, verify embedded identities, generate `SHA256SUMS`, and publish immutable release assets, plus `docs/releasing.md` documenting the artifact contract and `.gitignore` entry for generated version file.
- Add `tests/test_version.py` to assert both `spotter` and `spotterd` expose the packaged identity and that `package_version()` matches a numeric/semantic form.

### Testing
- Ran formatting and lint checks with `ruff format --check .` and `ruff check .`, both succeeded.
- Type checks with `mypy src tests` passed.
- Ran `pytest`, with the full test suite passing (`253 passed`).
- Built distributions with `python -m build --outdir /tmp/spotter-dist`, verified wheel console scripts contain `spotter` and `spotterd`, and generated SHA-256 checksums in `SHA256SUMS` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d6d0b450c8329b80911dcd24a47a0)