### PR TITLE
fix(metrics): unify outcome classification

### DIFF
--- a/src/spotter/observability.py
+++ b/src/spotter/observability.py
@@ -15,6 +15,7 @@ from fcntl import LOCK_EX, LOCK_UN, flock
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from spotter.outcomes import outcome_failure
 from spotter.snapshot import StepRecord
 from spotter.trace import TraceEvent
 
@@ -616,10 +617,7 @@ def _trace_status(event: TraceEvent) -> CoverageStatus:
 
 
 def _hook_outcome_visible(payload: Mapping[str, Any]) -> bool:
-    response = payload.get("tool_response")
-    if isinstance(response, Mapping):
-        return isinstance(response.get("exit_code"), int)
-    return isinstance(response, str) and "Exit code:" in response
+    return outcome_failure(payload) is not None
 
 
 def state_coverage_status(event: TraceEvent, state: ThreadState) -> CoverageStatus:

--- a/src/spotter/outcomes.py
+++ b/src/spotter/outcomes.py
@@ -1,0 +1,49 @@
+"""Shared classification for runtime outcome payloads."""
+
+import re
+from collections.abc import Mapping
+
+_EXIT_CODE_TEXT = re.compile(r"(?im)^Exit code: (-?\d+)\s*$")
+_FAILED_STATUSES = {"cancelled", "declined", "error", "failed", "interrupted"}
+_SUCCEEDED_STATUSES = {"completed", "passed", "succeeded", "success"}
+
+
+def outcome_failure(payload: Mapping[str, object]) -> bool | None:
+    """Return failure, success, or unknown for any normalized runtime outcome."""
+
+    response = payload.get("tool_response")
+    signals: list[bool] = []
+
+    if isinstance(response, Mapping):
+        _append_exit_code(signals, response.get("exit_code"))
+        _append_success(signals, response.get("ok"))
+        _append_status(signals, response.get("status"))
+    elif isinstance(response, str) and (match := _EXIT_CODE_TEXT.search(response)):
+        signals.append(int(match.group(1)) != 0)
+
+    _append_exit_code(signals, payload.get("exitCode", payload.get("exit_code")))
+    _append_success(signals, payload.get("success"))
+    _append_status(signals, payload.get("status"))
+
+    if any(signals):
+        return True
+    return False if signals else None
+
+
+def _append_exit_code(signals: list[bool], value: object) -> None:
+    if isinstance(value, int) and not isinstance(value, bool):
+        signals.append(value != 0)
+
+
+def _append_success(signals: list[bool], value: object) -> None:
+    if isinstance(value, bool):
+        signals.append(not value)
+
+
+def _append_status(signals: list[bool], value: object) -> None:
+    if not isinstance(value, str):
+        return
+    if value in _FAILED_STATUSES:
+        signals.append(True)
+    elif value in _SUCCEEDED_STATUSES:
+        signals.append(False)

--- a/src/spotter/runtime_metrics.py
+++ b/src/spotter/runtime_metrics.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from statistics import mean
 
+from spotter.outcomes import outcome_failure
 from spotter.snapshot import StepRecord
 
 _START_KINDS = {"tool_proposal", "command_started", "tool_started", "file_change_started"}
@@ -83,7 +84,7 @@ def measure_runtime_costs(
                 outcome_observations += 1
                 if key is not None:
                     outcomes.add(key)
-                    failure = _outcome_failure(event.payload)
+                    failure = outcome_failure(event.payload)
                     if failure is not None:
                         classified.add(key)
                     if failure is True:
@@ -125,6 +126,8 @@ def measure_runtime_costs(
         completed_turns += len(completed)
         token_turns += len(completed & token_covered)
         if latest_main_tokens is not None:
+            # Each journal represents one session; use only its latest cumulative
+            # observation so repeated token updates are not double-counted.
             main_tokens_known = True
             cumulative_main_tokens += latest_main_tokens
         if latest_reviewer_tokens is not None:
@@ -156,8 +159,9 @@ def render_runtime_costs(report: RuntimeCostReport) -> str:
     lines = ["Runtime cost / efficiency (coverage-aware):", "  Main semantic actions:"]
     for surface, cost in report.surfaces.items():
         lines.append(
-            f"    {surface}: actions={cost.actions}/{cost.action_observations} correlated, "
-            f"outcomes={cost.outcomes}/{cost.outcome_observations} correlated, "
+            f"    {surface}: actions={cost.actions} "
+            f"(from {_observations(cost.action_observations)}), outcomes={cost.outcomes} "
+            f"(from {_observations(cost.outcome_observations)}), "
             f"failed={cost.failed_outcomes}/{cost.classified_outcomes} classified"
         )
     tokens = (
@@ -230,24 +234,6 @@ def _total_tokens(payload: Mapping[str, object]) -> int | None:
     return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
 
 
-def _outcome_failure(payload: Mapping[str, object]) -> bool | None:
-    response = payload.get("tool_response")
-    exit_code = payload.get("exitCode")
-    if isinstance(response, Mapping):
-        exit_code = response.get("exit_code", exit_code)
-        ok = response.get("ok")
-        if isinstance(ok, bool):
-            return not ok
-    if isinstance(exit_code, int) and not isinstance(exit_code, bool):
-        return exit_code != 0
-    status = payload.get("status")
-    if status in {"failed", "error", "interrupted", "cancelled"}:
-        return True
-    if status in {"completed", "succeeded", "success", "passed"}:
-        return False
-    return None
-
-
 def _number(value: object) -> float | None:
     if not isinstance(value, int | float) or isinstance(value, bool):
         return None
@@ -265,3 +251,7 @@ def _sample(values: tuple[float, ...], eligible: int) -> str:
     if not values:
         return f"unknown (0/{eligible})"
     return f"avg={mean(values):.2f}ms max={max(values):.2f}ms ({len(values)}/{eligible})"
+
+
+def _observations(count: int) -> str:
+    return f"{count} observation{'s' if count != 1 else ''}"

--- a/src/spotter/thread_state.py
+++ b/src/spotter/thread_state.py
@@ -6,6 +6,7 @@ from enum import StrEnum
 from typing import Any
 
 from spotter.identity import RuntimeIdentity, ThreadId, TurnId
+from spotter.outcomes import outcome_failure
 from spotter.snapshot import StepRecord
 from spotter.trace import TraceEvent
 
@@ -675,31 +676,14 @@ def _outcome_text(event: TraceEvent) -> str:
 
 
 def _failed(payload: Mapping[str, Any]) -> bool:
-    status = payload.get("status")
-    exit_code = payload.get("exitCode", payload.get("exit_code"))
-    success = payload.get("success")
-    return (
-        status in {"failed", "error", "declined"}
-        or (isinstance(exit_code, int) and not isinstance(exit_code, bool) and exit_code != 0)
-        or success is False
-    )
+    return outcome_failure(payload) is True
 
 
 def _validation_status(payload: Mapping[str, Any]) -> ValidationStatus:
-    status = payload.get("status")
-    success = payload.get("success")
-    exit_code = payload.get("exitCode", payload.get("exit_code"))
-    if (
-        status in {"failed", "error"}
-        or success is False
-        or (isinstance(exit_code, int) and not isinstance(exit_code, bool) and exit_code != 0)
-    ):
+    failure = outcome_failure(payload)
+    if failure is True:
         return ValidationStatus.FAILED
-    if (
-        status in {"passed", "completed"}
-        or success is True
-        or (isinstance(exit_code, int) and not isinstance(exit_code, bool) and exit_code == 0)
-    ):
+    if failure is False:
         return ValidationStatus.PASSED
     return ValidationStatus.UNKNOWN
 

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -1,0 +1,30 @@
+import pytest
+
+from spotter.outcomes import outcome_failure
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"tool_response": {"exit_code": 0}}, False),
+        ({"tool_response": {"exit_code": 2}}, True),
+        ({"tool_response": {"ok": True}}, False),
+        ({"tool_response": {"ok": False}}, True),
+        ({"tool_response": "output\nExit code: 0\n"}, False),
+        ({"exitCode": 1}, True),
+        ({"success": True}, False),
+        ({"status": "cancelled"}, True),
+        ({"status": "completed"}, False),
+        ({"tool_response": {"exit_code": True}}, None),
+        ({"tool_response": "output without an exit status"}, None),
+        ({}, None),
+    ],
+)
+def test_outcome_failure_normalizes_runtime_shapes(
+    payload: dict[str, object], expected: bool | None
+) -> None:
+    assert outcome_failure(payload) is expected
+
+
+def test_failure_signal_wins_over_conflicting_success_signal() -> None:
+    assert outcome_failure({"exitCode": 1, "status": "completed"}) is True

--- a/tests/test_runtime_metrics.py
+++ b/tests/test_runtime_metrics.py
@@ -99,8 +99,10 @@ def test_runtime_costs_keep_surfaces_domains_and_coverage_separate() -> None:
 
     rendered = render_runtime_costs(report)
     assert "turn coverage 1/1" in rendered
-    assert "hook: actions=1/2 correlated, outcomes=1/1 correlated" in rendered
-    assert "app_server: actions=1/2 correlated, outcomes=1/1 correlated" in rendered
+    assert "hook: actions=1 (from 2 observations), outcomes=1 (from 1 observation)" in rendered
+    assert (
+        "app_server: actions=1 (from 2 observations), outcomes=1 (from 1 observation)" in rendered
+    )
 
 
 def test_unavailable_runtime_metrics_render_unknown_not_zero() -> None:

--- a/tests/test_thread_state.py
+++ b/tests/test_thread_state.py
@@ -336,6 +336,18 @@ def test_validation_and_unknown_coverage_never_infer_missing_outcomes() -> None:
     assert edited_after_validation.execution.validation == ValidationStatus.STALE
 
 
+def test_nested_hook_outcome_uses_shared_failure_classification() -> None:
+    state = ThreadStateStore().observe(
+        _event(
+            "tool_result",
+            {"tool_response": {"exit_code": 1}},
+            event_id="hook-failure",
+        )
+    )
+
+    assert state.execution.recent_failures[-1].provenance.event_id == "hook-failure"
+
+
 def test_hydration_skips_legacy_records_without_inventing_thread_identity() -> None:
     app_event = _event("thread_started", event_id="thread")
     records = [


### PR DESCRIPTION
## Summary
- share one failure/success/unknown classifier across runtime metrics, ThreadState, and observability coverage
- recognize Hook and App Server outcome shapes consistently without inventing missing outcomes
- clarify semantic-action observation counts and document the cumulative Main-token assumption

## Verification
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (398 passed)

Follow-up to #123. Part of #33.