### PR TITLE
fix(observe): harden source audit edge cases

### DIFF
--- a/src/spotter/ingestion.py
+++ b/src/spotter/ingestion.py
@@ -16,6 +16,8 @@ from spotter.identity import (
     TurnStatus,
 )
 from spotter.observability import (
+    APP_SERVER_ITEM_FIELDS,
+    APP_SERVER_METHOD_FIELDS,
     SOURCE_AUDIT_RELATIVE_PATH,
     CoverageStatus,
     SourceAuditStore,
@@ -58,7 +60,7 @@ class CodexTraceNormalizer:
             identity = self._identity(started_thread_id)
             return TraceEvent(
                 "thread_started",
-                _known(thread, "cwd", "sessionId", "status", "name"),
+                _known(thread, *APP_SERVER_METHOD_FIELDS["thread/started"].values()),
                 event_id,
                 _seconds(thread.get("createdAt")),
                 identity,
@@ -80,7 +82,7 @@ class CodexTraceNormalizer:
             identity, observed_start = self._finish_turn(
                 external_thread_id, external_turn_id, status
             )
-            payload = _known(completed_turn, "status", "durationMs", "error")
+            payload = _known(completed_turn, *APP_SERVER_METHOD_FIELDS["turn/completed"].values())
             payload["observed_start"] = observed_start
             return TraceEvent(
                 "turn_completed",
@@ -102,7 +104,7 @@ class CodexTraceNormalizer:
                 raise IngestionError("turn/started omitted turn")
             return TraceEvent(
                 "turn_started",
-                _known(turn_raw, "status"),
+                _known(turn_raw, *APP_SERVER_METHOD_FIELDS["turn/started"].values()),
                 event_id,
                 _seconds(turn_raw.get("startedAt")),
                 identity,
@@ -111,7 +113,7 @@ class CodexTraceNormalizer:
         if event.method == "thread/status/changed":
             return TraceEvent(
                 "thread_status",
-                _known(params, "status"),
+                _known(params, *APP_SERVER_METHOD_FIELDS["thread/status/changed"].values()),
                 event_id,
                 identity=identity,
                 provenance=provenance,
@@ -151,7 +153,7 @@ class CodexTraceNormalizer:
         if event.method == "turn/diff/updated":
             return TraceEvent(
                 "diff_updated",
-                _known(params, "diff"),
+                _known(params, *APP_SERVER_METHOD_FIELDS["turn/diff/updated"].values()),
                 event_id,
                 identity=identity,
                 provenance=provenance,
@@ -391,23 +393,14 @@ def _normalize_item(item: Mapping[str, Any], completed: bool) -> tuple[str, dict
     if item_type == "agentMessage":
         return "agent_message", _known(item, "text", "phase")
     if item_type == "plan":
-        return "plan", _known(item, "text")
+        return "plan", _known(item, *APP_SERVER_ITEM_FIELDS["plan"])
     if item_type == "reasoning":
         # App Server exposes both summary and raw reasoning content. Only the summary is Trace IR.
         summary = item.get("summary")
         return "reasoning_summary", {"summary": summary if isinstance(summary, list) else []}
     if item_type == "commandExecution":
         kind = "command_result" if completed else "command_started"
-        return kind, _known(
-            item,
-            "command",
-            "cwd",
-            "status",
-            "aggregatedOutput",
-            "exitCode",
-            "durationMs",
-            "source",
-        )
+        return kind, _known(item, *APP_SERVER_ITEM_FIELDS["commandExecution"])
     if item_type == "fileChange":
         changes = item.get("changes")
         normalized = (
@@ -426,24 +419,13 @@ def _normalize_item(item: Mapping[str, Any], completed: bool) -> tuple[str, dict
         }
     if item_type == "mcpToolCall":
         kind = "tool_result" if completed else "tool_started"
-        return kind, _known(
-            item, "server", "tool", "arguments", "status", "result", "error", "durationMs"
-        )
+        return kind, _known(item, *APP_SERVER_ITEM_FIELDS["mcpToolCall"])
     if item_type == "dynamicToolCall":
         kind = "tool_result" if completed else "tool_started"
-        return kind, _known(
-            item,
-            "namespace",
-            "tool",
-            "arguments",
-            "status",
-            "success",
-            "contentItems",
-            "durationMs",
-        )
+        return kind, _known(item, *APP_SERVER_ITEM_FIELDS["dynamicToolCall"])
     if item_type == "webSearch":
         return ("search" if completed else "search_started"), _known(
-            item, "query", "action", "results"
+            item, *APP_SERVER_ITEM_FIELDS["webSearch"]
         )
     return ("item_completed" if completed else "item_started"), {"item_type": item_type}
 

--- a/src/spotter/observability.py
+++ b/src/spotter/observability.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import re
 import time
 from collections import Counter
 from collections.abc import Iterable, Mapping
@@ -144,41 +145,36 @@ _ITEM_FAMILY: dict[str, tuple[EvidenceFamily, ...]] = {
     "webSearch": (EvidenceFamily.REPOSITORY_EXPLORATION,),
 }
 
-# Source fields intentionally preserved by the normalizer. Fields not listed here are either
-# identity/lifecycle metadata or deliberately excluded content (for example raw reasoning).
-_PRESERVED_FIELDS: dict[str, dict[str, str]] = {
-    "commandExecution": {
-        "params.item.command": "command",
-        "params.item.cwd": "cwd",
-        "params.item.status": "status",
-        "params.item.aggregatedOutput": "aggregatedOutput",
-        "params.item.exitCode": "exitCode",
-        "params.item.durationMs": "durationMs",
-        "params.item.source": "source",
-    },
-    "fileChange": {"params.item.changes": "changes", "params.item.status": "status"},
-    "mcpToolCall": {
-        "params.item.server": "server",
-        "params.item.tool": "tool",
-        "params.item.arguments": "arguments",
-        "params.item.status": "status",
-        "params.item.result": "result",
-        "params.item.error": "error",
-    },
-    "dynamicToolCall": {
-        "params.item.namespace": "namespace",
-        "params.item.tool": "tool",
-        "params.item.arguments": "arguments",
-        "params.item.status": "status",
-        "params.item.success": "success",
-        "params.item.contentItems": "contentItems",
-    },
-    "reasoning": {"params.item.summary": "summary"},
-    "plan": {"params.item.text": "text"},
-    "userMessage": {"params.item.content": "content"},
+# Shared with CodexTraceNormalizer so adding a normalized field cannot silently
+# leave source-vs-adapter audit sensitivity behind.
+APP_SERVER_ITEM_FIELDS: dict[str, tuple[str, ...]] = {
+    "commandExecution": (
+        "command",
+        "cwd",
+        "status",
+        "aggregatedOutput",
+        "exitCode",
+        "durationMs",
+        "source",
+    ),
+    "fileChange": ("changes", "status"),
+    "mcpToolCall": ("server", "tool", "arguments", "status", "result", "error", "durationMs"),
+    "dynamicToolCall": (
+        "namespace",
+        "tool",
+        "arguments",
+        "status",
+        "success",
+        "contentItems",
+        "durationMs",
+    ),
+    "reasoning": ("summary",),
+    "plan": ("text",),
+    "userMessage": ("content",),
+    "webSearch": ("query", "action", "results"),
 }
 
-_PRESERVED_METHOD_FIELDS: dict[str, dict[str, str]] = {
+APP_SERVER_METHOD_FIELDS: dict[str, dict[str, str]] = {
     "thread/started": {
         "params.thread.cwd": "cwd",
         "params.thread.sessionId": "sessionId",
@@ -202,6 +198,11 @@ _PRESERVED_METHOD_FIELDS: dict[str, dict[str, str]] = {
         "params.tokenUsage.total": "total",
         "params.tokenUsage.modelContextWindow": "modelContextWindow",
     },
+}
+
+_PRESERVED_FIELDS = {
+    item_type: {f"params.item.{field}": field for field in fields}
+    for item_type, fields in APP_SERVER_ITEM_FIELDS.items()
 }
 
 
@@ -296,7 +297,10 @@ class SourceAuditStore:
         with lock_path.open("a") as lock:
             flock(lock, LOCK_EX)
             try:
-                lines = self.path.read_text(encoding="utf-8").splitlines()
+                content = self.path.read_text(encoding="utf-8")
+                if content and not content.endswith("\n"):
+                    content = content.rsplit("\n", 1)[0]
+                lines = content.splitlines()
             finally:
                 flock(lock, LOCK_UN)
         samples = []
@@ -533,13 +537,13 @@ def _source_status(
     source_fields: tuple[str, ...],
     event: TraceEvent,
 ) -> CoverageStatus:
-    if any("encrypted" in field.lower() for field in source_fields):
+    if any(re.search(r"(?:^|[._-])encrypted(?:$|[._-]|[A-Z])", field) for field in source_fields):
         return CoverageStatus.OBSERVED_ENCRYPTED
     families = _families_for(raw_event.method, item_type)
     if not families or event.kind == "runtime_event_unknown":
         return CoverageStatus.UNKNOWN
     preservation = _PRESERVED_FIELDS.get(
-        item_type or "", _PRESERVED_METHOD_FIELDS.get(raw_event.method, {})
+        item_type or "", APP_SERVER_METHOD_FIELDS.get(raw_event.method, {})
     )
     lost = [
         target

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -10,6 +10,7 @@ from spotter.cli import main
 from spotter.identity import IdentityProvenance, RuntimeIdentity, ThreadId
 from spotter.ingestion import AppServerTraceIngestor, CodexTraceNormalizer
 from spotter.observability import (
+    APP_SERVER_ITEM_FIELDS,
     CoverageStatus,
     EvidenceFamily,
     EvidenceTiming,
@@ -82,6 +83,43 @@ def test_source_field_present_but_trace_drops_it_is_adapter_loss() -> None:
     dropped = replace(normalized, payload={"command": "pytest", "status": "completed"})
 
     assert source_audit_sample(raw, dropped).status == CoverageStatus.ADAPTER_DROPPED
+
+
+def test_normalizer_and_audit_share_the_item_field_whitelist() -> None:
+    for item_type, fields in APP_SERVER_ITEM_FIELDS.items():
+        raw = _raw(
+            "item/completed",
+            {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "item": {
+                    "id": f"{item_type}-1",
+                    "type": item_type,
+                    **dict.fromkeys(fields, "synthetic"),
+                },
+            },
+        )
+        event = CodexTraceNormalizer().normalize(raw)
+
+        assert source_audit_sample(raw, event).status == CoverageStatus.OBSERVED_EXACT
+
+
+def test_unencrypted_field_name_is_not_classified_as_ciphertext() -> None:
+    raw = _raw(
+        "item/completed",
+        {
+            "threadId": "thread-1",
+            "turnId": "turn-1",
+            "item": {
+                "id": "future-1",
+                "type": "futureItem",
+                "unencryptedContent": "synthetic",
+            },
+        },
+    )
+    event = CodexTraceNormalizer().normalize(raw)
+
+    assert source_audit_sample(raw, event).status == CoverageStatus.UNKNOWN
 
 
 @pytest.mark.parametrize(
@@ -158,6 +196,7 @@ def test_shape_audit_is_bounded_private_and_rejects_corruption(tmp_path: Path) -
     assert store.path.stat().st_mode & 0o777 == 0o600
     with store.path.open("ab") as sink:
         sink.write(b'{"torn":')
+    assert len(store.load()) == 2
     store.record(raw, event, disposition="ingested")
     assert len(store.load()) == 3
     store.path.write_text("not-json\n")


### PR DESCRIPTION
## Summary

Addresses the three actionable follow-ups from the merged PR #120 review:

- ignore an unterminated final audit line during read-only reports
- match encrypted field segments without treating unencryptedContent as ciphertext
- make the normalizer and source audit consume one shared field whitelist, including MCP/dynamic duration and web-search fields

## Verification

- ruff format --check .
- ruff check .
- mypy src tests
- pytest (378 passed)

Refs #37