### PR TITLE
feat(metrics): measure reviewer latency stages

### DIFF
--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -146,6 +146,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--reservation",
         help="review: token for a budget slot the caller already reserved (internal)",
     )
+    parser.add_argument("--review-job-id", help=argparse.SUPPRESS)
     parser.add_argument(
         "--check", help="experiment: success command run in each fork worktree (exit 0 = pass)"
     )
@@ -274,7 +275,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             config = SpotterConfig(MainAgentConfig("codex"), ReviewerConfig())
         if args.model:
             config = replace(config, reviewer=replace(config.reviewer, model=args.model))
-        return _review_main(args.session, config, window=args.window, reservation=args.reservation)
+        return _review_main(
+            args.session,
+            config,
+            window=args.window,
+            reservation=args.reservation,
+            review_job_id=args.review_job_id,
+        )
     if args.command == "fork":
         if not args.session or args.step is None:
             parser.error("fork requires --session and --step")
@@ -404,7 +411,12 @@ def _constraints_of(config: SpotterConfig) -> list[str]:
 
 
 def _review_main(
-    session: str, config: SpotterConfig, *, window: int, reservation: str | None = None
+    session: str,
+    config: SpotterConfig,
+    *,
+    window: int,
+    reservation: str | None = None,
+    review_job_id: str | None = None,
 ) -> int:
     """Shadow reviewer: judge the trajectory tail, journal the verdict, inject
     nothing. Injection rights are earned later via labeling + fork pairs."""
@@ -432,6 +444,15 @@ def _review_main(
         cancel(session, reservation)
         print("review failed: empty journal", file=sys.stderr)
         return 1
+    queued_at = next(
+        (
+            record.at
+            for record in reversed(records)
+            if record.event.kind == "review_job_queued"
+            and record.event.payload.get("review_job_id") == review_job_id
+        ),
+        None,
+    )
     try:
         # Check the ledger before spending, not after: the manual path calls
         # the model first, so a corrupt ledger would otherwise pay for a review
@@ -440,6 +461,17 @@ def _review_main(
     except LedgerCorrupt as error:
         print(f"review refused: {error}", file=sys.stderr)
         return 1
+    started = StepJournal(journal_file).record(
+        TraceEvent(
+            "review_inference_started",
+            {
+                "review_job_id": review_job_id,
+                "queue_ms": max(0.0, (time.time() - queued_at) * 1000)
+                if queued_at is not None
+                else None,
+            },
+        )
+    )
     constraints = _constraints_of(config)
     try:
         decision, digest = review(
@@ -451,7 +483,10 @@ def _review_main(
         # distinguishable from "reviewer silently died".
         with suppress(SnapshotError):
             StepJournal(journal_file).record(
-                TraceEvent("reviewer_error", {"error": str(error)[:300]})
+                TraceEvent(
+                    "reviewer_error",
+                    {"error": str(error)[:300], "review_job_id": review_job_id},
+                )
             )
         return 1
     # A reserved slot was already counted by the caller; charging again would
@@ -470,6 +505,11 @@ def _review_main(
                 "confidence": decision.confidence,
                 "model": config.reviewer.model,
                 "reviewed_upto": records[-1].step,
+                "review_job_id": review_job_id,
+                "timing": {
+                    "queue_ms": started.event.payload.get("queue_ms"),
+                    "inference_ms": decision.inference_ms,
+                },
                 "shadow": True,
                 # What the reviewer could actually see when it judged: a verdict
                 # made on a truncated view or with no goal must stay identifiable.

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -168,6 +168,14 @@ def _maybe_spawn_shadow_review(
         with suppress(SnapshotError, OSError):
             StepJournal(journal_file).record(TraceEvent(kind, {key: refusal}))
         return
+    review_job_id = f"proposal:{proposal_number}"
+    with suppress(SnapshotError, OSError):
+        StepJournal(journal_file).record(
+            TraceEvent(
+                "review_job_queued",
+                {"review_job_id": review_job_id},
+            )
+        )
     args = [
         sys.executable,
         "-m",
@@ -180,6 +188,8 @@ def _maybe_spawn_shadow_review(
         # The slot is already taken; the child settles the cost against it.
         "--reservation",
         token,
+        "--review-job-id",
+        review_job_id,
     ]
     if config_path is not None:
         # Without this the child builds a default config, so the constraints

--- a/src/spotter/reviewer.py
+++ b/src/spotter/reviewer.py
@@ -13,6 +13,7 @@ import json
 import os
 import subprocess
 import tempfile
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -73,6 +74,7 @@ class ReviewerDecision:
     reason: str
     confidence: float
     hypothesis: str = ""  # the assumption being flagged; "" when none
+    inference_ms: float | None = None
 
 
 def parse_decision(raw: str) -> ReviewerDecision:
@@ -202,11 +204,24 @@ def review(
         # not, refuse rather than send an unbounded request and interpret the
         # provider's error.
         raise RuntimeError(f"reviewer prompt exceeds budget after truncation: {len(prompt)} chars")
+    started = time.perf_counter_ns()
     decision = parse_decision(runner(model, prompt))
+    decision = ReviewerDecision(
+        decision.decision,
+        decision.failure_class,
+        decision.reason,
+        decision.confidence,
+        decision.hypothesis,
+        (time.perf_counter_ns() - started) / 1_000_000,
+    )
     if not digest.goal_present and decision.failure_class == "spec_drift":
         # Instruction alone is not enforcement: a model that answers spec_drift
         # without a specification is answering from imagination.
         decision = ReviewerDecision(
-            "continue", "none", "spec_drift claimed with no goal recorded; discarded", 0.0
+            "continue",
+            "none",
+            "spec_drift claimed with no goal recorded; discarded",
+            0.0,
+            inference_ms=decision.inference_ms,
         )
     return decision, digest

--- a/src/spotter/runtime_metrics.py
+++ b/src/spotter/runtime_metrics.py
@@ -33,6 +33,10 @@ class RuntimeCostReport:
     cumulative_main_tokens: int | None
     reviewer_calls: int
     reviewer_tokens: int | None
+    reviewer_jobs_queued: int
+    reviewer_jobs_started: int
+    reviewer_queue_ms: tuple[float, ...]
+    reviewer_inference_ms: tuple[float, ...]
     tool_duration_ms: tuple[float, ...]
     gate_calls: int
     hook_ms: tuple[float, ...]
@@ -49,8 +53,11 @@ def measure_runtime_costs(
     surfaces: dict[str, SurfaceCost] = {"hook": SurfaceCost(), "app_server": SurfaceCost()}
     sessions = events = completed_turns = token_turns = token_observations = 0
     cumulative_main_tokens = reviewer_calls = reviewer_tokens = journal_bytes = gate_calls = 0
+    reviewer_jobs_queued = reviewer_jobs_started = 0
     main_tokens_known = reviewer_tokens_known = False
     tool_duration_ms: list[float] = []
+    reviewer_queue_ms: list[float] = []
+    reviewer_inference_ms: list[float] = []
     hook_ms: list[float] = []
     ipc_ms: list[float] = []
     daemon_evaluation_ms: list[float] = []
@@ -109,6 +116,14 @@ def measure_runtime_costs(
                     value = spend.get("session_tokens")
                     if isinstance(value, int) and not isinstance(value, bool):
                         latest_reviewer_tokens = value
+                timing = event.payload.get("timing")
+                if isinstance(timing, Mapping):
+                    _append_number(reviewer_inference_ms, timing.get("inference_ms"))
+            if event.kind == "review_job_queued":
+                reviewer_jobs_queued += 1
+            if event.kind == "review_inference_started":
+                reviewer_jobs_started += 1
+                _append_number(reviewer_queue_ms, event.payload.get("queue_ms"))
             if event.kind == "gate_ipc":
                 gate_calls += 1
                 _append_number(hook_ms, event.payload.get("hook_ms"))
@@ -144,6 +159,10 @@ def measure_runtime_costs(
         cumulative_main_tokens if main_tokens_known else None,
         reviewer_calls,
         reviewer_tokens if reviewer_tokens_known else None,
+        reviewer_jobs_queued,
+        reviewer_jobs_started,
+        tuple(reviewer_queue_ms),
+        tuple(reviewer_inference_ms),
         tuple(tool_duration_ms),
         gate_calls,
         tuple(hook_ms),
@@ -176,9 +195,13 @@ def render_runtime_costs(report: RuntimeCostReport) -> str:
     reviewer_tokens = (
         str(report.reviewer_tokens) if report.reviewer_tokens is not None else "unknown"
     )
+    queue = _sample(report.reviewer_queue_ms, report.reviewer_jobs_started)
+    inference = _sample(report.reviewer_inference_ms, report.reviewer_calls)
+    jobs = f"{report.reviewer_calls}/{report.reviewer_jobs_started}/{report.reviewer_jobs_queued}"
     lines.append(
         f"  Spotter semantic: reviewer_calls={report.reviewer_calls}, "
-        f"recorded_session_tokens={reviewer_tokens}"
+        f"recorded_session_tokens={reviewer_tokens}; queue={queue}, "
+        f"inference={inference}; jobs={jobs} decided/started/queued"
     )
     lines.append(
         f"  Spotter deterministic: gate_calls={report.gate_calls}; "

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -9,9 +9,10 @@ import pytest
 import spotter.experiment as experiment
 from spotter.config import GatesConfig, MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.experiment import ArmResult, results_path, run_experiment, summarize
-from spotter.hook import run_hook
+from spotter.hook import journal_path, run_hook
 from spotter.paths import spotter_home
 from spotter.replay import ForkPlan
+from spotter.snapshot import StepJournal
 
 
 @pytest.fixture(autouse=True)
@@ -176,6 +177,9 @@ def test_cadence_forwards_user_config(monkeypatch: pytest.MonkeyPatch, tmp_path:
     # the slot was taken before spawning and is identified by a token, so the
     # child cannot claim a reservation it never received
     assert "--reservation" in argv and len(argv[argv.index("--reservation") + 1]) == 32
+    assert argv[argv.index("--review-job-id") + 1] == "proposal:1"
+    records = StepJournal.load(journal_path({"session_id": "cadence"}))
+    assert any(record.event.kind == "review_job_queued" for record in records)
 
 
 def test_failed_agent_is_not_checked_or_counted_as_success(

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -74,6 +74,7 @@ def test_review_uses_injected_runner() -> None:
 
     decision, _ = review(_records(), "test-model", runner=fake_runner)
     assert decision.decision == "continue"
+    assert decision.inference_ms is not None
     assert seen["model"] == "test-model"
     assert "pytest -x" in seen["prompt"]
 
@@ -100,6 +101,7 @@ def test_review_cli_journals_shadow_decision(
     assert verdict.event.payload["shadow"] is True
     assert verdict.event.payload["decision"] == "nudge"
     assert verdict.event.payload["reviewed_upto"] == 0
+    assert verdict.event.payload["timing"]["inference_ms"] is None
 
 
 def test_inflight_lock_skips_duplicate_review(

--- a/tests/test_runtime_metrics.py
+++ b/tests/test_runtime_metrics.py
@@ -39,9 +39,23 @@ def test_runtime_costs_keep_surfaces_domains_and_coverage_separate() -> None:
         ),
         _record(
             3,
+            TraceEvent("review_job_queued", {"review_job_id": "review-1"}),
+        ),
+        _record(
+            4,
+            TraceEvent(
+                "review_inference_started",
+                {"review_job_id": "review-1", "queue_ms": 4.0},
+            ),
+        ),
+        _record(
+            5,
             TraceEvent(
                 "reviewer_decision",
-                {"spend": {"session_tokens": 25}},
+                {
+                    "spend": {"session_tokens": 25},
+                    "timing": {"queue_ms": 4.0, "inference_ms": 8.0},
+                },
             ),
         ),
     ]
@@ -91,10 +105,13 @@ def test_runtime_costs_keep_surfaces_domains_and_coverage_separate() -> None:
     assert report.cumulative_main_tokens == 14
     assert report.reviewer_calls == 1
     assert report.reviewer_tokens == 25
+    assert report.reviewer_jobs_queued == report.reviewer_jobs_started == 1
+    assert report.reviewer_queue_ms == (4.0,)
+    assert report.reviewer_inference_ms == (8.0,)
     assert report.gate_calls == 1
     assert report.tool_duration_ms == (10.0,)
     assert report.source_timestamps == 4
-    assert report.receipt_timestamps == report.events == 8
+    assert report.receipt_timestamps == report.events == 10
     assert report.journal_bytes == 300
 
     rendered = render_runtime_costs(report)
@@ -103,6 +120,7 @@ def test_runtime_costs_keep_surfaces_domains_and_coverage_separate() -> None:
     assert (
         "app_server: actions=1 (from 2 observations), outcomes=1 (from 1 observation)" in rendered
     )
+    assert "jobs=1/1/1 decided/started/queued" in rendered
 
 
 def test_unavailable_runtime_metrics_render_unknown_not_zero() -> None:


### PR DESCRIPTION
## Summary
- persist reviewer job queued and inference-started markers with stable per-session job identities
- measure cross-process queue delay from durable receipt time and inference duration from a same-process monotonic clock
- report queue/inference latency with explicit stage coverage and queued/started/decided counts

## Verification
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (398 passed)

Part of #33.