### PR TITLE
fix(runtime): reconnect after consumer failure

### DIFF
--- a/src/spotter/daemon.py
+++ b/src/spotter/daemon.py
@@ -17,7 +17,7 @@ from enum import StrEnum
 from fcntl import LOCK_EX, LOCK_NB, LOCK_UN, flock
 from io import TextIOWrapper
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from spotter.config import GatesConfig
 from spotter.gates import Gate, GateDecision
@@ -26,6 +26,9 @@ from spotter.paths import secure_dir, spotter_home
 from spotter.snapshot import StepRecord
 from spotter.thread_state import ThreadState, ThreadStateStore
 from spotter.trace import TraceEvent
+
+if TYPE_CHECKING:
+    from spotter.runtime_connection import RecoveryState
 
 PROTOCOL_VERSION = 1
 CONTROL_TIMEOUT = 1.0
@@ -73,6 +76,12 @@ class DaemonTimeout(DaemonUnavailable):
 
 class DaemonAlreadyRunning(DaemonError):
     """Another daemon already owns the runtime socket."""
+
+
+class RuntimeRecovery(Protocol):
+    async def start(self) -> None: ...
+
+    async def close(self) -> None: ...
 
 
 def runtime_socket() -> Path:
@@ -206,7 +215,7 @@ class DaemonServer:
         self.thread_states = ThreadStateStore()
         self.app_server_endpoint = app_server_endpoint
         self.journals_dir = journals_dir or spotter_home() / "sessions"
-        self.recovery: Any | None = None
+        self.recovery: RuntimeRecovery | None = None
 
     def observe_trace(self, event: TraceEvent) -> ThreadState:
         """Increment daemon-owned hot state after adapter normalization and journaling."""
@@ -296,8 +305,8 @@ class DaemonServer:
         self.health = health
         self.health_detail = detail
 
-    def _on_recovery_state(self, state: object, detail: str | None) -> None:
-        value = getattr(state, "value", str(state))
+    def _on_recovery_state(self, state: "RecoveryState", detail: str | None) -> None:
+        value = state.value
         if value == "ready":
             self.set_health(RuntimeHealth.HEALTHY)
         elif value in {"connecting", "reconciling"}:

--- a/src/spotter/runtime_connection.py
+++ b/src/spotter/runtime_connection.py
@@ -225,6 +225,12 @@ class AppServerRecoveryLoop:
                 self.last_error = str(error)
             except AppServerError:
                 return
+            except Exception as error:
+                message = f"App Server event consumer failed: {error}"
+                self.last_error = message
+                self._set_state(RecoveryState.DEGRADED, message)
+                await client.disconnect()
+                raise AppServerTransportError(message) from error
 
     async def _reconcile(
         self,
@@ -449,7 +455,7 @@ class AppServerRecoveryLoop:
 async def _cancel_task(task: asyncio.Task[Any]) -> None:
     if not task.done():
         task.cancel()
-    with contextlib.suppress(asyncio.CancelledError, Exception):
+    with contextlib.suppress(asyncio.CancelledError):
         await task
 
 

--- a/tests/test_runtime_connection.py
+++ b/tests/test_runtime_connection.py
@@ -250,3 +250,53 @@ def test_unreachable_endpoint_backs_off_without_hiding_failure(tmp_path: Path) -
         await recovery.close()
 
     asyncio.run(scenario())
+
+
+def test_unexpected_consumer_failure_forces_degraded_reconnect(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def scenario() -> None:
+        send_event = asyncio.Event()
+
+        async def handler(connection: ServerConnection) -> None:
+            await _initialize(connection)
+            listed = await _receive(connection, "thread/list")
+            await _reply(connection, listed, {"data": [], "nextCursor": None})
+            await send_event.wait()
+            await connection.send(
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "method": "thread/status/changed",
+                        "params": {"threadId": "thread-1", "status": "active"},
+                    }
+                )
+            )
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            recovery = AppServerRecoveryLoop(
+                endpoint,
+                tmp_path / "sessions",
+                ThreadStateStore(),
+                initial_backoff=10,
+                maximum_backoff=10,
+            )
+            await recovery.start()
+            await _wait_until(lambda: recovery.state == RecoveryState.READY)
+
+            def fail_record(event: object) -> None:
+                raise RuntimeError("reducer exploded")
+
+            monkeypatch.setattr(recovery, "_record", fail_record)
+            send_event.set()
+            await _wait_until(lambda: recovery.state == RecoveryState.BACKING_OFF)
+
+            assert recovery.last_error is not None
+            assert "event consumer failed" in recovery.last_error
+            assert "reducer exploded" in recovery.last_error
+            assert recovery.metrics.reconnect_failures == 1
+            assert RecoveryState.DEGRADED in recovery.transitions
+            await recovery.close()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Why

PR #118 review identified a failure mode where an unexpected event-consumer exception could leave the App Server loop reporting READY while no events were being ingested.

## What changed

- turn unexpected consumer exceptions into an explicit DEGRADED transition and force the connection through the reconnect loop
- preserve the consumer root exception through `AsyncExitStack` cleanup instead of suppressing it
- replace the daemon recovery `Any` boundary with a small Protocol and type-only RecoveryState import without loading websockets on the Hook path
- add a regression test that injects a reducer failure after READY and proves degraded/backoff state plus failure telemetry

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (354 passed)

Follow-up to #118