### PR TITLE
feat(metrics): report coverage-aware runtime costs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -338,6 +338,13 @@ version-mismatched responses and unsupported proposal shapes fail open. Daemon e
 time, and total Hook time are recorded separately so latency percentiles can be computed without putting
 aggregation on the synchronous path.
 
+`spotter metrics` projects these durable records into separate accounting domains: Main semantic
+actions and token observations, Spotter semantic reviewer calls/tokens, deterministic Hook/IPC
+latency, timing coverage, and journal storage. Hook and App Server action surfaces are reported
+separately during migration rather than summed. Token totals remain `cumulative/unknown-scope`, and
+missing token/timing/latency data is printed as unknown with an explicit coverage denominator. Source
+wall time is never subtracted from receipt wall time to manufacture a latency across clock domains.
+
 ## 4.5 Turn completion
 
 ```text

--- a/docs/observability-baseline.md
+++ b/docs/observability-baseline.md
@@ -72,9 +72,9 @@ samples, and no failed/degraded session labels in this snapshot. Consequently:
 - no post-App-Server visible-in-time percentage can be stated;
 - no Hook-to-App-Server improvement can be stated;
 - no important failure-class ceiling can be stated; and
-- #37 remains open.
+- the post-App-Server evidence gate remains unmet.
 
-## Evidence needed to finish #37
+## Evidence still needed after #37's instrumentation work
 
 Collect representative failed or degraded App Server trajectories, label each failure boundary and
 minimal required evidence set, and run:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -120,7 +120,7 @@ The journal remains durable history and recovery input; it is not the normal hot
 
 - normalize App Server events into identity-rich Trace IR and durable history ([#85](https://github.com/spotter-agent/spotter/issues/85));
 - maintain live state from that stream ([#31](https://github.com/spotter-agent/spotter/issues/31));
-- record runtime cost/timing/provenance ([#33](https://github.com/spotter-agent/spotter/issues/33));
+- record runtime cost/timing/provenance ([#33](https://github.com/spotter-agent/spotter/issues/33)); durable records now project Main actions/token coverage, reviewer cost, gate latency, source/receipt timing coverage, and storage without treating unavailable values as zero, while resource sampling and delivery/outcome joins remain;
 - measure the actual observability ceiling after migration ([#37](https://github.com/spotter-agent/spotter/issues/37)); the [measurement instrument and current zero-sample baseline](observability-baseline.md) are documented, but labeled App Server failures are still required;
 - remove `SessionStart`, `UserPromptSubmit`, and `PostToolUse` only after parity is demonstrated, leaving the minimal enforcement bridge ([#86](https://github.com/spotter-agent/spotter/issues/86)).
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -98,7 +98,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Fork / replay | ✅ | Continue Codex from a shared prefix in a detached worktree | Measure fidelity/noise floor in #42 |
 | Shadow reviewer | ✅ | Produces `CONTINUE`, `VERIFY`, `NUDGE`; verdicts are recorded only | Move to event-driven candidates, then live delivery |
 | Audit / live state | 🟡 | Daemon-owned typed ThreadState distinguishes constraints, hypotheses, observations, verified facts, summaries, interventions, and coverage | Feed reviewer jobs and signals from immutable snapshots |
-| Evaluation labels / metrics | ✅ | Coverage-aware labeling and precision/FP metrics | Broader cost/miss/harm metrics (#33, #38, #34) |
+| Evaluation labels / metrics | 🟡 | Coverage-aware labels plus durable Main action/token/timing, reviewer, gate-latency, and storage projections; unavailable values remain unknown | Add live resource/queue/delivery telemetry and objective outcome joins (#33, #38, #34) |
 | Counterfactual harness | ✅ | Control/guidance same-prefix pairs can be prepared/run | Add mechanically scored tasks (#21) |
 | Standalone runtime | 🟡 | Long-lived process, IPC, lifecycle, isolated per-thread state, and App Server recovery ownership | Select and verify the shared endpoint during setup |
 | Runtime identity | ✅ | Logical threads/turns remain separate from per-connection attachment IDs and monotonically recovered epochs | Propagate the identity into future reviewer jobs |

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -52,6 +52,7 @@ from spotter.paths import secure_dir, spotter_home
 from spotter.redact import scan_text
 from spotter.replay import ReplayError, fork, plan_to_json
 from spotter.reviewer import last_usage, review
+from spotter.runtime_metrics import measure_runtime_costs, render_runtime_costs
 from spotter.snapshot import (
     SnapshotError,
     StepJournal,
@@ -763,6 +764,7 @@ def _metrics_main(session: str | None) -> int:
         print("no journals found", file=sys.stderr)
         return 1
     gates: dict[str, Tally] = {}
+    runtime_journals: list[tuple[list[StepRecord], int]] = []
     blind_spots: dict[str, int] = {}
     reviewer = ceiling = Tally()
     for journal in journals:
@@ -771,6 +773,7 @@ def _metrics_main(session: str | None) -> int:
         except SnapshotError as error:
             print(f"{journal.stem}: unreadable journal ({error})", file=sys.stderr)
             continue
+        runtime_journals.append((records, journal.stat().st_size))
         try:
             session_gates, session_reviewer, session_ceiling = tally_session(journal.stem, records)
         except LabelError as error:
@@ -799,6 +802,7 @@ def _metrics_main(session: str | None) -> int:
     print("  " + reviewer.rate_line("interventions", "correct"))
     print("P1 observability ceiling (label failed sessions visible|invisible):")
     print("  " + ceiling.rate_line("sessions", "visible"))
+    print(render_runtime_costs(measure_runtime_costs(runtime_journals)))
     return 0
 
 

--- a/src/spotter/runtime_metrics.py
+++ b/src/spotter/runtime_metrics.py
@@ -1,0 +1,267 @@
+"""Coverage-aware cost and timing projection from durable trajectory records."""
+
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from statistics import mean
+
+from spotter.snapshot import StepRecord
+
+_START_KINDS = {"tool_proposal", "command_started", "tool_started", "file_change_started"}
+_OUTCOME_KINDS = {"tool_result", "command_result", "file_edit"}
+
+
+@dataclass(frozen=True)
+class SurfaceCost:
+    actions: int = 0
+    action_observations: int = 0
+    outcomes: int = 0
+    outcome_observations: int = 0
+    classified_outcomes: int = 0
+    failed_outcomes: int = 0
+
+
+@dataclass(frozen=True)
+class RuntimeCostReport:
+    sessions: int
+    events: int
+    surfaces: Mapping[str, SurfaceCost]
+    completed_turns: int
+    token_turns: int
+    token_observations: int
+    cumulative_main_tokens: int | None
+    reviewer_calls: int
+    reviewer_tokens: int | None
+    tool_duration_ms: tuple[float, ...]
+    gate_calls: int
+    hook_ms: tuple[float, ...]
+    ipc_ms: tuple[float, ...]
+    daemon_evaluation_ms: tuple[float, ...]
+    source_timestamps: int
+    receipt_timestamps: int
+    journal_bytes: int
+
+
+def measure_runtime_costs(
+    journals: Iterable[tuple[Iterable[StepRecord], int]],
+) -> RuntimeCostReport:
+    surfaces: dict[str, SurfaceCost] = {"hook": SurfaceCost(), "app_server": SurfaceCost()}
+    sessions = events = completed_turns = token_turns = token_observations = 0
+    cumulative_main_tokens = reviewer_calls = reviewer_tokens = journal_bytes = gate_calls = 0
+    main_tokens_known = reviewer_tokens_known = False
+    tool_duration_ms: list[float] = []
+    hook_ms: list[float] = []
+    ipc_ms: list[float] = []
+    daemon_evaluation_ms: list[float] = []
+    source_timestamps = receipt_timestamps = 0
+
+    for records_iter, size in journals:
+        records = tuple(records_iter)
+        sessions += 1
+        journal_bytes += size
+        surface = _surface(records)
+        actions: set[str] = set()
+        outcomes: set[str] = set()
+        action_observations = outcome_observations = 0
+        classified: set[str] = set()
+        failed: set[str] = set()
+        completed: set[str] = set()
+        token_covered: set[str] = set()
+        latest_main_tokens: int | None = None
+        latest_reviewer_tokens: int | None = None
+        for record in records:
+            event = record.event
+            events += 1
+            source_timestamps += event.occurred_at is not None
+            receipt_timestamps += record.at is not None
+            key = _action_key(record)
+            if event.kind in _START_KINDS | _OUTCOME_KINDS:
+                action_observations += 1
+                if key is not None:
+                    actions.add(key)
+            if event.kind in _OUTCOME_KINDS:
+                outcome_observations += 1
+                if key is not None:
+                    outcomes.add(key)
+                    failure = _outcome_failure(event.payload)
+                    if failure is not None:
+                        classified.add(key)
+                    if failure is True:
+                        failed.add(key)
+            duration = _number(event.payload.get("durationMs"))
+            if duration is not None and event.kind in _OUTCOME_KINDS:
+                tool_duration_ms.append(duration)
+            turn_id = _turn_id(record)
+            if event.kind == "turn_completed" and turn_id is not None:
+                completed.add(turn_id)
+            if event.kind == "token_usage":
+                token_observations += 1
+                if turn_id is not None:
+                    token_covered.add(turn_id)
+                observed_tokens = _total_tokens(event.payload)
+                if observed_tokens is not None:
+                    latest_main_tokens = observed_tokens
+            if event.kind == "reviewer_decision":
+                reviewer_calls += 1
+                spend = event.payload.get("spend")
+                if isinstance(spend, Mapping):
+                    value = spend.get("session_tokens")
+                    if isinstance(value, int) and not isinstance(value, bool):
+                        latest_reviewer_tokens = value
+            if event.kind == "gate_ipc":
+                gate_calls += 1
+                _append_number(hook_ms, event.payload.get("hook_ms"))
+                _append_number(ipc_ms, event.payload.get("ipc_ms"))
+                _append_number(daemon_evaluation_ms, event.payload.get("daemon_evaluation_ms"))
+        current = surfaces[surface]
+        surfaces[surface] = SurfaceCost(
+            actions=current.actions + len(actions),
+            action_observations=current.action_observations + action_observations,
+            outcomes=current.outcomes + len(outcomes),
+            outcome_observations=current.outcome_observations + outcome_observations,
+            classified_outcomes=current.classified_outcomes + len(classified),
+            failed_outcomes=current.failed_outcomes + len(failed),
+        )
+        completed_turns += len(completed)
+        token_turns += len(completed & token_covered)
+        if latest_main_tokens is not None:
+            main_tokens_known = True
+            cumulative_main_tokens += latest_main_tokens
+        if latest_reviewer_tokens is not None:
+            reviewer_tokens_known = True
+            reviewer_tokens += latest_reviewer_tokens
+
+    return RuntimeCostReport(
+        sessions,
+        events,
+        surfaces,
+        completed_turns,
+        token_turns,
+        token_observations,
+        cumulative_main_tokens if main_tokens_known else None,
+        reviewer_calls,
+        reviewer_tokens if reviewer_tokens_known else None,
+        tuple(tool_duration_ms),
+        gate_calls,
+        tuple(hook_ms),
+        tuple(ipc_ms),
+        tuple(daemon_evaluation_ms),
+        source_timestamps,
+        receipt_timestamps,
+        journal_bytes,
+    )
+
+
+def render_runtime_costs(report: RuntimeCostReport) -> str:
+    lines = ["Runtime cost / efficiency (coverage-aware):", "  Main semantic actions:"]
+    for surface, cost in report.surfaces.items():
+        lines.append(
+            f"    {surface}: actions={cost.actions}/{cost.action_observations} correlated, "
+            f"outcomes={cost.outcomes}/{cost.outcome_observations} correlated, "
+            f"failed={cost.failed_outcomes}/{cost.classified_outcomes} classified"
+        )
+    tokens = (
+        f"{report.cumulative_main_tokens} cumulative/unknown-scope tokens"
+        if report.cumulative_main_tokens is not None
+        else "unknown"
+    )
+    lines.append(
+        f"  Main tokens: {tokens}; turn coverage "
+        f"{report.token_turns}/{report.completed_turns}; observations={report.token_observations}"
+    )
+    reviewer_tokens = (
+        str(report.reviewer_tokens) if report.reviewer_tokens is not None else "unknown"
+    )
+    lines.append(
+        f"  Spotter semantic: reviewer_calls={report.reviewer_calls}, "
+        f"recorded_session_tokens={reviewer_tokens}"
+    )
+    lines.append(
+        f"  Spotter deterministic: gate_calls={report.gate_calls}; "
+        f"hook={_sample(report.hook_ms, report.gate_calls)}, "
+        f"ipc={_sample(report.ipc_ms, report.gate_calls)}, "
+        f"daemon_eval={_sample(report.daemon_evaluation_ms, report.gate_calls)}"
+    )
+    tool_outcomes = sum(cost.outcome_observations for cost in report.surfaces.values())
+    lines.append(
+        f"  Timing: receipt_wall={report.receipt_timestamps}/{report.events}, "
+        f"source={report.source_timestamps}/{report.events}, "
+        f"tool_duration={_sample(report.tool_duration_ms, tool_outcomes)}"
+    )
+    lines.append(
+        f"  Storage: journals={report.journal_bytes} bytes across {report.sessions} sessions"
+    )
+    return "\n".join(lines)
+
+
+def _surface(records: tuple[StepRecord, ...]) -> str:
+    return (
+        "app_server"
+        if any(
+            record.event.connection_epoch is not None
+            or (
+                record.event.provenance is not None
+                and record.event.provenance.source == "codex_app_server"
+            )
+            for record in records
+        )
+        else "hook"
+    )
+
+
+def _action_key(record: StepRecord) -> str | None:
+    event = record.event
+    value = event.operation_id or event.payload.get("tool_use_id") or event.event_id
+    turn = _turn_id(record) or "unknown-turn"
+    return f"{turn}:{value}" if value is not None else None
+
+
+def _turn_id(record: StepRecord) -> str | None:
+    identity = record.event.identity
+    if identity is not None and identity.turn_id is not None:
+        return identity.turn_id.value
+    value = record.event.payload.get("turn_id")
+    return value if isinstance(value, str) and value else None
+
+
+def _total_tokens(payload: Mapping[str, object]) -> int | None:
+    total = payload.get("total")
+    value = total.get("totalTokens") if isinstance(total, Mapping) else None
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+
+
+def _outcome_failure(payload: Mapping[str, object]) -> bool | None:
+    response = payload.get("tool_response")
+    exit_code = payload.get("exitCode")
+    if isinstance(response, Mapping):
+        exit_code = response.get("exit_code", exit_code)
+        ok = response.get("ok")
+        if isinstance(ok, bool):
+            return not ok
+    if isinstance(exit_code, int) and not isinstance(exit_code, bool):
+        return exit_code != 0
+    status = payload.get("status")
+    if status in {"failed", "error", "interrupted", "cancelled"}:
+        return True
+    if status in {"completed", "succeeded", "success", "passed"}:
+        return False
+    return None
+
+
+def _number(value: object) -> float | None:
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        return None
+    parsed = float(value)
+    return parsed if math.isfinite(parsed) and parsed >= 0 else None
+
+
+def _append_number(target: list[float], value: object) -> None:
+    parsed = _number(value)
+    if parsed is not None:
+        target.append(parsed)
+
+
+def _sample(values: tuple[float, ...], eligible: int) -> str:
+    if not values:
+        return f"unknown (0/{eligible})"
+    return f"avg={mean(values):.2f}ms max={max(values):.2f}ms ({len(values)}/{eligible})"

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -206,6 +206,7 @@ def test_cli_label_and_metrics_roundtrip(capsys: pytest.CaptureFixture[str]) -> 
     assert "P3 gate false positives" in out
     assert "P4 reviewer precision" in out
     assert "P1 observability ceiling" in out
+    assert "Runtime cost / efficiency (coverage-aware)" in out
     assert "too few decided labels" in out  # honest about n=1
 
 

--- a/tests/test_runtime_metrics.py
+++ b/tests/test_runtime_metrics.py
@@ -1,0 +1,125 @@
+from spotter.identity import IdentityProvenance, RuntimeIdentity, ThreadId, TurnId
+from spotter.runtime_metrics import measure_runtime_costs, render_runtime_costs
+from spotter.snapshot import StepRecord
+from spotter.trace import TraceEvent, TraceProvenance
+
+
+def _record(step: int, event: TraceEvent, *, at: float | None = 1.0) -> StepRecord:
+    return StepRecord(step, event, None, at)
+
+
+def test_runtime_costs_keep_surfaces_domains_and_coverage_separate() -> None:
+    hook = [
+        _record(
+            0,
+            TraceEvent(
+                "tool_proposal",
+                {"tool_use_id": "call-1", "turn_id": "legacy-turn"},
+                provenance=TraceProvenance("codex_hook", "PreToolUse"),
+            ),
+        ),
+        _record(
+            1,
+            TraceEvent(
+                "tool_result",
+                {
+                    "tool_use_id": "call-1",
+                    "turn_id": "legacy-turn",
+                    "tool_response": {"exit_code": 1},
+                },
+                provenance=TraceProvenance("codex_hook", "PostToolUse"),
+            ),
+        ),
+        _record(
+            2,
+            TraceEvent(
+                "gate_ipc",
+                {"hook_ms": 3.0, "ipc_ms": 2.0, "daemon_evaluation_ms": 1.0},
+            ),
+        ),
+        _record(
+            3,
+            TraceEvent(
+                "reviewer_decision",
+                {"spend": {"session_tokens": 25}},
+            ),
+        ),
+    ]
+    identity = RuntimeIdentity(
+        ThreadId("thread-1"),
+        TurnId("turn-1"),
+        None,
+        IdentityProvenance("codex", "external-thread", "external-turn"),
+    )
+
+    def app(kind: str, payload: dict[str, object], operation: str | None = None) -> TraceEvent:
+        return TraceEvent(
+            kind,
+            payload,
+            occurred_at=2.0,
+            identity=identity,
+            operation_id=operation,
+            provenance=TraceProvenance("codex_app_server", "synthetic"),
+            connection_epoch=1,
+        )
+
+    app_server = [
+        _record(0, app("command_started", {}, "command-1")),
+        _record(
+            1,
+            app(
+                "command_result",
+                {"status": "completed", "exitCode": 0, "durationMs": 10},
+                "command-1",
+            ),
+        ),
+        _record(2, app("token_usage", {"total": {"totalTokens": 14}})),
+        _record(3, app("turn_completed", {"status": "completed"})),
+    ]
+
+    report = measure_runtime_costs([(hook, 100), (app_server, 200)])
+
+    assert report.surfaces["hook"].actions == 1
+    assert report.surfaces["hook"].action_observations == 2
+    assert report.surfaces["hook"].classified_outcomes == 1
+    assert report.surfaces["hook"].failed_outcomes == 1
+    assert report.surfaces["app_server"].actions == 1
+    assert report.surfaces["app_server"].action_observations == 2
+    assert report.surfaces["app_server"].outcomes == 1
+    assert report.surfaces["app_server"].classified_outcomes == 1
+    assert report.completed_turns == report.token_turns == 1
+    assert report.cumulative_main_tokens == 14
+    assert report.reviewer_calls == 1
+    assert report.reviewer_tokens == 25
+    assert report.gate_calls == 1
+    assert report.tool_duration_ms == (10.0,)
+    assert report.source_timestamps == 4
+    assert report.receipt_timestamps == report.events == 8
+    assert report.journal_bytes == 300
+
+    rendered = render_runtime_costs(report)
+    assert "turn coverage 1/1" in rendered
+    assert "hook: actions=1/2 correlated, outcomes=1/1 correlated" in rendered
+    assert "app_server: actions=1/2 correlated, outcomes=1/1 correlated" in rendered
+
+
+def test_unavailable_runtime_metrics_render_unknown_not_zero() -> None:
+    report = measure_runtime_costs([([_record(0, TraceEvent("session_start"), at=None)], 10)])
+
+    rendered = render_runtime_costs(report)
+    assert "Main tokens: unknown" in rendered
+    assert "hook=unknown (0/0)" in rendered
+    assert "receipt_wall=0/1" in rendered
+
+
+def test_uncorrelated_action_observations_do_not_invent_semantic_identity() -> None:
+    records = [
+        _record(0, TraceEvent("tool_proposal")),
+        _record(1, TraceEvent("tool_result", {"tool_response": {"exit_code": 1}})),
+    ]
+
+    report = measure_runtime_costs([(records, 10)])
+    hook = report.surfaces["hook"]
+    assert hook.actions == hook.outcomes == hook.classified_outcomes == 0
+    assert hook.action_observations == 2
+    assert hook.outcome_observations == 1


### PR DESCRIPTION
## Why

#33 requires cost and timing to be visible without making unavailable data look free or deriving latency across unrelated clocks. #86 is dependency-unblocked, but its own parity gate remains unmet because the current #37 baseline has zero App Server sessions and zero labeled failures, so removing observation Hooks now would be unsafe.

## What changed

- project durable journals into separate Main, Spotter semantic, and deterministic/runtime accounting domains
- correlate action starts/outcomes by semantic identity and report correlation coverage instead of inventing identity for uncorrelated events
- report token scope and turn coverage, reviewer calls/session tokens, Hook/IPC/evaluation latency coverage, source/receipt timing coverage, tool durations, and storage
- keep Hook and App Server surfaces separate during migration and print unavailable values as unknown
- avoid subtracting source and receipt wall clocks

This is a complete foundational slice of #33; resource sampling, queue/delivery stages, and objective outcome joins remain, so this PR does not close the issue.

## Validation

- ruff format --check .
- ruff check .
- mypy src tests
- pytest (384 passed)
- spotter metrics against the current 9-session local corpus

Refs #33