### PR TITLE
feat(metrics): report turn wall-time coverage

### DIFF
--- a/src/spotter/runtime_metrics.py
+++ b/src/spotter/runtime_metrics.py
@@ -37,6 +37,7 @@ class RuntimeCostReport:
     reviewer_jobs_started: int
     reviewer_queue_ms: tuple[float, ...]
     reviewer_inference_ms: tuple[float, ...]
+    turn_wall_ms: tuple[float, ...]
     tool_duration_ms: tuple[float, ...]
     gate_calls: int
     hook_ms: tuple[float, ...]
@@ -58,6 +59,7 @@ def measure_runtime_costs(
     tool_duration_ms: list[float] = []
     reviewer_queue_ms: list[float] = []
     reviewer_inference_ms: list[float] = []
+    turn_wall_ms: list[float] = []
     hook_ms: list[float] = []
     ipc_ms: list[float] = []
     daemon_evaluation_ms: list[float] = []
@@ -75,6 +77,7 @@ def measure_runtime_costs(
         failed: set[str] = set()
         completed: set[str] = set()
         token_covered: set[str] = set()
+        turn_starts: dict[tuple[str, int], float] = {}
         latest_main_tokens: int | None = None
         latest_reviewer_tokens: int | None = None
         for record in records:
@@ -100,8 +103,15 @@ def measure_runtime_costs(
             if duration is not None and event.kind in _OUTCOME_KINDS:
                 tool_duration_ms.append(duration)
             turn_id = _turn_id(record)
+            clock = _turn_clock(record)
+            if event.kind == "turn_started" and clock is not None:
+                turn_starts.setdefault(clock[:2], clock[2])
             if event.kind == "turn_completed" and turn_id is not None:
                 completed.add(turn_id)
+                if clock is not None and (started_at := turn_starts.get(clock[:2])) is not None:
+                    finished_at = clock[2]
+                    if finished_at >= started_at:
+                        turn_wall_ms.append((finished_at - started_at) * 1000)
             if event.kind == "token_usage":
                 token_observations += 1
                 if turn_id is not None:
@@ -163,6 +173,7 @@ def measure_runtime_costs(
         reviewer_jobs_started,
         tuple(reviewer_queue_ms),
         tuple(reviewer_inference_ms),
+        tuple(turn_wall_ms),
         tuple(tool_duration_ms),
         gate_calls,
         tuple(hook_ms),
@@ -213,6 +224,7 @@ def render_runtime_costs(report: RuntimeCostReport) -> str:
     lines.append(
         f"  Timing: receipt_wall={report.receipt_timestamps}/{report.events}, "
         f"source={report.source_timestamps}/{report.events}, "
+        f"turn_wall(source)={_sample(report.turn_wall_ms, report.completed_turns)}, "
         f"tool_duration={_sample(report.tool_duration_ms, tool_outcomes)}"
     )
     lines.append(
@@ -249,6 +261,17 @@ def _turn_id(record: StepRecord) -> str | None:
         return identity.turn_id.value
     value = record.event.payload.get("turn_id")
     return value if isinstance(value, str) and value else None
+
+
+def _turn_clock(record: StepRecord) -> tuple[str, int, float] | None:
+    """Identity for source-clock durations that must not cross reconnects."""
+
+    turn_id = _turn_id(record)
+    epoch = record.event.connection_epoch
+    occurred_at = record.event.occurred_at
+    if turn_id is None or epoch is None or occurred_at is None or not math.isfinite(occurred_at):
+        return None
+    return turn_id, epoch, occurred_at
 
 
 def _total_tokens(payload: Mapping[str, object]) -> int | None:

--- a/tests/test_runtime_metrics.py
+++ b/tests/test_runtime_metrics.py
@@ -66,11 +66,17 @@ def test_runtime_costs_keep_surfaces_domains_and_coverage_separate() -> None:
         IdentityProvenance("codex", "external-thread", "external-turn"),
     )
 
-    def app(kind: str, payload: dict[str, object], operation: str | None = None) -> TraceEvent:
+    def app(
+        kind: str,
+        payload: dict[str, object],
+        operation: str | None = None,
+        *,
+        occurred_at: float = 2.0,
+    ) -> TraceEvent:
         return TraceEvent(
             kind,
             payload,
-            occurred_at=2.0,
+            occurred_at=occurred_at,
             identity=identity,
             operation_id=operation,
             provenance=TraceProvenance("codex_app_server", "synthetic"),
@@ -78,17 +84,18 @@ def test_runtime_costs_keep_surfaces_domains_and_coverage_separate() -> None:
         )
 
     app_server = [
-        _record(0, app("command_started", {}, "command-1")),
+        _record(0, app("turn_started", {}, occurred_at=1.0)),
+        _record(1, app("command_started", {}, "command-1")),
         _record(
-            1,
+            2,
             app(
                 "command_result",
                 {"status": "completed", "exitCode": 0, "durationMs": 10},
                 "command-1",
             ),
         ),
-        _record(2, app("token_usage", {"total": {"totalTokens": 14}})),
-        _record(3, app("turn_completed", {"status": "completed"})),
+        _record(3, app("token_usage", {"total": {"totalTokens": 14}})),
+        _record(4, app("turn_completed", {"status": "completed"}, occurred_at=3.0)),
     ]
 
     report = measure_runtime_costs([(hook, 100), (app_server, 200)])
@@ -108,10 +115,11 @@ def test_runtime_costs_keep_surfaces_domains_and_coverage_separate() -> None:
     assert report.reviewer_jobs_queued == report.reviewer_jobs_started == 1
     assert report.reviewer_queue_ms == (4.0,)
     assert report.reviewer_inference_ms == (8.0,)
+    assert report.turn_wall_ms == (2000.0,)
     assert report.gate_calls == 1
     assert report.tool_duration_ms == (10.0,)
-    assert report.source_timestamps == 4
-    assert report.receipt_timestamps == report.events == 10
+    assert report.source_timestamps == 5
+    assert report.receipt_timestamps == report.events == 11
     assert report.journal_bytes == 300
 
     rendered = render_runtime_costs(report)
@@ -121,6 +129,7 @@ def test_runtime_costs_keep_surfaces_domains_and_coverage_separate() -> None:
         "app_server: actions=1 (from 2 observations), outcomes=1 (from 1 observation)" in rendered
     )
     assert "jobs=1/1/1 decided/started/queued" in rendered
+    assert "turn_wall(source)=avg=2000.00ms max=2000.00ms (1/1)" in rendered
 
 
 def test_unavailable_runtime_metrics_render_unknown_not_zero() -> None:
@@ -143,3 +152,28 @@ def test_uncorrelated_action_observations_do_not_invent_semantic_identity() -> N
     assert hook.actions == hook.outcomes == hook.classified_outcomes == 0
     assert hook.action_observations == 2
     assert hook.outcome_observations == 1
+
+
+def test_turn_duration_never_crosses_connection_epochs() -> None:
+    identity = RuntimeIdentity(
+        ThreadId("thread-1"),
+        TurnId("turn-1"),
+        None,
+        IdentityProvenance("codex", "external-thread", "external-turn"),
+    )
+    records = [
+        _record(
+            0,
+            TraceEvent("turn_started", occurred_at=10.0, identity=identity, connection_epoch=1),
+        ),
+        _record(
+            1,
+            TraceEvent("turn_completed", occurred_at=20.0, identity=identity, connection_epoch=2),
+        ),
+    ]
+
+    report = measure_runtime_costs([(records, 10)])
+
+    assert report.completed_turns == 1
+    assert report.turn_wall_ms == ()
+    assert "turn_wall(source)=unknown (0/1)" in render_runtime_costs(report)


### PR DESCRIPTION
## Summary
- derive App Server turn wall time only from source timestamps in the same turn and connection epoch
- refuse reconnect-spanning or incomplete clock pairs instead of inventing a duration
- report source turn-time samples with completed-turn coverage in `spotter metrics`

## Verification
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (399 passed)

Part of #33.