### PR TITLE
fix(observe): detect camel-case encrypted fields

### DIFF
--- a/src/spotter/observability.py
+++ b/src/spotter/observability.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from spotter.thread_state import ThreadState
 
 SOURCE_AUDIT_RELATIVE_PATH = Path("source-audit") / "samples.jsonl"
+_FIELD_SEGMENT = re.compile(r"[._-]|(?<=[a-z0-9])(?=[A-Z])")
 
 
 class ObservabilityError(ValueError):
@@ -537,7 +538,7 @@ def _source_status(
     source_fields: tuple[str, ...],
     event: TraceEvent,
 ) -> CoverageStatus:
-    if any(re.search(r"(?:^|[._-])encrypted(?:$|[._-]|[A-Z])", field) for field in source_fields):
+    if any(_is_encrypted_field(field) for field in source_fields):
         return CoverageStatus.OBSERVED_ENCRYPTED
     families = _families_for(raw_event.method, item_type)
     if not families or event.kind == "runtime_event_unknown":
@@ -678,6 +679,10 @@ def _path_has_value(raw: Mapping[str, Any], path: str) -> bool:
             return False
         value = value[component]
     return value is not None
+
+
+def _is_encrypted_field(field: str) -> bool:
+    return any(segment.casefold() == "encrypted" for segment in _FIELD_SEGMENT.split(field))
 
 
 def _required_string(raw: Mapping[str, Any], key: str) -> str:

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -104,7 +104,18 @@ def test_normalizer_and_audit_share_the_item_field_whitelist() -> None:
         assert source_audit_sample(raw, event).status == CoverageStatus.OBSERVED_EXACT
 
 
-def test_unencrypted_field_name_is_not_classified_as_ciphertext() -> None:
+@pytest.mark.parametrize(
+    ("field", "expected"),
+    [
+        ("encryptedContent", CoverageStatus.OBSERVED_ENCRYPTED),
+        ("childEncryptedContent", CoverageStatus.OBSERVED_ENCRYPTED),
+        ("isEncrypted", CoverageStatus.OBSERVED_ENCRYPTED),
+        ("unencryptedContent", CoverageStatus.UNKNOWN),
+    ],
+)
+def test_encrypted_field_names_follow_wire_name_segments(
+    field: str, expected: CoverageStatus
+) -> None:
     raw = _raw(
         "item/completed",
         {
@@ -113,13 +124,13 @@ def test_unencrypted_field_name_is_not_classified_as_ciphertext() -> None:
             "item": {
                 "id": "future-1",
                 "type": "futureItem",
-                "unencryptedContent": "synthetic",
+                field: "synthetic",
             },
         },
     )
     event = CodexTraceNormalizer().normalize(raw)
 
-    assert source_audit_sample(raw, event).status == CoverageStatus.UNKNOWN
+    assert source_audit_sample(raw, event).status == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Addresses the remaining PR #121 review wrinkle by splitting source field paths on separators and camelCase boundaries before checking for an encrypted segment. This recognizes encryptedContent, childEncryptedContent, and isEncrypted without regressing unencryptedContent.

## Verification

- ruff format --check .
- ruff check .
- mypy src tests
- pytest (381 passed)

Refs #37