### PR TITLE
feat(runtime): recover App Server connections safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ External Codex App Server
 ```
 
 [#78](https://github.com/spotter-agent/spotter/issues/78) proved shared observation and steering for a
-Spotter-managed external App Server. Current Runtime work turns that viable control boundary into
-the daemon, identity, lifecycle, and recovery components required for ordinary use.
+Spotter-managed external App Server. The daemon now owns connection epochs, reconnect/reconciliation,
+and conservative control freshness; endpoint selection in setup remains the last ordinary-use gap.
 
 For the fastest project snapshot, read [Status](docs/status.md). For sequence and evidence gates, read [Roadmap](docs/roadmap.md).
 
@@ -77,8 +77,8 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Claim/evidence audit ledger | 🟡 | Works where observable outcomes exist |
 | Evaluation labels / metrics | ✅ | Coverage-aware evaluation and precision/FP metrics |
 | Counterfactual experiment harness | ✅ | Control/guidance same-prefix pairs |
-| Standalone `spotterd` runtime | 🟡 | Process, gate/control IPC, managed startup, and per-thread immutable live state implemented; App Server connection ownership remains |
-| App Server primary observation | 🟡 | Client, identity-rich Trace IR, durable ingestion, and incremental ThreadState reducer implemented; daemon connection routing remains |
+| Standalone `spotterd` runtime | 🟡 | Process, gate IPC, per-thread immutable state, and App Server recovery ownership implemented; setup endpoint selection remains |
+| App Server primary observation | 🟡 | Configured endpoints route through daemon-owned epoch/reconciliation into durable Trace IR and ThreadState; setup does not select an endpoint yet |
 | Event-driven signal engine | ❌ | Current reviewer trigger is periodic |
 | Live `VERIFY / NUDGE` | ❌ | Target: `turn/steer` |
 | `INTERRUPT` | ❌ | Target: `turn/interrupt` |
@@ -97,14 +97,15 @@ MCP, search, diff, and token events into durable Trace IR. Exact replays are ded
 restarts, operation outcomes correlate by item ID, and unknown notification families remain explicit.
 [#31](https://github.com/spotter-agent/spotter/issues/31) reduces that Trace IR into isolated,
 immutable, versioned ThreadState snapshots owned by `spotterd`; restart hydration deliberately
-requires live turn reconciliation before control becomes ready again.
+requires live turn reconciliation before control becomes ready again. [#87](https://github.com/spotter-agent/spotter/issues/87)
+adds the single-owner connection loop, bounded reconnect backoff, durable observation gaps,
+connection/attachment epochs, multi-thread reconciliation, and exact epoch+turn control fencing.
 [#79](https://github.com/spotter-agent/spotter/issues/79)
 adds the `spotterd` process, versioned local control handshake, manual lifecycle commands, and a
 platform-neutral service boundary. [#83](https://github.com/spotter-agent/spotter/issues/83) adds
 transactional Codex setup/teardown, managed user-service registration, and integration ownership.
 [#84](https://github.com/spotter-agent/spotter/issues/84) makes `status` and `doctor` distinguish
-daemon, observation, control, enforcement, integration drift, storage, and reviewer health. Event
-routing and recovery remain separate work.
+daemon, observation, control, enforcement, integration drift, storage, and reviewer health.
 
 ---
 
@@ -330,8 +331,9 @@ spotter setup codex
 spotter teardown codex
 ```
 
-App Server endpoint selection remains pending until the remaining ingestion/lifecycle work lands;
-setup does not print or claim an endpoint that it has not verified.
+App Server endpoint selection remains pending; when a verified endpoint is present in the integration
+manifest, `spotterd` owns its connection and recovery loop. Setup does not print or claim an endpoint
+that it has not verified.
 
 Useful commands:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
 > **Status:** this document describes both the current hook-based prototype and the target architecture. Active implementation is tracked by the [Roadmap](roadmap.md) and native GitHub Milestones.
-> The `spotterd` process/control foundation, bounded Hook gate IPC, shared-server PoC, production App Server transport, and durable Trace IR ingestion are implemented. Daemon event routing and live supervision delivery remain **target behavior**.
+> The `spotterd` process/control foundation, bounded Hook gate IPC, shared-server PoC, production App Server transport, durable Trace IR ingestion, and daemon reconnect/reconciliation are implemented. Live supervision delivery remains **target behavior**.
 
 ---
 
@@ -113,10 +113,10 @@ handshake rather than treating a PID file as liveness. The server serializes own
 concurrent clients, reports `healthy` / `degraded` / `recovering`, and makes absence explicit as
 `unavailable`.
 
-Manual process management implements the `ServiceManager` boundary used by the CLI. Managed
-`launchd` / `systemd --user` registration belongs to setup lifecycle work. This daemon currently
-owns semantic `ThreadState` and bounded Hook gate IPC, but no App Server connection or event routing,
-so stopping it cannot stop a shared Codex App Server and existing Hook behavior remains independent.
+Manual process management implements the `ServiceManager` boundary used by the CLI. For a configured
+endpoint, the daemon owns one App Server connection/reconnect loop, routes epoch-tagged Trace IR into
+durable journals and `ThreadState`, and reconciles loaded threads before reporting control-ready.
+It never owns or stops the shared App Server process; existing Hook enforcement remains independent.
 
 ## 1.3 Target runtime
 
@@ -477,7 +477,7 @@ disappearing or leaking a new wire shape into core consumers.
 
 `AppServerTraceIngestor` writes one journal per Spotter thread identity, separately named from
 Hook-era session journals. Its recovery scan rebuilds deduplication and lifecycle state after a
-restart. Item starts and outcomes correlate by App Server item ID, not journal adjacency. A terminal
+restart. Item starts and outcomes correlate by App Server item ID plus connection epoch, not journal adjacency. A terminal
 event seen before its start is retained with `observed_start=false`; a later start cannot regress it.
 Timestamp regressions are accepted but marked `out_of_order`, and conflicting terminal outcomes fail
 explicitly. Hook records carry legacy-session provenance with unknown thread, turn, and attachment
@@ -590,8 +590,8 @@ only be created by an explicit verification-satisfied event. Duplicate event IDs
 out-of-order lifecycle is recorded as partial coverage, and thread identities remain isolated.
 
 Journal hydration deterministically replays Trace IR but clears active-turn/control readiness. A
-recovered daemon must receive a live `runtime_reconciled` event before control can be considered
-safe; #87 owns that connection and reconciliation loop.
+recovered daemon receives a live `runtime_reconciled` event only after the App Server thread list/read
+pass proves current attachment and exact active-turn identity. Until then control remains unavailable.
 
 ## 8.2 Durable journal
 
@@ -676,8 +676,8 @@ State scope:
   than being promoted into an identity it cannot prove.
 
 The registry owns identity and lifecycle only. App Server Trace normalization and the daemon's
-semantic `ThreadState` consume those identities without importing Codex wire shapes. Daemon
-connection reconciliation remains #87.
+semantic `ThreadState` consume those identities without importing Codex wire shapes. Each physical
+connection gets a new attachment ID and monotonically recovered epoch; logical thread IDs survive it.
 
 ---
 
@@ -715,8 +715,9 @@ This allows a Codex upgrade to degrade one feature without forcing a binary “s
 
 `spotter status` now reports this split without probing external services. `spotter doctor` performs
 the deeper App Server connection/initialize probe when the integration manifest has an endpoint.
-Until #85 wires a persistent runtime consumer, thread counts and reviewer queue state are reported
-as unknown/unavailable instead of being derived from incompatible Hook-era sessions.
+When the integration manifest contains an endpoint, `spotterd` keeps the persistent consumer and a
+full per-connection capability/server fingerprint. Endpoint selection remains explicit and pending in
+setup rather than being inferred from a listener that merely answers a socket.
 
 ---
 
@@ -772,14 +773,15 @@ During daemon downtime, the Hook gate fails open.
 ### App Server disconnect
 
 ```text
-CONNECTED
-  ↓
-DEGRADED
-  ↓
-RECONNECTING
-  ├─ CONNECTED
-  └─ UNAVAILABLE
+DISCONNECTED → CONNECTING → RECONCILING → READY
+                    ↑                       │
+                    └─ BACKING_OFF ← DEGRADED
 ```
+
+Every successful physical connection advances the durable-enough local epoch. Disconnect intervals
+produce per-thread `observation_gap` records; current thread/turn state is queried rather than
+invented. Control calls must name the exact reconciled epoch and active turn, so late results from an
+older connection are rejected instead of silently retargeted.
 
 A healthy daemon with no observation/control channel is not fully healthy.
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -424,9 +424,10 @@ Spotter ↔ App Server initialized
 Hook IPC reachable
 ```
 
-The current #83 implementation verifies Codex's `app-server --listen` and `--remote` capability but
-records endpoint selection as pending because it does not create or own a shared App Server. Live
-endpoint selection and App Server initialize/event verification join #85/#87 and #84 diagnostics.
+The current setup verifies Codex's `app-server --listen` and `--remote` capability but records
+endpoint selection as pending because it does not create or own a shared App Server. When a verified
+endpoint is present in the manifest, `spotterd` owns connection, epoch, backoff, and reconciliation;
+`doctor` continues to probe the same explicit endpoint.
 
 ## 4.7 VERIFY
 
@@ -487,7 +488,8 @@ re-running setup heals forward, while teardown cannot remove an unrecorded mutat
 
 # 5. App Server lifecycle
 
-This is the largest open lifecycle dependency in the target design.
+Connection recovery is implemented; selecting and verifying the shared endpoint without claiming
+ownership of another client's App Server remains the lifecycle dependency.
 
 ## 5.1 Why startup order matters
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -30,7 +30,7 @@ PreToolUse Hook only
 (deterministic synchronous enforcement)
 ```
 
-The shared App Server gate is resolved: an explicitly connected TUI and Spotter can observe and steer the same real turn. The Hook now uses bounded daemon IPC for deterministic enforcement. The immediate work is long-lived App Server event routing and reconnect/reconciliation in #87. See [App Server connection validation](app-server-validation.md).
+The shared App Server gate is resolved: an explicitly connected TUI and Spotter can observe and steer the same real turn. The Hook now uses bounded daemon IPC for deterministic enforcement, and `spotterd` owns reconnect/reconciliation for configured App Server endpoints. The immediate work is measuring App Server observability in #37 before reducing redundant Hooks in #86. See [App Server connection validation](app-server-validation.md).
 The roadmap no longer uses `P0–P9` / `E0–E5`. It is organized by named outcomes:
 
 ```text
@@ -40,8 +40,8 @@ Runtime → Observe → Detect → Intervene → Recover → Harden
 The shared-server gate in [#78](https://github.com/spotter-agent/spotter/issues/78) passed for the
 Spotter-managed external App Server path. Spotter now has a production WebSocket client and a
 Thread/Turn/Runtime Attachment registry, durable normalized ingestion, and an incremental immutable
-ThreadState reducer. The standalone daemon owns isolated state snapshots and a versioned local
-control/gate handshake; App Server connection ownership and reconnect remain next.
+ThreadState reducer. The standalone daemon owns isolated state snapshots, a versioned local
+control/gate handshake, and the App Server connection/recovery loop.
 
 ---
 
@@ -64,14 +64,11 @@ transactional Codex Hook/plugin migration, and managed `launchd`/`systemd --user
 manifest and Hook ownership checks, App Server probing when an endpoint exists, and explicit
 degraded consequences when observation/control are unavailable but Hook enforcement remains.
 
-The remaining runtime boundary is tracked in:
-
-- [#87](https://github.com/spotter-agent/spotter/issues/87) — daemon/App Server reconnect and identity reconciliation.
-
 [#31](https://github.com/spotter-agent/spotter/issues/31) adds daemon-owned immutable ThreadState,
 deterministic Trace IR reduction, durable replay hydration, explicit coverage gaps, and conservative
-control readiness after restart. [#87](https://github.com/spotter-agent/spotter/issues/87) will connect
-that state owner to the long-lived App Server recovery loop.
+control readiness after restart. [#87](https://github.com/spotter-agent/spotter/issues/87) connects
+that state owner to a single-owner App Server loop with connection epochs, bounded backoff,
+multi-thread reconciliation, durable observation gaps, and exact epoch/turn control fencing.
 
 The assumption that merely starting the external server would make plain `codex` reuse it was
 rejected by the [2026-08-13 validation](app-server-validation.md). The explicit `--remote` path
@@ -96,18 +93,18 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | --- | --- | --- | --- |
 | Hook ingestion | ✅ | `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse` are journaled | Measure App Server parity in #37, then remove redundant Hooks in #86 |
 | Deterministic gate | ✅ | Shell-aware daemon evaluation over bounded local IPC; unavailable/timeout uses the local Gate, while incompatible responses fail open | Continue policy precision/miss-rate measurement |
-| Journal | ✅ | Crash-tolerant JSONL stores identity-rich App Server Trace IR with locking, fsync, and torn-tail recovery | Add bounded retention/checkpoint lifecycle in #87/#89 |
+| Journal | ✅ | Crash-tolerant JSONL stores identity-rich App Server Trace IR with locking, fsync, torn-tail recovery, and recovery gaps | Add bounded retention/checkpoint lifecycle in #89 |
 | Snapshot | ✅ | Git-backed snapshots, deduplication, pruning, detached restore | Preserve lineage through runtime/retention migration (#89) |
 | Fork / replay | ✅ | Continue Codex from a shared prefix in a detached worktree | Measure fidelity/noise floor in #42 |
 | Shadow reviewer | ✅ | Produces `CONTINUE`, `VERIFY`, `NUDGE`; verdicts are recorded only | Move to event-driven candidates, then live delivery |
 | Audit / live state | 🟡 | Daemon-owned typed ThreadState distinguishes constraints, hypotheses, observations, verified facts, summaries, interventions, and coverage | Feed reviewer jobs and signals from immutable snapshots |
 | Evaluation labels / metrics | ✅ | Coverage-aware labeling and precision/FP metrics | Broader cost/miss/harm metrics (#33, #38, #34) |
 | Counterfactual harness | ✅ | Control/guidance same-prefix pairs can be prepared/run | Add mechanically scored tasks (#21) |
-| Standalone runtime | 🟡 | Long-lived process, IPC, lifecycle, and isolated per-thread hot-state ownership | Add App Server connection/reconciliation in #87 |
-| Runtime identity | 🟡 | Lifecycle registry feeds normalized journals and ThreadState while legacy dimensions remain explicit unknowns | Add connection epochs and attachment reconciliation in #87 |
-| App Server primary observation | 🟡 | Async client, normalized durable Trace IR, and incremental ThreadState reduction | Route the long-lived connection through `spotterd` in #87 |
-| Managed Codex lifecycle | 🟡 | Transactional setup/teardown, versioned ownership manifest, legacy migration, launchd/systemd-user service, runtime diagnostics | Connect and reconcile the external App Server in #87 |
-| Runtime reconnect/recovery | ❌ | Durable hydration is conservative, but no long-lived App Server reconnect owner exists | Implement #87 on the daemon/state boundaries |
+| Standalone runtime | 🟡 | Long-lived process, IPC, lifecycle, isolated per-thread state, and App Server recovery ownership | Select and verify the shared endpoint during setup |
+| Runtime identity | ✅ | Logical threads/turns remain separate from per-connection attachment IDs and monotonically recovered epochs | Propagate the identity into future reviewer jobs |
+| App Server primary observation | 🟡 | Configured endpoints route through `spotterd` into normalized durable Trace IR and incremental ThreadState | Measure parity/ceiling in #37, then reduce Hooks in #86 |
+| Managed Codex lifecycle | 🟡 | Transactional setup/teardown, managed service, diagnostics, and configured-endpoint recovery | Add verified endpoint selection without claiming shared-process ownership |
+| Runtime reconnect/recovery | ✅ | Explicit connect/reconcile/backoff states, restart hydration, durable gaps, capability/server fingerprints, and stale-control fencing | Add retention/checkpoints in #89 |
 | Event-driven detection | ❌ | Reviewer is still cadence-based | #28 after Runtime/Observe |
 | Live `VERIFY` / `NUDGE` | ❌ | Reviewer decisions stop at the journal | #22 via `turn/steer` |
 | `INTERRUPT` / `RESTART` | ❌ | No live recovery path | #26 + #30 after soft intervention is understood |
@@ -158,7 +155,7 @@ Implementation progress and research evidence remain separate.
 | Is the fork instrument's causal noise floor known? | **No — #42** |
 | Is there a reproducible mechanically scored task corpus? | **No — #21** |
 | Has live Spotter guidance been shown to improve outcomes? | **No** |
-| Is the App Server control boundary operationally viable? | **Yes for the Spotter-managed external path; daemon lifecycle and reconnect remain** |
+| Is the App Server control boundary operationally viable? | **Yes for a configured Spotter-managed external path, including daemon reconnect/reconciliation** |
 
 A mechanism being implemented does not prove it improves outcomes. Null and negative results are first-class outcomes for this project.
 

--- a/src/spotter/daemon.py
+++ b/src/spotter/daemon.py
@@ -141,6 +141,9 @@ class DaemonClient:
                 health=health,
                 pid=pid,
                 protocol=PROTOCOL_VERSION,
+                detail=(
+                    response.get("detail") if isinstance(response.get("detail"), str) else None
+                ),
             )
         except DaemonUnavailable as error:
             return DaemonStatus(RuntimeHealth.UNAVAILABLE, detail=str(error))
@@ -186,14 +189,24 @@ class DaemonClient:
 class DaemonServer:
     """Own the local runtime socket without owning any agent App Server."""
 
-    def __init__(self, socket_path: Path | None = None) -> None:
+    def __init__(
+        self,
+        socket_path: Path | None = None,
+        *,
+        app_server_endpoint: str | None = None,
+        journals_dir: Path | None = None,
+    ) -> None:
         self.socket_path = socket_path or runtime_socket()
         self.health = RuntimeHealth.HEALTHY
+        self.health_detail: str | None = None
         self._server: asyncio.AbstractServer | None = None
         self._shutdown = asyncio.Event()
         self._socket_inode: int | None = None
         self._lock: TextIOWrapper | None = None
         self.thread_states = ThreadStateStore()
+        self.app_server_endpoint = app_server_endpoint
+        self.journals_dir = journals_dir or spotter_home() / "sessions"
+        self.recovery: Any | None = None
 
     def observe_trace(self, event: TraceEvent) -> ThreadState:
         """Increment daemon-owned hot state after adapter normalization and journaling."""
@@ -238,6 +251,17 @@ class DaemonServer:
             raise
         self.socket_path.chmod(0o600)
         self._socket_inode = self.socket_path.stat().st_ino
+        if self.app_server_endpoint is not None:
+            # Keep websockets and the App Server stack off the Hook import path.
+            from spotter.runtime_connection import AppServerRecoveryLoop
+
+            self.recovery = AppServerRecoveryLoop(
+                self.app_server_endpoint,
+                self.journals_dir,
+                self.thread_states,
+                on_state=self._on_recovery_state,
+            )
+            await self.recovery.start()
 
     async def serve(self) -> None:
         await self.start()
@@ -250,6 +274,9 @@ class DaemonServer:
         await self._shutdown.wait()
 
     async def close(self) -> None:
+        if self.recovery is not None:
+            await self.recovery.close()
+            self.recovery = None
         if self._server is not None:
             self._server.close()
             await self._server.wait_closed()
@@ -263,10 +290,20 @@ class DaemonServer:
         self._socket_inode = None
         self._release_lock()
 
-    def set_health(self, health: RuntimeHealth) -> None:
+    def set_health(self, health: RuntimeHealth, detail: str | None = None) -> None:
         if health == RuntimeHealth.UNAVAILABLE:
             raise ValueError("a running daemon cannot report itself unavailable")
         self.health = health
+        self.health_detail = detail
+
+    def _on_recovery_state(self, state: object, detail: str | None) -> None:
+        value = getattr(state, "value", str(state))
+        if value == "ready":
+            self.set_health(RuntimeHealth.HEALTHY)
+        elif value in {"connecting", "reconciling"}:
+            self.set_health(RuntimeHealth.RECOVERING, detail)
+        elif value in {"degraded", "backing_off"}:
+            self.set_health(RuntimeHealth.DEGRADED, detail)
 
     def _release_lock(self) -> None:
         if self._lock is None:
@@ -294,6 +331,8 @@ class DaemonServer:
                 "health": self.health.value,
                 "pid": os.getpid(),
             }
+            if self.health_detail is not None:
+                response["detail"] = self.health_detail
             if method == "gate":
                 response.update(_evaluate_gate(request.get("params")))
         except (
@@ -624,13 +663,23 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run the Spotter supervision daemon")
     parser.parse_args(argv)
     try:
-        asyncio.run(DaemonServer().serve())
+        asyncio.run(DaemonServer(app_server_endpoint=_configured_app_server_endpoint()).serve())
     except DaemonAlreadyRunning as error:
         print(error, file=sys.stderr)
         return 1
     except KeyboardInterrupt:
         return 0
     return 0
+
+
+def _configured_app_server_endpoint() -> str | None:
+    path = spotter_home() / "integrations" / "codex.json"
+    try:
+        raw = json.loads(path.read_bytes())
+    except (OSError, ValueError):
+        return None
+    endpoint = raw.get("app_server_endpoint") if isinstance(raw, dict) else None
+    return endpoint if isinstance(endpoint, str) and endpoint.strip() else None
 
 
 if __name__ == "__main__":

--- a/src/spotter/ingestion.py
+++ b/src/spotter/ingestion.py
@@ -226,15 +226,25 @@ class AppServerTraceIngestor:
         self.journals_dir.mkdir(parents=True, exist_ok=True)
         self.normalizer = CodexTraceNormalizer()
         self._seen: set[str] = set()
-        self._operations: dict[tuple[str, str, str], tuple[str, str | None]] = {}
+        self._operations: dict[tuple[str, str, str, str], tuple[str, str | None]] = {}
         self._terminal_turns: set[str] = set()
-        self._last_at: dict[tuple[str, str], float] = {}
-        # ponytail: recovery is O(all App Server history); #87 should checkpoint per-thread
-        # reconciliation state and apply retention before the daemon owns long-lived ingestion.
+        self._last_at: dict[tuple[str, str, str], float] = {}
+        self.last_connection_epoch = 0
+        # ponytail: recovery is O(all App Server history); #89 should checkpoint per-thread
+        # reconciliation state when retained histories become measurably expensive.
         self._recover()
 
-    def ingest(self, raw_event: AppServerEvent) -> StepRecord | None:
+    def ingest(
+        self, raw_event: AppServerEvent, *, connection_epoch: int | None = None
+    ) -> StepRecord | None:
         event = self.normalizer.normalize(raw_event)
+        if connection_epoch is not None:
+            event = replace(event, connection_epoch=connection_epoch)
+        return self.record(event)
+
+    def record(self, event: TraceEvent) -> StepRecord | None:
+        """Append one already-normalized runtime event through the same idempotency path."""
+
         if event.event_id is not None and event.event_id in self._seen:
             return None
         route = _route(event)
@@ -272,6 +282,15 @@ class AppServerTraceIngestor:
         record = StepJournal(self.journals_dir / route).record(event)
         self._remember(record.event, route)
         return record
+
+    def records(self) -> tuple[StepRecord, ...]:
+        """Return durable App Server history for conservative daemon hydration."""
+
+        return tuple(
+            record
+            for path in sorted(self.journals_dir.glob("app-server-*.jsonl"))
+            for record in StepJournal.load(path, repair_tail=True)
+        )
 
     def _recover(self) -> None:
         for path in sorted(self.journals_dir.glob("app-server-*.jsonl")):
@@ -318,6 +337,8 @@ class AppServerTraceIngestor:
             self._last_at[ordering_key] = max(
                 self._last_at.get(ordering_key, event.occurred_at), event.occurred_at
             )
+        if event.connection_epoch is not None:
+            self.last_connection_epoch = max(self.last_connection_epoch, event.connection_epoch)
 
 
 def _normalize_item(item: Mapping[str, Any], completed: bool) -> tuple[str, dict[str, Any]]:
@@ -402,23 +423,23 @@ def _route(event: TraceEvent) -> str:
     return "app-server-unscoped.jsonl"
 
 
-def _operation_key(event: TraceEvent, route: str) -> tuple[str, str, str]:
+def _operation_key(event: TraceEvent, route: str) -> tuple[str, str, str, str]:
     turn_id = (
         event.identity.turn_id.value
         if event.identity is not None and event.identity.turn_id is not None
         else ""
     )
     assert event.operation_id is not None
-    return route, turn_id, event.operation_id
+    return route, turn_id, str(event.connection_epoch or ""), event.operation_id
 
 
-def _ordering_key(event: TraceEvent, route: str) -> tuple[str, str]:
+def _ordering_key(event: TraceEvent, route: str) -> tuple[str, str, str]:
     turn_id = (
         event.identity.turn_id.value
         if event.identity is not None and event.identity.turn_id is not None
         else ""
     )
-    return route, turn_id
+    return route, turn_id, str(event.connection_epoch or "")
 
 
 def _token_usage(value: object) -> dict[str, Any]:

--- a/src/spotter/runtime_connection.py
+++ b/src/spotter/runtime_connection.py
@@ -1,0 +1,483 @@
+"""Daemon-owned App Server reconnect, reconciliation, and epoch fencing."""
+
+import asyncio
+import contextlib
+import hashlib
+import json
+import random
+import time
+from collections.abc import Callable, Mapping
+from contextlib import AsyncExitStack
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from spotter.app_server import (
+    AppServerCapabilities,
+    AppServerError,
+    AppServerTransportError,
+    CapabilityStatus,
+    CodexAppServerClient,
+)
+from spotter.identity import AttachmentId, RuntimeIdentity, ThreadId
+from spotter.ingestion import AppServerTraceIngestor, IngestionError
+from spotter.thread_state import ThreadState, ThreadStateError, ThreadStateStore
+from spotter.trace import TraceEvent, TraceProvenance
+
+
+class RecoveryState(StrEnum):
+    DISCONNECTED = "disconnected"
+    CONNECTING = "connecting"
+    RECONCILING = "reconciling"
+    READY = "ready"
+    DEGRADED = "degraded"
+    BACKING_OFF = "backing_off"
+
+
+@dataclass(frozen=True)
+class ConnectionIdentity:
+    runtime_attachment_id: str
+    connection_epoch: int
+    endpoint_fingerprint: str
+    server_fingerprint: str
+    connected_at: float
+    capabilities: AppServerCapabilities
+    server_changed: bool
+
+
+@dataclass(frozen=True)
+class RecoveryMetrics:
+    reconnect_successes: int = 0
+    reconnect_failures: int = 0
+    observation_gaps: int = 0
+    last_recovery_seconds: float | None = None
+
+
+@dataclass(frozen=True)
+class RuntimeControlTarget:
+    identity: RuntimeIdentity
+    connection_epoch: int
+
+
+class StaleControlTarget(AppServerError):
+    """A live control request no longer names the exact reconciled epoch and turn."""
+
+
+StateCallback = Callable[[RecoveryState, str | None], None]
+ClientFactory = Callable[[str], CodexAppServerClient]
+
+
+class AppServerRecoveryLoop:
+    """Own exactly one App Server connection and conservatively reconcile it."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        journals_dir: Path,
+        thread_states: ThreadStateStore,
+        *,
+        on_state: StateCallback | None = None,
+        client_factory: ClientFactory | None = None,
+        initial_backoff: float = 0.1,
+        maximum_backoff: float = 30,
+    ) -> None:
+        if not endpoint.strip():
+            raise ValueError("App Server endpoint must be non-empty")
+        if initial_backoff < 0 or maximum_backoff < initial_backoff:
+            raise ValueError("invalid reconnect backoff")
+        self.endpoint = endpoint
+        self.thread_states = thread_states
+        self.ingestor = AppServerTraceIngestor(journals_dir)
+        self.on_state = on_state
+        self.client_factory = client_factory or (lambda value: CodexAppServerClient(value))
+        self.initial_backoff = initial_backoff
+        self.maximum_backoff = maximum_backoff
+        self.state = RecoveryState.DISCONNECTED
+        self.connection: ConnectionIdentity | None = None
+        self.metrics = RecoveryMetrics()
+        self.last_error: str | None = None
+        self.transitions: tuple[RecoveryState, ...] = (self.state,)
+        self._connection_epoch = self.ingestor.last_connection_epoch
+        self._client: CodexAppServerClient | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._stop = asyncio.Event()
+        self._retry = asyncio.Event()
+        self._attachments: dict[ThreadId, AttachmentId] = {}
+        self._disconnected_at: float | None = None
+
+        records = self.ingestor.records()
+        if records:
+            self.thread_states.hydrate(records)
+
+    async def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._stop.clear()
+        self._task = asyncio.create_task(self._run(), name="spotter-app-server-recovery")
+
+    async def close(self) -> None:
+        self._stop.set()
+        self._retry.set()
+        if self._client is not None:
+            with contextlib.suppress(Exception):
+                await self._client.disconnect()
+        if self._task is not None:
+            if not self._task.done():
+                self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        self._set_state(RecoveryState.DISCONNECTED)
+
+    def retry_now(self) -> None:
+        self._retry.set()
+
+    async def steer(self, target: RuntimeControlTarget, text: str) -> Mapping[str, Any]:
+        client, thread_id, turn_id = self._validate_target(target)
+        return await client.steer(thread_id, turn_id, text)
+
+    async def interrupt(self, target: RuntimeControlTarget) -> Mapping[str, Any]:
+        client, thread_id, turn_id = self._validate_target(target)
+        return await client.interrupt(thread_id, turn_id)
+
+    async def _run(self) -> None:
+        delay = self.initial_backoff
+        while not self._stop.is_set():
+            self._set_state(RecoveryState.CONNECTING)
+            client = self.client_factory(self.endpoint)
+            self._client = client
+            try:
+                async with AsyncExitStack() as stack:
+                    await client.connect()
+                    stack.push_async_callback(client.disconnect)
+                    self._connection_epoch += 1
+                    epoch = self._connection_epoch
+                    attachment_id = uuid4().hex
+                    connected_at = time.time()
+                    server_fingerprint = _fingerprint(client.server_info or {})
+                    previous_server = (
+                        self.connection.server_fingerprint if self.connection is not None else None
+                    )
+                    self.connection = ConnectionIdentity(
+                        attachment_id,
+                        epoch,
+                        _fingerprint(self.endpoint),
+                        server_fingerprint,
+                        connected_at,
+                        client.capabilities,
+                        previous_server is not None and previous_server != server_fingerprint,
+                    )
+                    consumer = asyncio.create_task(self._consume(client, epoch, attachment_id))
+                    stack.push_async_callback(_cancel_task, consumer)
+                    self._set_state(RecoveryState.RECONCILING)
+                    started = time.monotonic()
+                    await self._reconcile(client, epoch, attachment_id)
+                    if epoch != self._connection_epoch or self._stop.is_set():
+                        continue
+                    self.connection = replace(self.connection, capabilities=client.capabilities)
+                    self.metrics = replace(
+                        self.metrics,
+                        reconnect_successes=self.metrics.reconnect_successes + 1,
+                        last_recovery_seconds=time.monotonic() - started,
+                    )
+                    self.last_error = None
+                    self._set_state(RecoveryState.READY)
+                    delay = self.initial_backoff
+                    error = await client.wait_closed()
+                    if self._stop.is_set():
+                        break
+                    raise error or AppServerTransportError("App Server connection closed")
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                self.last_error = str(error)
+                self.metrics = replace(
+                    self.metrics,
+                    reconnect_failures=self.metrics.reconnect_failures + 1,
+                )
+                self._disconnected_at = time.time()
+                self._set_state(RecoveryState.DEGRADED, self.last_error)
+            finally:
+                self._client = None
+                self._detach_all()
+            if self._stop.is_set():
+                break
+            self._set_state(RecoveryState.BACKING_OFF, self.last_error)
+            await self._wait_backoff(delay + random.uniform(0, delay * 0.2))
+            delay = min(max(delay * 2, self.initial_backoff), self.maximum_backoff)
+
+    async def _consume(self, client: CodexAppServerClient, epoch: int, attachment_id: str) -> None:
+        while epoch == self._connection_epoch and not self._stop.is_set():
+            try:
+                raw_event = await client.next_event()
+                if epoch != self._connection_epoch:
+                    return
+                event = self.ingestor.normalizer.normalize(raw_event)
+                event = replace(
+                    event,
+                    identity=self._epoch_identity(event.identity, attachment_id),
+                    connection_epoch=epoch,
+                )
+                self._record(event)
+            except IngestionError as error:
+                self.last_error = str(error)
+            except AppServerError:
+                return
+
+    async def _reconcile(
+        self,
+        client: CodexAppServerClient,
+        epoch: int,
+        attachment_id: str,
+    ) -> None:
+        discovered: dict[str, Mapping[str, Any]] = {}
+        cursor: str | None = None
+        while True:
+            page = await client.list_threads(limit=100, cursor=cursor)
+            data = page.get("data")
+            if not isinstance(data, list):
+                raise AppServerTransportError("thread/list returned no data array")
+            for value in data:
+                if isinstance(value, Mapping) and isinstance(value.get("id"), str):
+                    discovered[value["id"]] = value
+            cursor = page.get("nextCursor") if isinstance(page.get("nextCursor"), str) else None
+            if cursor is None:
+                break
+
+        known = {
+            state.identity.provenance.agent_thread_id: state
+            for state in self.thread_states.snapshots()
+            if state.identity.provenance.agent_thread_id is not None
+        }
+        capabilities = _available_capabilities(client.capabilities)
+        ended_at = time.time()
+        for external_thread_id in sorted(discovered):
+            result = await client.read_thread(external_thread_id, include_turns=True)
+            thread = result.get("thread")
+            thread = thread if isinstance(thread, Mapping) else discovered[external_thread_id]
+            active_turn_id = _active_turn_id(thread)
+            identity = self._runtime_identity(external_thread_id, active_turn_id, attachment_id)
+            assert identity.thread_id is not None
+            previous = known.get(external_thread_id)
+            if previous is None or previous.connection_epoch != epoch:
+                self._record_gap(
+                    identity,
+                    previous,
+                    epoch,
+                    ended_at,
+                    (
+                        "reconnect"
+                        if previous is not None and self.metrics.reconnect_successes > 0
+                        else "daemon_restart"
+                        if previous is not None
+                        else "new_attachment"
+                    ),
+                )
+            self._record(
+                TraceEvent(
+                    "runtime_reconciled",
+                    {
+                        "active_turn": active_turn_id is not None,
+                        "capabilities": list(capabilities),
+                        "runtime_attachment_id": attachment_id,
+                    },
+                    event_id=f"spotter:reconciled:{identity.thread_id.value}:{epoch}",
+                    occurred_at=ended_at,
+                    identity=identity,
+                    provenance=TraceProvenance("spotterd", "runtime_reconciled"),
+                    connection_epoch=epoch,
+                )
+            )
+
+        for external_thread_id in sorted(known.keys() - discovered.keys()):
+            state = known[external_thread_id]
+            self._record_gap(
+                state.identity,
+                state,
+                epoch,
+                ended_at,
+                "daemon_restart" if self.metrics.reconnect_successes == 0 else "reconnect",
+            )
+            self._record(
+                TraceEvent(
+                    "runtime_attachment_unavailable",
+                    {"runtime_attachment_id": attachment_id},
+                    event_id=f"spotter:unavailable:{state.thread_id.value}:{epoch}",
+                    occurred_at=ended_at,
+                    identity=state.identity,
+                    provenance=TraceProvenance("spotterd", "runtime_attachment_unavailable"),
+                    connection_epoch=epoch,
+                )
+            )
+
+    def _record_gap(
+        self,
+        identity: RuntimeIdentity,
+        previous: ThreadState | None,
+        epoch: int,
+        ended_at: float,
+        source: str,
+    ) -> None:
+        if identity.thread_id is None:
+            return
+        epoch_before = previous.connection_epoch if previous is not None else None
+        self._record(
+            TraceEvent(
+                "observation_gap",
+                {
+                    "started_at": self._disconnected_at,
+                    "ended_at": ended_at,
+                    "epoch_before": epoch_before,
+                    "epoch_after": epoch,
+                    "backfill_status": "none",
+                    "recovery_source": source,
+                },
+                event_id=f"spotter:gap:{identity.thread_id.value}:{epoch_before}:{epoch}",
+                occurred_at=ended_at,
+                identity=identity,
+                provenance=TraceProvenance("spotterd", "observation_gap"),
+                connection_epoch=epoch,
+            )
+        )
+        self.metrics = replace(self.metrics, observation_gaps=self.metrics.observation_gaps + 1)
+
+    def _record(self, event: TraceEvent) -> None:
+        record = self.ingestor.record(event)
+        if record is None or event.identity is None or event.identity.thread_id is None:
+            return
+        self.thread_states.observe(record.event)
+
+    def _runtime_identity(
+        self,
+        external_thread_id: str,
+        external_turn_id: str | None,
+        attachment_id: str,
+    ) -> RuntimeIdentity:
+        registry = self.ingestor.normalizer.identities
+        thread = registry.observe_thread("codex", external_thread_id)
+        attachment = registry.attach(thread.id, agent_attachment_id=attachment_id)
+        self._attachments[thread.id] = attachment.id
+        if external_turn_id is None:
+            return RuntimeIdentity(
+                thread.id,
+                None,
+                attachment.id,
+                replace(thread.provenance, agent_attachment_id=attachment_id),
+            )
+        turn = registry.start_turn(thread.id, external_turn_id, observed_start=False)
+        return RuntimeIdentity(
+            thread.id,
+            turn.id,
+            attachment.id,
+            replace(turn.provenance, agent_attachment_id=attachment_id),
+        )
+
+    def _epoch_identity(
+        self, identity: RuntimeIdentity | None, attachment_id: str
+    ) -> RuntimeIdentity | None:
+        if identity is None or identity.thread_id is None:
+            return identity
+        registry = self.ingestor.normalizer.identities
+        attachment = registry.attach(identity.thread_id, agent_attachment_id=attachment_id)
+        self._attachments[identity.thread_id] = attachment.id
+        return replace(
+            identity,
+            attachment_id=attachment.id,
+            provenance=replace(
+                identity.provenance,
+                agent_attachment_id=attachment_id,
+            ),
+        )
+
+    def _validate_target(
+        self, target: RuntimeControlTarget
+    ) -> tuple[CodexAppServerClient, str, str]:
+        identity = target.identity
+        client = self._client
+        if (
+            self.state != RecoveryState.READY
+            or self.connection is None
+            or client is None
+            or target.connection_epoch != self.connection.connection_epoch
+            or identity.thread_id is None
+            or identity.turn_id is None
+        ):
+            raise StaleControlTarget("control target is not ready in the current connection epoch")
+        try:
+            state = self.thread_states.snapshot(identity.thread_id)
+        except ThreadStateError as error:
+            raise StaleControlTarget("control target names an unknown thread") from error
+        if (
+            not state.control_ready
+            or state.connection_epoch != target.connection_epoch
+            or state.active_turn_id != identity.turn_id
+        ):
+            raise StaleControlTarget("control target no longer names the active reconciled turn")
+        thread_id = identity.provenance.agent_thread_id
+        turn_id = identity.provenance.agent_turn_id
+        if thread_id is None or turn_id is None:
+            raise StaleControlTarget("control target has no agent thread/turn provenance")
+        return client, thread_id, turn_id
+
+    def _detach_all(self) -> None:
+        registry = self.ingestor.normalizer.identities
+        for attachment_id in self._attachments.values():
+            with contextlib.suppress(Exception):
+                registry.detach(attachment_id)
+        self._attachments.clear()
+
+    async def _wait_backoff(self, delay: float) -> None:
+        self._retry.clear()
+        stop = asyncio.create_task(self._stop.wait())
+        retry = asyncio.create_task(self._retry.wait())
+        try:
+            await asyncio.wait({stop, retry}, timeout=delay, return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            await _cancel_task(stop)
+            await _cancel_task(retry)
+
+    def _set_state(self, state: RecoveryState, detail: str | None = None) -> None:
+        if self.state != state:
+            self.state = state
+            self.transitions += (state,)
+        if self.on_state is not None:
+            self.on_state(state, detail)
+
+
+async def _cancel_task(task: asyncio.Task[Any]) -> None:
+    if not task.done():
+        task.cancel()
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        await task
+
+
+def _active_turn_id(thread: Mapping[str, Any]) -> str | None:
+    active = thread.get("activeTurn")
+    active_id = active.get("id") if isinstance(active, Mapping) else None
+    if isinstance(active_id, str):
+        return active_id
+    turns = thread.get("turns")
+    if isinstance(turns, list):
+        for turn in reversed(turns):
+            if not isinstance(turn, Mapping):
+                continue
+            status = turn.get("status")
+            turn_id = turn.get("id")
+            if status in {"active", "inProgress", "running"} and isinstance(turn_id, str):
+                return turn_id
+    return None
+
+
+def _available_capabilities(capabilities: AppServerCapabilities) -> tuple[str, ...]:
+    return tuple(
+        name
+        for name in ("observation", "thread_query", "steer", "interrupt")
+        if getattr(capabilities, name) == CapabilityStatus.AVAILABLE
+    )
+
+
+def _fingerprint(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode()
+    return hashlib.sha256(encoded).hexdigest()

--- a/src/spotter/thread_state.py
+++ b/src/spotter/thread_state.py
@@ -101,6 +101,8 @@ class TaskState:
 
 @dataclass(frozen=True)
 class EvidenceState:
+    # Evidence remains addressable for later verification/invalidation. #89 may compact
+    # only after persisted conditions and dependencies gain the same retention boundary.
     items: tuple[StateItem, ...] = ()
     conditions: tuple[VerificationCondition, ...] = ()
 
@@ -155,9 +157,6 @@ class ThreadState:
     execution: ExecutionState = field(default_factory=ExecutionState)
     supervision: SupervisionState = field(default_factory=SupervisionState)
     coverage: CoverageState = field(default_factory=CoverageState)
-    # ponytail: exact dedupe retains IDs for the thread lifetime; #87 checkpoints and
-    # #89 retention should compact only with an explicit durable replay boundary.
-    applied_event_ids: frozenset[str] = field(default_factory=frozenset, repr=False)
 
     @property
     def thread_id(self) -> ThreadId:
@@ -178,8 +177,6 @@ class ThreadStateReducer:
             raise ThreadStateError("Trace event has no logical thread identity")
         if state is not None and state.thread_id != identity.thread_id:
             raise ThreadStateError("Trace event belongs to another thread")
-        if state is not None and event.event_id and event.event_id in state.applied_event_ids:
-            return state
         if arrival_seq <= 0 or (state is not None and arrival_seq <= state.last_arrival_seq):
             raise ThreadStateError("arrival sequence must increase monotonically")
 
@@ -189,9 +186,6 @@ class ThreadStateReducer:
             and current.connection_epoch is not None
             and event.connection_epoch != current.connection_epoch
         )
-        applied = current.applied_event_ids
-        if event.event_id:
-            applied = applied | {event.event_id}
         current = replace(
             current,
             identity=identity,
@@ -205,7 +199,6 @@ class ThreadStateReducer:
             ),
             active_turn_id=None if epoch_changed else current.active_turn_id,
             control_ready=False if epoch_changed else current.control_ready,
-            applied_event_ids=applied,
         )
         current = self._lifecycle(current, event)
         current = self._semantic(current, event)
@@ -233,10 +226,24 @@ class ThreadStateReducer:
             return replace(state, active_turn_id=None, control_ready=False, execution=execution)
         if event.kind in {"thread_archived", "thread_closed", "thread_deleted"}:
             return replace(state, active_turn_id=None, control_ready=False)
+        if event.kind == "runtime_attachment_unavailable":
+            return replace(
+                state,
+                active_turn_id=None,
+                capabilities=(),
+                control_ready=False,
+            )
+        # runtime_reconciled is produced by #87. The semantic-only kinds below are
+        # reserved for later signal/reviewer producers; Trace IR keeps them transport-neutral.
         if event.kind == "runtime_reconciled":
             capabilities = event.payload.get("capabilities")
+            active_turn_value = event.payload.get("active_turn")
             active_turn = (
-                turn_id if event.payload.get("active_turn") is True else state.active_turn_id
+                turn_id
+                if active_turn_value is True
+                else None
+                if active_turn_value is False
+                else state.active_turn_id
             )
             return replace(
                 state,
@@ -266,9 +273,8 @@ class ThreadStateReducer:
                 if previous is not None:
                     evidence = replace(
                         evidence,
-                        items=_bounded(
-                            evidence.items + (replace(previous, status=StateItemStatus.SUPERSEDED),)
-                        ),
+                        items=evidence.items
+                        + (replace(previous, status=StateItemStatus.SUPERSEDED),),
                     )
                 return replace(state, task=replace(state.task, goal=goal), evidence=evidence)
         if event.kind == "constraint":
@@ -292,9 +298,7 @@ class ThreadStateReducer:
                 )
                 return replace(
                     state,
-                    evidence=replace(
-                        state.evidence, items=_bounded(state.evidence.items + (hypothesis,))
-                    ),
+                    evidence=replace(state.evidence, items=state.evidence.items + (hypothesis,)),
                 )
         if event.kind == "plan":
             text = _summary_text(event.payload)
@@ -374,9 +378,7 @@ class ThreadStateReducer:
             workspace = _workspace(state.workspace, event, edits)
             return replace(
                 state,
-                evidence=replace(
-                    state.evidence, items=_bounded(state.evidence.items + (observation,))
-                ),
+                evidence=replace(state.evidence, items=state.evidence.items + (observation,)),
                 workspace=workspace,
                 execution=replace(
                     state.execution,
@@ -442,15 +444,24 @@ class ThreadStateStore:
     def __init__(self, reducer: ThreadStateReducer | None = None) -> None:
         self.reducer = reducer or ThreadStateReducer()
         self._states: dict[ThreadId, ThreadState] = {}
+        # Exact dedup belongs to the daemon's mutable store, not every immutable snapshot.
+        # ponytail: IDs remain for the thread lifetime; #89 may compact them only at a
+        # durable replay boundary.
+        self._seen_event_ids: dict[ThreadId, set[str]] = {}
         self._arrival_seq = 0
 
     def observe(self, event: TraceEvent) -> ThreadState:
         if event.identity is None or event.identity.thread_id is None:
             raise ThreadStateError("Trace event has no logical thread identity")
         thread_id = event.identity.thread_id
+        seen = self._seen_event_ids.setdefault(thread_id, set())
+        if event.event_id is not None and event.event_id in seen:
+            return self.snapshot(thread_id)
         self._arrival_seq += 1
         state = self.reducer.reduce(self._states.get(thread_id), event, self._arrival_seq)
         self._states[thread_id] = state
+        if event.event_id is not None:
+            seen.add(event.event_id)
         return state
 
     def snapshot(self, thread_id: ThreadId) -> ThreadState:
@@ -581,7 +592,7 @@ def _satisfy_condition(
         state,
         evidence=replace(
             state.evidence,
-            items=_bounded(state.evidence.items + (fact,)),
+            items=state.evidence.items + (fact,),
             conditions=tuple(conditions),
         ),
     )

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -214,6 +214,28 @@ def test_operation_and_timestamp_state_is_scoped_to_a_turn(tmp_path: Path) -> No
     assert "out_of_order" not in second_turn.event.payload
 
 
+def test_operation_correlation_does_not_cross_connection_epochs(tmp_path: Path) -> None:
+    ingestor = AppServerTraceIngestor(tmp_path)
+    item = {
+        "id": "command-7",
+        "type": "commandExecution",
+        "command": "pytest",
+        "cwd": "/repo",
+        "status": "inProgress",
+        "commandActions": [],
+    }
+    ingestor.ingest(_item_event("item/started", item, 2_000), connection_epoch=1)
+    completed = ingestor.ingest(
+        _item_event("item/completed", {**item, "status": "completed"}, 1_000),
+        connection_epoch=2,
+    )
+
+    assert completed is not None
+    assert completed.event.connection_epoch == 2
+    assert completed.event.payload["observed_start"] is False
+    assert "out_of_order" not in completed.event.payload
+
+
 def test_out_of_order_timestamp_is_explicit_and_terminal_conflicts_fail(tmp_path: Path) -> None:
     ingestor = AppServerTraceIngestor(tmp_path)
     item = {

--- a/tests/test_runtime_connection.py
+++ b/tests/test_runtime_connection.py
@@ -1,0 +1,252 @@
+import asyncio
+import json
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from websockets.asyncio.server import ServerConnection, serve
+
+from spotter.runtime_connection import (
+    AppServerRecoveryLoop,
+    RecoveryState,
+    RuntimeControlTarget,
+    StaleControlTarget,
+)
+from spotter.thread_state import HistoryStatus, ThreadStateStore
+
+Handler = Callable[[ServerConnection], Awaitable[None]]
+
+
+def _message(raw: str | bytes) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(raw))
+
+
+async def _receive(connection: ServerConnection, method: str) -> dict[str, Any]:
+    message = _message(await connection.recv())
+    assert message["method"] == method
+    return message
+
+
+async def _reply(connection: ServerConnection, request: dict[str, Any], result: Any) -> None:
+    await connection.send(json.dumps({"jsonrpc": "2.0", "id": request["id"], "result": result}))
+
+
+async def _initialize(connection: ServerConnection) -> None:
+    request = await _receive(connection, "initialize")
+    await _reply(
+        connection,
+        request,
+        {"userAgent": "codex_cli_rs/0.147.0", "platformFamily": "unix"},
+    )
+    await _receive(connection, "initialized")
+    probe = await _receive(connection, "thread/list")
+    await _reply(connection, probe, {"data": [], "nextCursor": None})
+
+
+@asynccontextmanager
+async def _server(handler: Handler) -> AsyncIterator[str]:
+    async with serve(handler, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        yield f"ws://127.0.0.1:{port}"
+
+
+async def _wait_until(predicate: Callable[[], bool]) -> None:
+    async with asyncio.timeout(2):
+        while not predicate():
+            await asyncio.sleep(0)
+
+
+def test_reconnect_reconciles_epoch_gap_and_stale_control(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        connections: list[ServerConnection] = []
+
+        async def handler(connection: ServerConnection) -> None:
+            connections.append(connection)
+            number = len(connections)
+            await _initialize(connection)
+            listed = await _receive(connection, "thread/list")
+            await _reply(
+                connection,
+                listed,
+                {"data": [{"id": "thread-1"}], "nextCursor": None},
+            )
+            read = await _receive(connection, "thread/read")
+            turns = [{"id": "turn-1", "status": "active"}] if number == 1 else []
+            await _reply(
+                connection,
+                read,
+                {"thread": {"id": "thread-1", "turns": turns}},
+            )
+            while True:
+                try:
+                    request = _message(await connection.recv())
+                except Exception:
+                    return
+                if request.get("method") == "turn/steer":
+                    await _reply(connection, request, {"turnId": "turn-1"})
+
+        async with _server(handler) as endpoint:
+            store = ThreadStateStore()
+            recovery = AppServerRecoveryLoop(
+                endpoint,
+                tmp_path / "sessions",
+                store,
+                initial_backoff=0,
+                maximum_backoff=0,
+            )
+            await recovery.start()
+            await _wait_until(lambda: recovery.state == RecoveryState.READY)
+
+            first = store.snapshots()[0]
+            assert first.connection_epoch == 1
+            assert first.control_ready is True
+            assert first.coverage.history == HistoryStatus.PARTIAL
+            target = RuntimeControlTarget(first.identity, 1)
+            assert (await recovery.steer(target, "verify"))["turnId"] == "turn-1"
+
+            await connections[0].close()
+            await _wait_until(
+                lambda: (
+                    recovery.state == RecoveryState.READY
+                    and recovery.connection is not None
+                    and recovery.connection.connection_epoch == 2
+                )
+            )
+
+            second = store.snapshots()[0]
+            assert second.connection_epoch == 2
+            assert second.active_turn_id is None
+            assert second.control_ready is False
+            assert len(second.coverage.gaps) == 2
+            assert recovery.metrics.reconnect_successes == 2
+            assert recovery.metrics.observation_gaps == 2
+            assert RecoveryState.RECONCILING in recovery.transitions
+            assert RecoveryState.BACKING_OFF in recovery.transitions
+            with pytest.raises(StaleControlTarget):
+                await recovery.steer(target, "late")
+            await recovery.close()
+
+    asyncio.run(scenario())
+
+
+def test_restart_hydrates_without_control_until_live_reconciliation(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await _initialize(connection)
+            listed = await _receive(connection, "thread/list")
+            await _reply(
+                connection,
+                listed,
+                {"data": [{"id": "thread-1"}], "nextCursor": None},
+            )
+            read = await _receive(connection, "thread/read")
+            await _reply(
+                connection,
+                read,
+                {
+                    "thread": {
+                        "id": "thread-1",
+                        "turns": [{"id": "turn-1", "status": "active"}],
+                    }
+                },
+            )
+            await connection.wait_closed()
+
+        sessions = tmp_path / "sessions"
+        async with _server(handler) as endpoint:
+            first_store = ThreadStateStore()
+            first = AppServerRecoveryLoop(endpoint, sessions, first_store)
+            await first.start()
+            await _wait_until(lambda: first.state == RecoveryState.READY)
+            await first.close()
+
+            recovered_store = ThreadStateStore()
+            recovered = AppServerRecoveryLoop(endpoint, sessions, recovered_store)
+            hydrated = recovered_store.snapshots()[0]
+            assert hydrated.active_turn_id is None
+            assert hydrated.control_ready is False
+
+            await recovered.start()
+            await _wait_until(lambda: recovered.state == RecoveryState.READY)
+            reconciled = recovered_store.snapshots()[0]
+            assert reconciled.connection_epoch == 2
+            assert reconciled.active_turn_id is not None
+            assert reconciled.control_ready is True
+            await recovered.close()
+
+    asyncio.run(scenario())
+
+
+def test_reconciliation_keeps_multiple_threads_isolated(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await _initialize(connection)
+            listed = await _receive(connection, "thread/list")
+            await _reply(
+                connection,
+                listed,
+                {
+                    "data": [{"id": "thread-1"}, {"id": "thread-2"}],
+                    "nextCursor": None,
+                },
+            )
+            for thread_id, turn_id in (("thread-1", "turn-1"), ("thread-2", "turn-2")):
+                read = await _receive(connection, "thread/read")
+                assert read["params"]["threadId"] == thread_id
+                await _reply(
+                    connection,
+                    read,
+                    {
+                        "thread": {
+                            "id": thread_id,
+                            "turns": [{"id": turn_id, "status": "active"}],
+                        }
+                    },
+                )
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            store = ThreadStateStore()
+            recovery = AppServerRecoveryLoop(endpoint, tmp_path / "sessions", store)
+            await recovery.start()
+            await _wait_until(lambda: recovery.state == RecoveryState.READY)
+
+            states = sorted(
+                store.snapshots(),
+                key=lambda state: state.identity.provenance.agent_thread_id or "",
+            )
+            assert [state.identity.provenance.agent_thread_id for state in states] == [
+                "thread-1",
+                "thread-2",
+            ]
+            assert [state.identity.provenance.agent_turn_id for state in states] == [
+                "turn-1",
+                "turn-2",
+            ]
+            assert len({state.active_turn_id for state in states}) == 2
+            assert all(state.control_ready for state in states)
+            await recovery.close()
+
+    asyncio.run(scenario())
+
+
+def test_unreachable_endpoint_backs_off_without_hiding_failure(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        recovery = AppServerRecoveryLoop(
+            "ws://127.0.0.1:1",
+            tmp_path / "sessions",
+            ThreadStateStore(),
+            initial_backoff=10,
+            maximum_backoff=10,
+        )
+        await recovery.start()
+        await _wait_until(lambda: recovery.state == RecoveryState.BACKING_OFF)
+
+        assert recovery.metrics.reconnect_failures == 1
+        assert recovery.last_error is not None
+        assert RecoveryState.DEGRADED in recovery.transitions
+        await recovery.close()
+
+    asyncio.run(scenario())

--- a/tests/test_thread_state.py
+++ b/tests/test_thread_state.py
@@ -273,6 +273,48 @@ def test_verification_and_invalidation_keep_fact_types_distinct() -> None:
     assert hypothesis.status == StateItemStatus.STALE
 
 
+def test_old_evidence_remains_addressable_for_later_verification() -> None:
+    store = ThreadStateStore()
+    store.observe(
+        _event(
+            "test_result",
+            {"status": "passed", "text": "original proof"},
+            event_id="proof",
+        )
+    )
+    for index in range(51):
+        store.observe(
+            _event(
+                "command_result",
+                {"status": "completed", "command": f"echo {index}"},
+                event_id=f"outcome-{index}",
+            )
+        )
+    store.observe(
+        _event(
+            "verification_condition",
+            {
+                "condition_id": "condition",
+                "kind": "test_passes",
+                "required_evidence": ["test_result"],
+            },
+            event_id="condition-event",
+        )
+    )
+    state = store.observe(
+        _event(
+            "verification_satisfied",
+            {"condition_id": "condition", "evidence_id": "proof"},
+            event_id="fact",
+        )
+    )
+
+    assert state.evidence.conditions[0].status == ConditionStatus.SATISFIED
+    assert all(
+        "unknown_verification_evidence" not in value for value in state.coverage.inconsistencies
+    )
+
+
 def test_validation_and_unknown_coverage_never_infer_missing_outcomes() -> None:
     store = ThreadStateStore()
     state = store.observe(_event("runtime_event_unknown", {"method": "future"}))


### PR DESCRIPTION
## Why

A connected socket is not enough to safely preserve live thread/turn identity across App Server disconnects or daemon restarts. Spotter needs a single recovery owner that makes observation gaps and stale control targets explicit while keeping Hook enforcement independent.

## What changed

- add a daemon-owned `DISCONNECTED → CONNECTING → RECONCILING → READY` loop with bounded jittered backoff and one cleanup path
- assign monotonically recovered connection epochs, per-connection attachment IDs, endpoint/server fingerprints, and capability snapshots
- hydrate durable ThreadState conservatively, reconcile every loaded thread, journal explicit observation gaps, and mark missing attachments unavailable
- fence steer/interrupt by the exact reconciled epoch and active turn; late connection callbacks and cross-epoch operation correlations cannot retarget current work
- move Trace event deduplication out of immutable snapshots and keep old evidence addressable for later verification, addressing the two follow-ups from PR #115
- update current-state, architecture, and lifecycle documentation while leaving endpoint selection/ownership explicitly out of scope

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (353 passed)

Closes #87