### PR TITLE
feat(observe): add observability coverage audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ spotter analyze
 spotter review --session <id>
 spotter label --session <id> --step <n> --verdict fp
 spotter metrics
+spotter observability [--session <id>]
 spotter fork --session <id> --step <n>
 spotter prune --repo /path/to/repo  # dry-run unless --apply is supplied
 spotter experiment --session <id> --step <n> --guidance "..." --check "..."

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Start here if you are reading the repository for the first time.
 | What happens from install through uninstall/reinstall? | [Lifecycle](lifecycle.md) | command-by-command operational lifecycle |
 | What did the App Server proof of concept establish? | [App Server PoC](app-server-poc.md) | exploratory protocol and transport findings |
 | Was shared TUI control validated end to end? | [App Server validation](app-server-validation.md) | historical validation evidence and limitations |
+| How is source/Trace IR/ThreadState coverage measured? | [Observability baseline](observability-baseline.md) | taxonomy, safe audit method, current sample limits |
 | What should become trustworthy next? | [Roadmap](roadmap.md) | Runtime → Observe → Detect → Intervene → Recover → Harden, with evidence gates |
 | What prior papers/systems should I study, and what does Spotter borrow from them? | [Reference](reference.md) | literature + implementation precedents, boundaries, and implementation hints |
 | What hypotheses remain unproven, and how will Spotter evaluate them? | [Research](research.md) | evidence posture, research questions, experiments, and metrics |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -484,6 +484,13 @@ explicitly. Hook records carry legacy-session provenance with unknown thread, tu
 dimensions, so consumers never need Codex transport objects and never infer that a Hook session is an
 App Server thread.
 
+The daemon also writes a bounded, value-free source-shape audit beside session journals. It records
+which App Server field paths existed, which normalized fields and evidence families survived, and
+whether the fact remained available in live `ThreadState`. Source values, raw reasoning, command
+output, and encrypted content are never copied into this audit. `spotter observability` compares the
+Hook and App Server surfaces without treating adapter/state loss as a theoretical source limit. See
+[Observability ceiling baseline](observability-baseline.md).
+
 ---
 
 # 7. Reviewer jobs and freshness

--- a/docs/observability-baseline.md
+++ b/docs/observability-baseline.md
@@ -1,0 +1,91 @@
+# Observability ceiling baseline
+
+This document separates the measurement instrument from the evidence it has collected. The
+instrument exists; the post-App-Server ceiling required by
+[#37](https://github.com/spotter-agent/spotter/issues/37) is not yet measured.
+
+## What is measured
+
+`spotter observability` reports three distinct projection stages:
+
+```text
+Codex/App Server source field shapes
+          ↓
+normalized Trace IR
+          ↓
+live ThreadState
+```
+
+It also reports Hook and App Server Trace IR separately. Counts are grouped by evidence family, not
+collapsed into one event percentage. This prevents a parser or state-projection loss from being
+misreported as a structural source limit.
+
+Coverage uses the following explicit vocabulary:
+
+| Status | Meaning |
+| --- | --- |
+| `OBSERVED_EXACT` | the relevant exposed fact was preserved |
+| `OBSERVED_PARTIAL` | useful evidence survived, but not the complete fact |
+| `OBSERVED_ENCRYPTED` | only encrypted/opaque content was exposed |
+| `OBSERVED_UNCORRELATED` | evidence exists without proven thread/turn identity |
+| `SOURCE_NOT_EXPOSED` | the runtime did not expose the required fact |
+| `ADAPTER_DROPPED` | source or Trace IR exposed the fact, but a later projection lost it |
+| `OBSERVATION_GAP` | the fact may have occurred during a known disconnect gap |
+| `LEGACY_UNAVAILABLE` | an older record lacks the provenance needed to judge it |
+| `NOT_PERFORMED` | Main never performed the evidence-gathering action |
+| `NOT_APPLICABLE` | the evidence family is irrelevant to this opportunity |
+| `UNKNOWN` | available evidence cannot support a stronger classification |
+
+For a labeled failure or degraded trajectory, required evidence is classified relative to the
+failure/decision boundary as `VISIBLE_IN_TIME`, `VISIBLE_TOO_LATE`, `STRUCTURALLY_INVISIBLE`,
+`LOST_BY_ADAPTER`, `LOST_BY_GAP`, or `UNJUDGEABLE`. Missing, encrypted, or late facts are never
+reconstructed.
+
+## Source audit safety
+
+The daemon retains a bounded audit at `sessions/source-audit/samples.jsonl`. Samples contain method
+names, field paths, normalized field names, evidence families, correlation identity, epoch, and
+coverage classifications. They do not contain source values, command output, reasoning content, or
+encrypted content. The file is mode `0600`, fsynced, and compacted to the most recent 1,000 samples
+after it grows beyond 2,000.
+
+The synthetic conformance corpus in `tests/fixtures/app_server_conformance.json` protects command,
+file, MCP, plan, reasoning-summary, usage, lifecycle, unknown-method, and encrypted-child behavior.
+It is regression coverage only; synthetic cases are not outcome evidence and do not contribute to
+the measured ceiling.
+
+## Current aggregate snapshot
+
+On 2026-08-13, the available local dataset reported:
+
+```text
+sessions: 9 (hook=9, app_server=0)
+events: 2659; observation_gaps: 0; unknown_events: 0
+source-vs-adapter samples: none
+session observability labels: 0/9
+```
+
+The Hook records predate current provenance and therefore classify as `LEGACY_UNAVAILABLE`; they
+cannot establish exact source or timing coverage. There are no App Server journals, no raw-shape
+samples, and no failed/degraded session labels in this snapshot. Consequently:
+
+- no post-App-Server visible-in-time percentage can be stated;
+- no Hook-to-App-Server improvement can be stated;
+- no important failure-class ceiling can be stated; and
+- #37 remains open.
+
+## Evidence needed to finish #37
+
+Collect representative failed or degraded App Server trajectories, label each failure boundary and
+minimal required evidence set, and run:
+
+```bash
+spotter observability
+spotter metrics
+```
+
+The final report must include opportunity counts and label coverage, evidence/failure-family rows,
+gap contamination, `NOT_PERFORMED` versus source limits versus projection loss, and earliest
+source/Trace IR/ThreadState availability where timestamps exist. That evidence—not the existence of
+this command—determines whether the next bottleneck is the observation surface, adapter/state
+projection, or detector/reviewer.

--- a/docs/research.md
+++ b/docs/research.md
@@ -396,7 +396,9 @@ RESTART
 1. **No ground-truth task set** large enough to run meaningful counterfactual experiments.
 2. **No measured positive intervention advantage** for Spotter guidance.
 3. **No sampled miss-rate/recall estimate** for semantic detector behavior.
-4. **No post-migration App Server observability-ceiling measurement** yet.
+4. **No post-migration App Server observability-ceiling measurement** yet. The coverage taxonomy,
+   value-free source audit, and conformance corpus exist, but the current snapshot has no App Server
+   sessions or labeled failures; see the [observability baseline](observability-baseline.md).
 5. **No replay/fork noise-floor measurement** supporting causal interpretation.
 6. **No live wrong-nudge/sycophancy evaluation** before injection.
 7. **No full runtime overhead measurement** for the target architecture.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -121,7 +121,7 @@ The journal remains durable history and recovery input; it is not the normal hot
 - normalize App Server events into identity-rich Trace IR and durable history ([#85](https://github.com/spotter-agent/spotter/issues/85));
 - maintain live state from that stream ([#31](https://github.com/spotter-agent/spotter/issues/31));
 - record runtime cost/timing/provenance ([#33](https://github.com/spotter-agent/spotter/issues/33));
-- measure the actual observability ceiling after migration ([#37](https://github.com/spotter-agent/spotter/issues/37));
+- measure the actual observability ceiling after migration ([#37](https://github.com/spotter-agent/spotter/issues/37)); the [measurement instrument and current zero-sample baseline](observability-baseline.md) are documented, but labeled App Server failures are still required;
 - remove `SessionStart`, `UserPromptSubmit`, and `PostToolUse` only after parity is demonstrated, leaving the minimal enforcement bridge ([#86](https://github.com/spotter-agent/spotter/issues/86)).
 
 ## Evidence gate

--- a/docs/status.md
+++ b/docs/status.md
@@ -30,7 +30,7 @@ PreToolUse Hook only
 (deterministic synchronous enforcement)
 ```
 
-The shared App Server gate is resolved: an explicitly connected TUI and Spotter can observe and steer the same real turn. The Hook now uses bounded daemon IPC for deterministic enforcement, and `spotterd` owns reconnect/reconciliation for configured App Server endpoints. The immediate work is measuring App Server observability in #37 before reducing redundant Hooks in #86. See [App Server connection validation](app-server-validation.md).
+The shared App Server gate is resolved: an explicitly connected TUI and Spotter can observe and steer the same real turn. The Hook now uses bounded daemon IPC for deterministic enforcement, and `spotterd` owns reconnect/reconciliation for configured App Server endpoints. The #37 instrument now separates Hook, App Server source, Trace IR, and ThreadState coverage, but the available snapshot has no App Server or labeled failure samples, so the post-migration ceiling remains unmeasured. See [Observability ceiling baseline](observability-baseline.md).
 The roadmap no longer uses `P0–P9` / `E0–E5`. It is organized by named outcomes:
 
 ```text
@@ -102,7 +102,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Counterfactual harness | ✅ | Control/guidance same-prefix pairs can be prepared/run | Add mechanically scored tasks (#21) |
 | Standalone runtime | 🟡 | Long-lived process, IPC, lifecycle, isolated per-thread state, and App Server recovery ownership | Select and verify the shared endpoint during setup |
 | Runtime identity | ✅ | Logical threads/turns remain separate from per-connection attachment IDs and monotonically recovered epochs | Propagate the identity into future reviewer jobs |
-| App Server primary observation | 🟡 | Configured endpoints route through `spotterd` into normalized durable Trace IR and incremental ThreadState | Measure parity/ceiling in #37, then reduce Hooks in #86 |
+| App Server primary observation | 🟡 | Configured endpoints route through `spotterd` into normalized durable Trace IR and incremental ThreadState; a bounded value-free source audit and conformance corpus measure projection coverage | Collect labeled App Server failures to finish #37, then reduce Hooks in #86 |
 | Managed Codex lifecycle | 🟡 | Transactional setup/teardown, managed service, diagnostics, and configured-endpoint recovery | Add verified endpoint selection without claiming shared-process ownership |
 | Runtime reconnect/recovery | ✅ | Explicit connect/reconcile/backoff states, restart hydration, durable gaps, capability/server fingerprints, and stale-control fencing | Add retention/checkpoints in #89 |
 | Event-driven detection | ❌ | Reviewer is still cadence-based | #28 after Runtime/Observe |
@@ -156,6 +156,7 @@ Implementation progress and research evidence remain separate.
 | Is there a reproducible mechanically scored task corpus? | **No — #21** |
 | Has live Spotter guidance been shown to improve outcomes? | **No** |
 | Is the App Server control boundary operationally viable? | **Yes for a configured Spotter-managed external path, including daemon reconnect/reconciliation** |
+| Is the post-App-Server visible-in-time ceiling measured? | **No — the instrument exists, but the current sample has 0 App Server sessions and 0/9 labeled sessions (#37)** |
 
 A mechanism being implemented does not prove it improves outcomes. Null and negative results are first-class outcomes for this project.
 

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -41,6 +41,13 @@ from spotter.hook import journal_path, run_hook
 from spotter.integration import IntegrationError, IntegrationManager, IntegrationManifest
 from spotter.labels import LabelError, add_label, valid_session
 from spotter.metrics import Tally, merge, tally_session
+from spotter.observability import (
+    SOURCE_AUDIT_RELATIVE_PATH,
+    ObservabilityError,
+    SourceAuditStore,
+    measure_observability,
+    render_observability,
+)
 from spotter.paths import secure_dir, spotter_home
 from spotter.redact import scan_text
 from spotter.replay import ReplayError, fork, plan_to_json
@@ -72,6 +79,7 @@ def build_parser() -> argparse.ArgumentParser:
             "experiment",
             "label",
             "metrics",
+            "observability",
             "status",
             "doctor",
             "daemon",
@@ -87,6 +95,7 @@ def build_parser() -> argparse.ArgumentParser:
             "experiment: counterfactual fork pairs — nudge vs control (needs --run to execute); "
             "label: record a human verdict on a gate flag, reviewer decision, or session; "
             "metrics: gate FP rate, reviewer precision and observability ceiling from labels; "
+            "observability: compare Hook/App Server Trace IR and source-adapter coverage; "
             "status: what Spotter is storing, and whether it is actually running; "
             "doctor: verify supervision end to end (non-zero exit when broken); "
             "daemon: manually start, stop, restart, or inspect spotterd; "
@@ -100,7 +109,9 @@ def build_parser() -> argparse.ArgumentParser:
         help="daemon lifecycle action or integration target",
     )
     parser.add_argument("--config", type=Path, help="path to Spotter TOML config")
-    parser.add_argument("--session", help="session id (fork; analyze filters to it)")
+    parser.add_argument(
+        "--session", help="session id (fork; analyze/metrics/observability filter to it)"
+    )
     parser.add_argument("--step", type=int, help="journal step to branch at (fork)")
     parser.add_argument(
         "--repo", type=Path, help="repo path (prune; fork override when the journal lacks cwd)"
@@ -253,6 +264,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _label_main(args.session, args.step, args.verdict, args.note)
     if args.command == "metrics":
         return _metrics_main(args.session)
+    if args.command == "observability":
+        return _observability_main(args.session)
     if args.command == "review":
         if not args.session:
             parser.error("review requires --session")
@@ -786,6 +799,38 @@ def _metrics_main(session: str | None) -> int:
     print("  " + reviewer.rate_line("interventions", "correct"))
     print("P1 observability ceiling (label failed sessions visible|invisible):")
     print("  " + ceiling.rate_line("sessions", "visible"))
+    return 0
+
+
+def _observability_main(session: str | None) -> int:
+    """Report evidence coverage without claiming an unlabeled failure ceiling."""
+
+    sessions_dir = journal_path({"session_id": "probe"}).parent
+    journals = sorted(sessions_dir.glob("*.jsonl"))
+    if session:
+        journals = [journal for journal in journals if journal.stem == session]
+    if not journals:
+        print("no journals found", file=sys.stderr)
+        return 1
+    histories: list[list[StepRecord]] = []
+    for journal in journals:
+        try:
+            histories.append(StepJournal.load(journal))
+        except (OSError, SnapshotError) as error:
+            print(f"{journal.stem}: unreadable journal ({error})", file=sys.stderr)
+    if not histories:
+        return 1
+    try:
+        source_samples = SourceAuditStore(sessions_dir / SOURCE_AUDIT_RELATIVE_PATH).load()
+    except (OSError, UnicodeError, ObservabilityError) as error:
+        print(f"source audit unreadable: {error}", file=sys.stderr)
+        return 1
+    if session:
+        thread_id = (
+            session.removeprefix("app-server-") if session.startswith("app-server-") else None
+        )
+        source_samples = tuple(sample for sample in source_samples if sample.thread_id == thread_id)
+    print(render_observability(measure_observability(histories, source_samples)))
     return 0
 
 

--- a/src/spotter/ingestion.py
+++ b/src/spotter/ingestion.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import warnings
 from collections.abc import Mapping
 from dataclasses import replace
 from pathlib import Path
@@ -13,6 +14,11 @@ from spotter.identity import (
     RuntimeIdentity,
     RuntimeIdentityRegistry,
     TurnStatus,
+)
+from spotter.observability import (
+    SOURCE_AUDIT_RELATIVE_PATH,
+    CoverageStatus,
+    SourceAuditStore,
 )
 from spotter.snapshot import StepJournal, StepRecord
 from spotter.trace import TraceEvent, TraceProvenance
@@ -225,6 +231,8 @@ class AppServerTraceIngestor:
         self.journals_dir = journals_dir
         self.journals_dir.mkdir(parents=True, exist_ok=True)
         self.normalizer = CodexTraceNormalizer()
+        self.source_audit = SourceAuditStore(journals_dir / SOURCE_AUDIT_RELATIVE_PATH)
+        self.last_source_audit_error: str | None = None
         self._seen: set[str] = set()
         self._operations: dict[tuple[str, str, str, str], tuple[str, str | None]] = {}
         self._terminal_turns: set[str] = set()
@@ -240,7 +248,42 @@ class AppServerTraceIngestor:
         event = self.normalizer.normalize(raw_event)
         if connection_epoch is not None:
             event = replace(event, connection_epoch=connection_epoch)
-        return self.record(event)
+        return self.record_source(raw_event, event)
+
+    def record_source(self, raw_event: AppServerEvent, event: TraceEvent) -> StepRecord | None:
+        """Persist normalized IR and a bounded value-free source-shape comparison."""
+
+        record = self.record(event)
+        self.audit_source(
+            raw_event,
+            record.event if record is not None else event,
+            disposition="ingested" if record is not None else "deduplicated",
+        )
+        return record
+
+    def audit_source(
+        self,
+        raw_event: AppServerEvent,
+        event: TraceEvent,
+        *,
+        disposition: str,
+        state_status: CoverageStatus | None = None,
+    ) -> None:
+        """Retain field shapes without allowing audit I/O to break observation."""
+
+        try:
+            self.source_audit.record(
+                raw_event,
+                event,
+                disposition=disposition,
+                state_status=state_status,
+            )
+            self.last_source_audit_error = None
+        except (OSError, UnicodeError) as error:
+            # The primary journal already contains the event. Losing the optional
+            # shape audit must not disconnect observation or skip live-state reduction.
+            self.last_source_audit_error = str(error)
+            warnings.warn(f"source audit unavailable: {error}", RuntimeWarning, stacklevel=2)
 
     def record(self, event: TraceEvent) -> StepRecord | None:
         """Append one already-normalized runtime event through the same idempotency path."""

--- a/src/spotter/observability.py
+++ b/src/spotter/observability.py
@@ -1,0 +1,717 @@
+"""Coverage taxonomy and source-vs-Trace IR observability audits."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from fcntl import LOCK_EX, LOCK_UN, flock
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from spotter.snapshot import StepRecord
+from spotter.trace import TraceEvent
+
+if TYPE_CHECKING:
+    from spotter.app_server import AppServerEvent
+    from spotter.thread_state import ThreadState
+
+SOURCE_AUDIT_RELATIVE_PATH = Path("source-audit") / "samples.jsonl"
+
+
+class ObservabilityError(ValueError):
+    """A persisted source audit cannot be trusted."""
+
+
+class EvidenceFamily(StrEnum):
+    USER_GOAL = "user_goal"
+    THREAD_TURN_IDENTITY = "thread_turn_identity"
+    PLAN_SUMMARY = "plan_summary"
+    REASONING_SUMMARY = "reasoning_summary"
+    REPOSITORY_EXPLORATION = "repository_exploration"
+    COMMAND_TOOL_CALL = "command_tool_call"
+    TOOL_OUTCOME = "tool_outcome"
+    FILE_EDIT_DIFF = "file_edit_diff"
+    MCP_CALL_RESULT = "mcp_call_result"
+    SUBAGENT_LINEAGE = "subagent_lineage"
+    VALIDATION_OUTCOME = "validation_outcome"
+    INTERVENTION_DELIVERY = "intervention_delivery"
+    EXTERNAL_EFFECT = "external_effect"
+    RUNTIME_USAGE = "runtime_usage"
+
+
+class CoverageStatus(StrEnum):
+    OBSERVED_EXACT = "observed_exact"
+    OBSERVED_PARTIAL = "observed_partial"
+    OBSERVED_ENCRYPTED = "observed_encrypted"
+    OBSERVED_UNCORRELATED = "observed_uncorrelated"
+    SOURCE_NOT_EXPOSED = "source_not_exposed"
+    ADAPTER_DROPPED = "adapter_dropped"
+    OBSERVATION_GAP = "observation_gap"
+    LEGACY_UNAVAILABLE = "legacy_unavailable"
+    NOT_PERFORMED = "not_performed"
+    NOT_APPLICABLE = "not_applicable"
+    UNKNOWN = "unknown"
+
+
+class OpportunityStatus(StrEnum):
+    VISIBLE_IN_TIME = "visible_in_time"
+    VISIBLE_TOO_LATE = "visible_too_late"
+    STRUCTURALLY_INVISIBLE = "structurally_invisible"
+    LOST_BY_ADAPTER = "lost_by_adapter"
+    LOST_BY_GAP = "lost_by_gap"
+    UNJUDGEABLE = "unjudgeable"
+
+
+@dataclass(frozen=True)
+class EvidenceTiming:
+    family: EvidenceFamily
+    status: CoverageStatus
+    source_step: int | None = None
+    trace_step: int | None = None
+    state_step: int | None = None
+
+
+def classify_opportunity(
+    failure_boundary: int, required_evidence: Iterable[EvidenceTiming]
+) -> OpportunityStatus:
+    """Classify visibility without reconstructing facts the runtime never exposed."""
+
+    evidence = tuple(required_evidence)
+    if not evidence:
+        return OpportunityStatus.UNJUDGEABLE
+    statuses = {item.status for item in evidence}
+    if CoverageStatus.OBSERVATION_GAP in statuses:
+        return OpportunityStatus.LOST_BY_GAP
+    if statuses & {CoverageStatus.ADAPTER_DROPPED, CoverageStatus.OBSERVED_UNCORRELATED}:
+        return OpportunityStatus.LOST_BY_ADAPTER
+    if statuses & {CoverageStatus.SOURCE_NOT_EXPOSED, CoverageStatus.OBSERVED_ENCRYPTED}:
+        return OpportunityStatus.STRUCTURALLY_INVISIBLE
+    if statuses & {
+        CoverageStatus.LEGACY_UNAVAILABLE,
+        CoverageStatus.NOT_PERFORMED,
+        CoverageStatus.UNKNOWN,
+    }:
+        return OpportunityStatus.UNJUDGEABLE
+    available = [item.state_step for item in evidence]
+    if any(step is None for step in available):
+        return OpportunityStatus.UNJUDGEABLE
+    return (
+        OpportunityStatus.VISIBLE_IN_TIME
+        if max(step for step in available if step is not None) <= failure_boundary
+        else OpportunityStatus.VISIBLE_TOO_LATE
+    )
+
+
+@dataclass(frozen=True)
+class SourceAuditSample:
+    method: str
+    source_fields: tuple[str, ...]
+    normalized_kind: str
+    normalized_fields: tuple[str, ...]
+    families: tuple[str, ...]
+    status: str
+    state_status: str | None
+    thread_id: str | None
+    connection_epoch: int | None
+    disposition: str
+    recorded_at: float
+
+
+_METHOD_FAMILY: dict[str, tuple[EvidenceFamily, ...]] = {
+    "thread/started": (EvidenceFamily.THREAD_TURN_IDENTITY,),
+    "thread/status/changed": (EvidenceFamily.THREAD_TURN_IDENTITY,),
+    "turn/started": (EvidenceFamily.THREAD_TURN_IDENTITY,),
+    "turn/completed": (EvidenceFamily.THREAD_TURN_IDENTITY,),
+    "turn/plan/updated": (EvidenceFamily.PLAN_SUMMARY,),
+    "turn/diff/updated": (EvidenceFamily.FILE_EDIT_DIFF,),
+    "thread/tokenUsage/updated": (EvidenceFamily.RUNTIME_USAGE,),
+}
+
+_ITEM_FAMILY: dict[str, tuple[EvidenceFamily, ...]] = {
+    "userMessage": (EvidenceFamily.USER_GOAL,),
+    "plan": (EvidenceFamily.PLAN_SUMMARY,),
+    "reasoning": (EvidenceFamily.REASONING_SUMMARY,),
+    "commandExecution": (EvidenceFamily.COMMAND_TOOL_CALL, EvidenceFamily.TOOL_OUTCOME),
+    "fileChange": (EvidenceFamily.FILE_EDIT_DIFF,),
+    "mcpToolCall": (EvidenceFamily.MCP_CALL_RESULT,),
+    "dynamicToolCall": (EvidenceFamily.MCP_CALL_RESULT,),
+    "webSearch": (EvidenceFamily.REPOSITORY_EXPLORATION,),
+}
+
+# Source fields intentionally preserved by the normalizer. Fields not listed here are either
+# identity/lifecycle metadata or deliberately excluded content (for example raw reasoning).
+_PRESERVED_FIELDS: dict[str, dict[str, str]] = {
+    "commandExecution": {
+        "params.item.command": "command",
+        "params.item.cwd": "cwd",
+        "params.item.status": "status",
+        "params.item.aggregatedOutput": "aggregatedOutput",
+        "params.item.exitCode": "exitCode",
+        "params.item.durationMs": "durationMs",
+        "params.item.source": "source",
+    },
+    "fileChange": {"params.item.changes": "changes", "params.item.status": "status"},
+    "mcpToolCall": {
+        "params.item.server": "server",
+        "params.item.tool": "tool",
+        "params.item.arguments": "arguments",
+        "params.item.status": "status",
+        "params.item.result": "result",
+        "params.item.error": "error",
+    },
+    "dynamicToolCall": {
+        "params.item.namespace": "namespace",
+        "params.item.tool": "tool",
+        "params.item.arguments": "arguments",
+        "params.item.status": "status",
+        "params.item.success": "success",
+        "params.item.contentItems": "contentItems",
+    },
+    "reasoning": {"params.item.summary": "summary"},
+    "plan": {"params.item.text": "text"},
+    "userMessage": {"params.item.content": "content"},
+}
+
+_PRESERVED_METHOD_FIELDS: dict[str, dict[str, str]] = {
+    "thread/started": {
+        "params.thread.cwd": "cwd",
+        "params.thread.sessionId": "sessionId",
+        "params.thread.status": "status",
+        "params.thread.name": "name",
+    },
+    "thread/status/changed": {"params.status": "status"},
+    "turn/started": {"params.turn.status": "status"},
+    "turn/completed": {
+        "params.turn.status": "status",
+        "params.turn.durationMs": "durationMs",
+        "params.turn.error": "error",
+    },
+    "turn/plan/updated": {
+        "params.plan": "steps",
+        "params.explanation": "explanation",
+    },
+    "turn/diff/updated": {"params.diff": "diff"},
+    "thread/tokenUsage/updated": {
+        "params.tokenUsage.last": "last",
+        "params.tokenUsage.total": "total",
+        "params.tokenUsage.modelContextWindow": "modelContextWindow",
+    },
+}
+
+
+def source_audit_sample(
+    raw_event: AppServerEvent,
+    event: TraceEvent,
+    *,
+    disposition: str = "ingested",
+    state_status: CoverageStatus | None = None,
+) -> SourceAuditSample:
+    source_fields = tuple(sorted(_field_paths(raw_event.raw)))
+    item_type = _item_type(raw_event.raw)
+    families = _families_for(raw_event.method, item_type)
+    status = _source_status(raw_event, item_type, source_fields, event)
+    if status == CoverageStatus.OBSERVED_ENCRYPTED:
+        # State cannot turn opaque source content into a known fact. Preserve the
+        # epistemic limit even when a generic lifecycle marker reached the reducer.
+        state_status = CoverageStatus.OBSERVED_ENCRYPTED
+    return SourceAuditSample(
+        method=raw_event.method,
+        source_fields=source_fields,
+        normalized_kind=event.kind,
+        normalized_fields=tuple(sorted(event.payload)),
+        families=tuple(item.value for item in families),
+        status=status.value,
+        state_status=state_status.value if state_status is not None else None,
+        thread_id=(
+            event.identity.thread_id.value
+            if event.identity is not None and event.identity.thread_id is not None
+            else None
+        ),
+        connection_epoch=event.connection_epoch,
+        disposition=disposition,
+        recorded_at=time.time(),
+    )
+
+
+class SourceAuditStore:
+    """Bounded shape-only source audit; values and reasoning content are never retained."""
+
+    def __init__(self, path: Path, *, max_records: int = 1000) -> None:
+        if max_records < 1:
+            raise ValueError("max_records must be positive")
+        self.path = path
+        self.max_records = max_records
+        try:
+            self._count = path.read_bytes().count(b"\n") if path.exists() else 0
+        except OSError:
+            # The primary observation path must still start. The first attempted
+            # audit write and the reporting command surface the filesystem error.
+            self._count = 0
+
+    def record(
+        self,
+        raw_event: AppServerEvent,
+        event: TraceEvent,
+        *,
+        disposition: str,
+        state_status: CoverageStatus | None = None,
+    ) -> SourceAuditSample:
+        sample = source_audit_sample(
+            raw_event,
+            event,
+            disposition=disposition,
+            state_status=state_status,
+        )
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+        with lock_path.open("a") as lock:
+            flock(lock, LOCK_EX)
+            try:
+                self._repair_tail()
+                if not self.path.exists():
+                    self.path.touch(mode=0o600)
+                else:
+                    self.path.chmod(0o600)
+                with self.path.open("a", encoding="utf-8") as sink:
+                    sink.write(json.dumps(asdict(sample), separators=(",", ":")) + "\n")
+                    sink.flush()
+                    os.fsync(sink.fileno())
+                self._count += 1
+                if self._count > self.max_records * 2:
+                    self._compact()
+            finally:
+                flock(lock, LOCK_UN)
+        return sample
+
+    def load(self) -> tuple[SourceAuditSample, ...]:
+        if not self.path.exists():
+            return ()
+        lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+        with lock_path.open("a") as lock:
+            flock(lock, LOCK_EX)
+            try:
+                lines = self.path.read_text(encoding="utf-8").splitlines()
+            finally:
+                flock(lock, LOCK_UN)
+        samples = []
+        for line_number, line in enumerate(lines, start=1):
+            if not line.strip():
+                continue
+            try:
+                raw = json.loads(line)
+                if not isinstance(raw, Mapping):
+                    raise TypeError("sample is not an object")
+                epoch = raw.get("connection_epoch")
+                if isinstance(epoch, bool) or not isinstance(epoch, int | None):
+                    raise TypeError("connection_epoch is not an integer or null")
+                thread_id = raw.get("thread_id")
+                if not isinstance(thread_id, str | None):
+                    raise TypeError("thread_id is not a string or null")
+                status = CoverageStatus(_required_string(raw, "status")).value
+                raw_state_status = _optional_string(raw, "state_status")
+                state_status = (
+                    CoverageStatus(raw_state_status).value if raw_state_status is not None else None
+                )
+                families = _string_tuple(raw, "families")
+                for family in families:
+                    EvidenceFamily(family)
+                disposition = _required_string(raw, "disposition")
+                if disposition not in {"ingested", "deduplicated"}:
+                    raise ValueError(f"unknown disposition {disposition!r}")
+                raw_recorded_at = raw["recorded_at"]
+                if isinstance(raw_recorded_at, bool) or not isinstance(
+                    raw_recorded_at, int | float
+                ):
+                    raise TypeError("recorded_at is not numeric")
+                recorded_at = float(raw_recorded_at)
+                if not math.isfinite(recorded_at):
+                    raise ValueError("recorded_at is not finite")
+                samples.append(
+                    SourceAuditSample(
+                        method=_required_string(raw, "method"),
+                        source_fields=_string_tuple(raw, "source_fields"),
+                        normalized_kind=_required_string(raw, "normalized_kind"),
+                        normalized_fields=_string_tuple(raw, "normalized_fields"),
+                        families=families,
+                        status=status,
+                        state_status=state_status,
+                        thread_id=thread_id,
+                        connection_epoch=epoch,
+                        disposition=disposition,
+                        recorded_at=recorded_at,
+                    )
+                )
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+                raise ObservabilityError(
+                    f"{self.path} line {line_number} is not a valid source audit sample: {error}"
+                ) from error
+        return tuple(samples)
+
+    def _repair_tail(self) -> None:
+        if not self.path.exists():
+            return
+        content = self.path.read_bytes()
+        if not content or content.endswith(b"\n"):
+            self._count = content.count(b"\n")
+            return
+        boundary = content.rfind(b"\n") + 1
+        with self.path.open("r+b") as sink:
+            sink.truncate(boundary)
+            sink.flush()
+            os.fsync(sink.fileno())
+        self._count = content[:boundary].count(b"\n")
+
+    def _compact(self) -> None:
+        lines = self.path.read_text().splitlines()[-self.max_records :]
+        temporary = self.path.with_suffix(self.path.suffix + ".tmp")
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as sink:
+            sink.write("\n".join(lines) + "\n")
+            sink.flush()
+            os.fsync(sink.fileno())
+        os.replace(temporary, self.path)
+        directory = os.open(self.path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+        self._count = len(lines)
+
+
+@dataclass(frozen=True)
+class ObservabilityReport:
+    sessions: int
+    hook_sessions: int
+    app_server_sessions: int
+    events: int
+    gaps: int
+    unknown_events: int
+    deduplicated_source_samples: int
+    trace_family_status: Mapping[str, Mapping[str, Mapping[str, int]]]
+    source_status: Mapping[str, int]
+    source_family_status: Mapping[str, Mapping[str, int]]
+    state_family_status: Mapping[str, Mapping[str, int]]
+
+
+def measure_observability(
+    journals: Iterable[Iterable[StepRecord]],
+    source_samples: Iterable[SourceAuditSample] = (),
+) -> ObservabilityReport:
+    source_samples = tuple(source_samples)
+    deduplicated_source_samples = sum(
+        sample.disposition == "deduplicated" for sample in source_samples
+    )
+    source_samples = tuple(sample for sample in source_samples if sample.disposition == "ingested")
+    trace_family_status: dict[str, dict[str, Counter[str]]] = {
+        "hook": {},
+        "app_server": {},
+    }
+    sessions = hook_sessions = app_server_sessions = events = gaps = unknown_events = 0
+    for records_iter in journals:
+        records = tuple(records_iter)
+        sessions += 1
+        sources = {
+            record.event.provenance.source
+            for record in records
+            if record.event.provenance is not None
+        }
+        is_app_server = "codex_app_server" in sources or any(
+            record.event.connection_epoch is not None for record in records
+        )
+        if is_app_server:
+            app_server_sessions += 1
+        else:
+            hook_sessions += 1
+        surface = "app_server" if is_app_server else "hook"
+        for record in records:
+            event = record.event
+            events += 1
+            if event.kind == "observation_gap":
+                gaps += 1
+                continue
+            if event.kind == "runtime_event_unknown":
+                unknown_events += 1
+            status = _trace_status(event)
+            for trace_family in _trace_families(event):
+                trace_family_status[surface].setdefault(trace_family.value, Counter())[
+                    status.value
+                ] += 1
+    source_status = Counter(sample.status for sample in source_samples)
+    source_family_status: dict[str, Counter[str]] = {}
+    state_family_status: dict[str, Counter[str]] = {}
+    for sample in source_samples:
+        for family_name in sample.families or ("unclassified",):
+            source_family_status.setdefault(family_name, Counter())[sample.status] += 1
+            if sample.state_status is not None:
+                state_family_status.setdefault(family_name, Counter())[sample.state_status] += 1
+    return ObservabilityReport(
+        sessions,
+        hook_sessions,
+        app_server_sessions,
+        events,
+        gaps,
+        unknown_events,
+        deduplicated_source_samples,
+        {
+            surface: {family: dict(counts) for family, counts in sorted(family_status.items())}
+            for surface, family_status in trace_family_status.items()
+        },
+        dict(sorted(source_status.items())),
+        {family: dict(counts) for family, counts in sorted(source_family_status.items())},
+        {family: dict(counts) for family, counts in sorted(state_family_status.items())},
+    )
+
+
+def render_observability(report: ObservabilityReport) -> str:
+    lines = [
+        (
+            f"sessions: {report.sessions} "
+            f"(hook={report.hook_sessions}, app_server={report.app_server_sessions})"
+        ),
+        (
+            f"events: {report.events}; observation_gaps: {report.gaps}; "
+            f"unknown_events: {report.unknown_events}"
+        ),
+        f"deduplicated source notifications excluded: {report.deduplicated_source_samples}",
+        "Trace IR evidence-family coverage:",
+    ]
+    for surface, family_status in report.trace_family_status.items():
+        lines.append(f"  {surface}:")
+        if not family_status:
+            lines.append("    no classified evidence")
+        for family, counts in family_status.items():
+            summary = ", ".join(f"{status}={count}" for status, count in sorted(counts.items()))
+            lines.append(f"    {family}: {summary}")
+    lines.append("source-vs-adapter samples:")
+    if not report.source_status:
+        lines.append("  none — post-App-Server source ceiling cannot be stated")
+    else:
+        for status, count in report.source_status.items():
+            lines.append(f"  {status}: {count}")
+        lines.append("  by evidence family:")
+        for family, counts in report.source_family_status.items():
+            summary = ", ".join(f"{status}={count}" for status, count in sorted(counts.items()))
+            lines.append(f"    {family}: {summary}")
+        lines.append("ThreadState preservation:")
+        if not report.state_family_status:
+            lines.append("  none — source samples have not been reduced through live state")
+        for family, counts in report.state_family_status.items():
+            summary = ", ".join(f"{status}={count}" for status, count in sorted(counts.items()))
+            lines.append(f"  {family}: {summary}")
+    return "\n".join(lines)
+
+
+def _field_paths(value: object, prefix: str = "", depth: int = 0) -> set[str]:
+    if not isinstance(value, Mapping) or depth >= 3:
+        return {prefix} if prefix else set()
+    paths: set[str] = set()
+    for key, child in value.items():
+        path = f"{prefix}.{key}" if prefix else str(key)
+        if isinstance(child, Mapping):
+            paths.update(_field_paths(child, path, depth + 1))
+        else:
+            paths.add(path)
+    return paths
+
+
+def _item_type(raw: Mapping[str, Any]) -> str | None:
+    params = raw.get("params")
+    item = params.get("item") if isinstance(params, Mapping) else None
+    value = item.get("type") if isinstance(item, Mapping) else None
+    return value if isinstance(value, str) else None
+
+
+def _source_status(
+    raw_event: AppServerEvent,
+    item_type: str | None,
+    source_fields: tuple[str, ...],
+    event: TraceEvent,
+) -> CoverageStatus:
+    if any("encrypted" in field.lower() for field in source_fields):
+        return CoverageStatus.OBSERVED_ENCRYPTED
+    families = _families_for(raw_event.method, item_type)
+    if not families or event.kind == "runtime_event_unknown":
+        return CoverageStatus.UNKNOWN
+    preservation = _PRESERVED_FIELDS.get(
+        item_type or "", _PRESERVED_METHOD_FIELDS.get(raw_event.method, {})
+    )
+    lost = [
+        target
+        for source, target in preservation.items()
+        if _path_has_value(raw_event.raw, source) and target not in event.payload
+    ]
+    if lost:
+        return CoverageStatus.ADAPTER_DROPPED
+    if event.identity is None or event.identity.provenance.agent_thread_id is None:
+        return CoverageStatus.OBSERVED_UNCORRELATED
+    return CoverageStatus.OBSERVED_EXACT
+
+
+_TRACE_FAMILY: dict[str, tuple[EvidenceFamily, ...]] = {
+    "user_prompt": (EvidenceFamily.USER_GOAL,),
+    "thread_started": (EvidenceFamily.THREAD_TURN_IDENTITY,),
+    "thread_status": (EvidenceFamily.THREAD_TURN_IDENTITY,),
+    "turn_started": (EvidenceFamily.THREAD_TURN_IDENTITY,),
+    "turn_completed": (EvidenceFamily.THREAD_TURN_IDENTITY,),
+    "plan": (EvidenceFamily.PLAN_SUMMARY,),
+    "reasoning_summary": (EvidenceFamily.REASONING_SUMMARY,),
+    "search": (EvidenceFamily.REPOSITORY_EXPLORATION,),
+    "search_started": (EvidenceFamily.REPOSITORY_EXPLORATION,),
+    "command_started": (EvidenceFamily.COMMAND_TOOL_CALL,),
+    "command_result": (EvidenceFamily.COMMAND_TOOL_CALL, EvidenceFamily.TOOL_OUTCOME),
+    "tool_started": (EvidenceFamily.MCP_CALL_RESULT,),
+    "tool_result": (EvidenceFamily.TOOL_OUTCOME,),
+    "file_change_started": (EvidenceFamily.FILE_EDIT_DIFF,),
+    "file_edit": (EvidenceFamily.FILE_EDIT_DIFF,),
+    "diff_updated": (EvidenceFamily.FILE_EDIT_DIFF,),
+    "test_result": (EvidenceFamily.VALIDATION_OUTCOME,),
+    "reviewer_decision": (EvidenceFamily.INTERVENTION_DELIVERY,),
+    "intervention": (EvidenceFamily.INTERVENTION_DELIVERY,),
+    "effect_proposed": (EvidenceFamily.EXTERNAL_EFFECT,),
+    "effect_observed": (EvidenceFamily.EXTERNAL_EFFECT,),
+    "token_usage": (EvidenceFamily.RUNTIME_USAGE,),
+}
+
+
+def _trace_families(event: TraceEvent) -> tuple[EvidenceFamily, ...]:
+    if (
+        event.kind == "tool_result"
+        and event.provenance is not None
+        and event.provenance.source == "codex_app_server"
+    ):
+        return (EvidenceFamily.MCP_CALL_RESULT, EvidenceFamily.TOOL_OUTCOME)
+    if event.kind == "tool_proposal":
+        tool = event.payload.get("tool")
+        if tool == "apply_patch":
+            return (EvidenceFamily.FILE_EDIT_DIFF,)
+        return (EvidenceFamily.COMMAND_TOOL_CALL,)
+    return _TRACE_FAMILY.get(event.kind, ())
+
+
+def _trace_status(event: TraceEvent) -> CoverageStatus:
+    if event.provenance is None:
+        return CoverageStatus.LEGACY_UNAVAILABLE
+    if event.provenance.source == "codex_hook":
+        if event.kind == "tool_result" and not _hook_outcome_visible(event.payload):
+            return CoverageStatus.OBSERVED_PARTIAL
+        return CoverageStatus.OBSERVED_EXACT
+    if event.kind == "runtime_event_unknown":
+        return CoverageStatus.UNKNOWN
+    if event.provenance.source == "codex_app_server" and (
+        event.identity is None or event.identity.provenance.agent_thread_id is None
+    ):
+        return CoverageStatus.OBSERVED_UNCORRELATED
+    return CoverageStatus.OBSERVED_EXACT
+
+
+def _hook_outcome_visible(payload: Mapping[str, Any]) -> bool:
+    response = payload.get("tool_response")
+    if isinstance(response, Mapping):
+        return isinstance(response.get("exit_code"), int)
+    return isinstance(response, str) and "Exit code:" in response
+
+
+def state_coverage_status(event: TraceEvent, state: ThreadState) -> CoverageStatus:
+    """Classify whether normalized evidence survives in live supervisory state."""
+
+    if event.kind == "runtime_event_unknown":
+        return CoverageStatus.UNKNOWN
+    if event.kind == "thread_started":
+        return CoverageStatus.OBSERVED_EXACT
+    if event.kind == "token_usage":
+        return CoverageStatus.ADAPTER_DROPPED
+    if event.kind in {"thread_status", "diff_updated"}:
+        return CoverageStatus.OBSERVED_PARTIAL
+    if event.kind == "turn_started":
+        turn_id = event.identity.turn_id if event.identity is not None else None
+        return (
+            CoverageStatus.OBSERVED_EXACT
+            if turn_id is not None and state.active_turn_id == turn_id
+            else CoverageStatus.ADAPTER_DROPPED
+        )
+    if event.kind == "turn_completed":
+        turn_id = event.identity.turn_id if event.identity is not None else None
+        return (
+            CoverageStatus.OBSERVED_EXACT
+            if turn_id is not None and turn_id in state.execution.completed_turns
+            else CoverageStatus.ADAPTER_DROPPED
+        )
+    if event.kind == "user_prompt":
+        item = state.task.goal
+        return _state_item_status(event, item.provenance.event_id if item else None)
+    if event.kind == "plan":
+        item = state.execution.plan_summary
+        return _state_item_status(event, item.provenance.event_id if item else None)
+    if event.kind == "reasoning_summary":
+        return _state_evidence_status(event, state)
+    if event.kind in {"command_started", "tool_started", "file_change_started"}:
+        return (
+            CoverageStatus.OBSERVED_EXACT
+            if event.operation_id is not None and event.operation_id in state.execution.active_items
+            else CoverageStatus.ADAPTER_DROPPED
+        )
+    if event.kind in {"command_result", "tool_result", "file_edit", "search"}:
+        return _state_evidence_status(event, state)
+    return CoverageStatus.UNKNOWN
+
+
+def _families_for(method: str, item_type: str | None) -> tuple[EvidenceFamily, ...]:
+    if item_type is not None and item_type in _ITEM_FAMILY:
+        return _ITEM_FAMILY[item_type]
+    return _METHOD_FAMILY.get(method, ())
+
+
+def _path_has_value(raw: Mapping[str, Any], path: str) -> bool:
+    value: object = raw
+    for component in path.split("."):
+        if not isinstance(value, Mapping) or component not in value:
+            return False
+        value = value[component]
+    return value is not None
+
+
+def _required_string(raw: Mapping[str, Any], key: str) -> str:
+    value = raw[key]
+    if not isinstance(value, str) or not value:
+        raise TypeError(f"{key} is not a non-empty string")
+    return value
+
+
+def _string_tuple(raw: Mapping[str, Any], key: str) -> tuple[str, ...]:
+    value = raw[key]
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise TypeError(f"{key} is not a string list")
+    return tuple(value)
+
+
+def _optional_string(raw: Mapping[str, Any], key: str) -> str | None:
+    value = raw.get(key)
+    if value is not None and not isinstance(value, str):
+        raise TypeError(f"{key} is not a string or null")
+    return value
+
+
+def _state_item_status(event: TraceEvent, state_event_id: str | None) -> CoverageStatus:
+    if event.event_id is None:
+        return CoverageStatus.OBSERVED_PARTIAL
+    return (
+        CoverageStatus.OBSERVED_EXACT
+        if state_event_id == event.event_id
+        else CoverageStatus.ADAPTER_DROPPED
+    )
+
+
+def _state_evidence_status(event: TraceEvent, state: ThreadState) -> CoverageStatus:
+    if event.event_id is None:
+        return CoverageStatus.OBSERVED_PARTIAL
+    return (
+        CoverageStatus.OBSERVED_EXACT
+        if any(item.provenance.event_id == event.event_id for item in state.evidence.items)
+        else CoverageStatus.ADAPTER_DROPPED
+    )

--- a/src/spotter/runtime_connection.py
+++ b/src/spotter/runtime_connection.py
@@ -23,6 +23,8 @@ from spotter.app_server import (
 )
 from spotter.identity import AttachmentId, RuntimeIdentity, ThreadId
 from spotter.ingestion import AppServerTraceIngestor, IngestionError
+from spotter.observability import state_coverage_status
+from spotter.snapshot import StepRecord
 from spotter.thread_state import ThreadState, ThreadStateError, ThreadStateStore
 from spotter.trace import TraceEvent, TraceProvenance
 
@@ -220,7 +222,21 @@ class AppServerRecoveryLoop:
                     identity=self._epoch_identity(event.identity, attachment_id),
                     connection_epoch=epoch,
                 )
-                self._record(event)
+                record = self._record(event)
+                state_status = None
+                if (
+                    record is not None
+                    and event.identity is not None
+                    and event.identity.thread_id is not None
+                ):
+                    state = self.thread_states.snapshot(event.identity.thread_id)
+                    state_status = state_coverage_status(record.event, state)
+                self.ingestor.audit_source(
+                    raw_event,
+                    record.event if record is not None else event,
+                    disposition="ingested" if record is not None else "deduplicated",
+                    state_status=state_status,
+                )
             except IngestionError as error:
                 self.last_error = str(error)
             except AppServerError:
@@ -349,11 +365,12 @@ class AppServerRecoveryLoop:
         )
         self.metrics = replace(self.metrics, observation_gaps=self.metrics.observation_gaps + 1)
 
-    def _record(self, event: TraceEvent) -> None:
+    def _record(self, event: TraceEvent) -> StepRecord | None:
         record = self.ingestor.record(event)
         if record is None or event.identity is None or event.identity.thread_id is None:
-            return
+            return record
         self.thread_states.observe(record.event)
+        return record
 
     def _runtime_identity(
         self,

--- a/tests/fixtures/app_server_conformance.json
+++ b/tests/fixtures/app_server_conformance.json
@@ -1,0 +1,90 @@
+[
+  {
+    "name": "thread identity",
+    "method": "thread/started",
+    "params": {"thread": {"id": "thread-1", "cwd": "/repo", "status": {"type": "idle"}}},
+    "expected_kind": "thread_started",
+    "expected_status": "observed_exact",
+    "families": ["thread_turn_identity"]
+  },
+  {
+    "name": "turn identity",
+    "method": "turn/started",
+    "params": {"threadId": "thread-1", "turn": {"id": "turn-1", "status": "inProgress"}},
+    "expected_kind": "turn_started",
+    "expected_status": "observed_exact",
+    "families": ["thread_turn_identity"]
+  },
+  {
+    "name": "turn completion",
+    "method": "turn/completed",
+    "params": {"threadId": "thread-1", "turn": {"id": "turn-1", "status": "completed", "durationMs": 20}},
+    "expected_kind": "turn_completed",
+    "expected_status": "observed_exact",
+    "families": ["thread_turn_identity"]
+  },
+  {
+    "name": "command outcome",
+    "method": "item/completed",
+    "params": {"threadId": "thread-1", "turnId": "turn-1", "item": {"id": "command-1", "type": "commandExecution", "command": "pytest", "cwd": "/repo", "status": "completed", "aggregatedOutput": "ok", "exitCode": 0}},
+    "expected_kind": "command_result",
+    "expected_status": "observed_exact",
+    "families": ["command_tool_call", "tool_outcome"]
+  },
+  {
+    "name": "file diff",
+    "method": "item/completed",
+    "params": {"threadId": "thread-1", "turnId": "turn-1", "item": {"id": "file-1", "type": "fileChange", "status": "completed", "changes": [{"path": "src/example.py", "kind": "update", "diff": "+pass"}]}},
+    "expected_kind": "file_edit",
+    "expected_status": "observed_exact",
+    "families": ["file_edit_diff"]
+  },
+  {
+    "name": "MCP result",
+    "method": "item/completed",
+    "params": {"threadId": "thread-1", "turnId": "turn-1", "item": {"id": "mcp-1", "type": "mcpToolCall", "server": "github", "tool": "read", "arguments": {"id": 1}, "status": "completed", "result": {"ok": true}}},
+    "expected_kind": "tool_result",
+    "expected_status": "observed_exact",
+    "families": ["mcp_call_result"]
+  },
+  {
+    "name": "plan summary",
+    "method": "item/completed",
+    "params": {"threadId": "thread-1", "turnId": "turn-1", "item": {"id": "plan-1", "type": "plan", "text": "Run focused checks"}},
+    "expected_kind": "plan",
+    "expected_status": "observed_exact",
+    "families": ["plan_summary"]
+  },
+  {
+    "name": "reasoning summary excludes raw content",
+    "method": "item/completed",
+    "params": {"threadId": "thread-1", "turnId": "turn-1", "item": {"id": "reasoning-1", "type": "reasoning", "summary": ["Inspect the boundary"], "content": ["SYNTHETIC_PRIVATE_REASONING"]}},
+    "expected_kind": "reasoning_summary",
+    "expected_status": "observed_exact",
+    "families": ["reasoning_summary"]
+  },
+  {
+    "name": "runtime usage",
+    "method": "thread/tokenUsage/updated",
+    "params": {"threadId": "thread-1", "turnId": "turn-1", "tokenUsage": {"last": {"inputTokens": 10, "outputTokens": 4}, "total": {"totalTokens": 14}, "modelContextWindow": 200000}},
+    "expected_kind": "token_usage",
+    "expected_status": "observed_exact",
+    "families": ["runtime_usage"]
+  },
+  {
+    "name": "unknown method remains visible",
+    "method": "future/event",
+    "params": {"threadId": "thread-1", "turnId": "turn-1", "futurePayload": {"shape": "known-only-to-source"}},
+    "expected_kind": "runtime_event_unknown",
+    "expected_status": "unknown",
+    "families": []
+  },
+  {
+    "name": "encrypted child content is not reconstructed",
+    "method": "item/completed",
+    "params": {"threadId": "thread-1", "turnId": "turn-1", "item": {"id": "child-1", "type": "collabToolCall", "status": "completed", "encryptedContent": "SYNTHETIC_CIPHERTEXT"}},
+    "expected_kind": "item_completed",
+    "expected_status": "observed_encrypted",
+    "families": []
+  }
+]

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,279 @@
+import json
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from spotter.app_server import AppServerEvent
+from spotter.cli import main
+from spotter.identity import IdentityProvenance, RuntimeIdentity, ThreadId
+from spotter.ingestion import AppServerTraceIngestor, CodexTraceNormalizer
+from spotter.observability import (
+    CoverageStatus,
+    EvidenceFamily,
+    EvidenceTiming,
+    ObservabilityError,
+    OpportunityStatus,
+    SourceAuditStore,
+    classify_opportunity,
+    measure_observability,
+    source_audit_sample,
+    state_coverage_status,
+)
+from spotter.snapshot import StepJournal, StepRecord
+from spotter.thread_state import ThreadStateStore
+from spotter.trace import TraceEvent, TraceProvenance
+
+FIXTURE = Path(__file__).parent / "fixtures" / "app_server_conformance.json"
+
+
+def _raw(method: str, params: dict[str, Any]) -> AppServerEvent:
+    return AppServerEvent(method, {"method": method, "params": params})
+
+
+def _cases() -> list[dict[str, Any]]:
+    loaded = json.loads(FIXTURE.read_text())
+    assert isinstance(loaded, list)
+    return loaded
+
+
+@pytest.mark.parametrize("case", _cases(), ids=lambda case: str(case["name"]))
+def test_source_vs_trace_conformance_corpus(case: dict[str, Any]) -> None:
+    raw = _raw(str(case["method"]), case["params"])
+    event = CodexTraceNormalizer().normalize(raw)
+    state = ThreadStateStore().observe(event)
+    sample = source_audit_sample(
+        raw,
+        event,
+        state_status=state_coverage_status(event, state),
+    )
+
+    assert event.kind == case["expected_kind"]
+    assert sample.status == case["expected_status"]
+    assert list(sample.families) == case["families"]
+    expected_state = {
+        "token_usage": CoverageStatus.ADAPTER_DROPPED,
+        "runtime_event_unknown": CoverageStatus.UNKNOWN,
+        "item_completed": CoverageStatus.OBSERVED_ENCRYPTED,
+    }.get(event.kind, CoverageStatus.OBSERVED_EXACT)
+    assert sample.state_status == expected_state
+    serialized = json.dumps(sample.__dict__)
+    assert "SYNTHETIC_PRIVATE_REASONING" not in serialized
+    assert "SYNTHETIC_CIPHERTEXT" not in serialized
+
+
+def test_source_field_present_but_trace_drops_it_is_adapter_loss() -> None:
+    raw = _raw(
+        "item/completed",
+        {
+            "threadId": "thread-1",
+            "turnId": "turn-1",
+            "item": {
+                "id": "command-1",
+                "type": "commandExecution",
+                "command": "pytest",
+                "status": "completed",
+                "exitCode": 1,
+            },
+        },
+    )
+    normalized = CodexTraceNormalizer().normalize(raw)
+    dropped = replace(normalized, payload={"command": "pytest", "status": "completed"})
+
+    assert source_audit_sample(raw, dropped).status == CoverageStatus.ADAPTER_DROPPED
+
+
+@pytest.mark.parametrize(
+    ("evidence", "boundary", "expected"),
+    [
+        (
+            [
+                EvidenceTiming(
+                    EvidenceFamily.TOOL_OUTCOME, CoverageStatus.OBSERVED_EXACT, state_step=4
+                )
+            ],
+            4,
+            OpportunityStatus.VISIBLE_IN_TIME,
+        ),
+        (
+            [
+                EvidenceTiming(
+                    EvidenceFamily.TOOL_OUTCOME, CoverageStatus.OBSERVED_EXACT, state_step=5
+                )
+            ],
+            4,
+            OpportunityStatus.VISIBLE_TOO_LATE,
+        ),
+        (
+            [EvidenceTiming(EvidenceFamily.SUBAGENT_LINEAGE, CoverageStatus.SOURCE_NOT_EXPOSED)],
+            4,
+            OpportunityStatus.STRUCTURALLY_INVISIBLE,
+        ),
+        (
+            [EvidenceTiming(EvidenceFamily.TOOL_OUTCOME, CoverageStatus.ADAPTER_DROPPED)],
+            4,
+            OpportunityStatus.LOST_BY_ADAPTER,
+        ),
+        (
+            [EvidenceTiming(EvidenceFamily.TOOL_OUTCOME, CoverageStatus.OBSERVATION_GAP)],
+            4,
+            OpportunityStatus.LOST_BY_GAP,
+        ),
+        (
+            [EvidenceTiming(EvidenceFamily.REPOSITORY_EXPLORATION, CoverageStatus.NOT_PERFORMED)],
+            4,
+            OpportunityStatus.UNJUDGEABLE,
+        ),
+    ],
+)
+def test_opportunity_classification(
+    evidence: list[EvidenceTiming], boundary: int, expected: OpportunityStatus
+) -> None:
+    assert classify_opportunity(boundary, evidence) == expected
+
+
+def test_shape_audit_is_bounded_private_and_rejects_corruption(tmp_path: Path) -> None:
+    store = SourceAuditStore(tmp_path / "audit.jsonl", max_records=2)
+    ingestor = AppServerTraceIngestor(tmp_path / "journals")
+    raw = _raw(
+        "item/completed",
+        {
+            "threadId": "thread-1",
+            "turnId": "turn-1",
+            "item": {
+                "id": "reasoning-1",
+                "type": "reasoning",
+                "summary": ["safe"],
+                "content": ["SECRET_VALUE"],
+            },
+        },
+    )
+    event = ingestor.normalizer.normalize(raw)
+    for _ in range(5):
+        store.record(raw, event, disposition="ingested")
+
+    assert len(store.load()) == 2
+    assert "SECRET_VALUE" not in store.path.read_text()
+    assert store.path.stat().st_mode & 0o777 == 0o600
+    with store.path.open("ab") as sink:
+        sink.write(b'{"torn":')
+    store.record(raw, event, disposition="ingested")
+    assert len(store.load()) == 3
+    store.path.write_text("not-json\n")
+    with pytest.raises(ObservabilityError, match="line 1"):
+        store.load()
+
+
+def test_measurement_separates_hook_app_server_source_and_state() -> None:
+    identity = RuntimeIdentity(
+        ThreadId("thread-1"),
+        None,
+        None,
+        IdentityProvenance("codex", agent_thread_id="external-1"),
+    )
+    hook = [
+        StepRecord(
+            0,
+            TraceEvent(
+                "tool_result",
+                {"tool_response": "output without an exit status"},
+                provenance=TraceProvenance("codex_hook", "PostToolUse"),
+            ),
+            None,
+        )
+    ]
+    app_event = TraceEvent(
+        "command_result",
+        {"command": "pytest", "exitCode": 0},
+        event_id="event-1",
+        identity=identity,
+        provenance=TraceProvenance("codex_app_server", "item/completed"),
+        connection_epoch=1,
+    )
+    app = [
+        StepRecord(0, app_event, None),
+        StepRecord(
+            1,
+            TraceEvent("observation_gap", identity=identity, connection_epoch=1),
+            None,
+        ),
+    ]
+    raw = _raw(
+        "item/completed",
+        {
+            "threadId": "external-1",
+            "turnId": "turn-1",
+            "item": {
+                "id": "command-1",
+                "type": "commandExecution",
+                "command": "pytest",
+                "exitCode": 0,
+            },
+        },
+    )
+    sample = source_audit_sample(
+        raw,
+        app_event,
+        state_status=CoverageStatus.OBSERVED_EXACT,
+    )
+    report = measure_observability(
+        [hook, app], [sample, replace(sample, disposition="deduplicated")]
+    )
+
+    assert report.hook_sessions == report.app_server_sessions == 1
+    assert report.gaps == 1
+    assert report.deduplicated_source_samples == 1
+    assert report.trace_family_status["hook"]["tool_outcome"] == {"observed_partial": 1}
+    assert report.trace_family_status["app_server"]["tool_outcome"] == {"observed_exact": 1}
+    assert report.source_family_status["tool_outcome"] == {"observed_exact": 1}
+    assert report.state_family_status["tool_outcome"] == {"observed_exact": 1}
+
+
+def test_live_ingestion_records_thread_state_preservation(tmp_path: Path) -> None:
+    ingestor = AppServerTraceIngestor(tmp_path)
+    states = ThreadStateStore()
+    raw = _raw(
+        "item/completed",
+        {
+            "threadId": "thread-1",
+            "turnId": "turn-1",
+            "item": {
+                "id": "command-1",
+                "type": "commandExecution",
+                "command": "pytest",
+                "status": "completed",
+                "exitCode": 0,
+            },
+        },
+    )
+    event = replace(ingestor.normalizer.normalize(raw), connection_epoch=1)
+    record = ingestor.record(event)
+    assert record is not None
+    state = states.observe(record.event)
+
+    ingestor.audit_source(
+        raw,
+        record.event,
+        disposition="ingested",
+        state_status=state_coverage_status(record.event, state),
+    )
+
+    sample = ingestor.source_audit.load()[0]
+    assert sample.status == CoverageStatus.OBSERVED_EXACT
+    assert sample.state_status == CoverageStatus.OBSERVED_EXACT
+
+
+def test_observability_cli_does_not_claim_an_unmeasured_ceiling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path))
+    (tmp_path / "sessions").mkdir()
+    StepJournal(tmp_path / "sessions" / "hook-session.jsonl").record(
+        TraceEvent("user_prompt", {"prompt": "synthetic"})
+    )
+
+    assert main(["observability"]) == 0
+    output = capsys.readouterr().out
+    assert "hook=1, app_server=0" in output
+    assert "post-App-Server source ceiling cannot be stated" in output


### PR DESCRIPTION
## Why

Issue #37 needs source limits, normalization loss, live-state loss, reconnect gaps, and late evidence to remain distinguishable. Counting raw events or treating an implemented adapter as outcome evidence would overstate the observability ceiling.

## What changed

- add the explicit evidence-family, coverage, and intervention-opportunity taxonomy
- retain a bounded mode-0600 value-free App Server field-shape audit with locking, fsync, torn-tail repair, compaction, and duplicate exclusion
- measure Hook and App Server Trace IR separately, plus source-to-Trace-IR and Trace-IR-to-ThreadState preservation
- add a synthetic conformance corpus for lifecycle, command, file, MCP, plan, reasoning summary, usage, unknown methods, and encrypted child content
- add spotter observability and document the current aggregate baseline

## Current evidence

The available local snapshot contains 9 Hook journals, 0 App Server journals, 0 source audit samples, and 0/9 session-level observability labels. The command therefore reports that the post-App-Server ceiling cannot be stated. This PR intentionally does not close #37; representative labeled failed/degraded App Server trajectories are still required.

## Validation

- ruff format --check .
- ruff check .
- mypy src tests
- pytest (376 passed)

Refs #37