### PR TITLE
feat(metrics): sample daemon resource costs

### DIFF
--- a/src/spotter/daemon.py
+++ b/src/spotter/daemon.py
@@ -4,13 +4,16 @@ import argparse
 import asyncio
 import hashlib
 import json
+import math
 import os
 import plistlib
+import resource
 import shutil
 import stat
 import subprocess
 import sys
 import time
+import uuid
 from contextlib import suppress
 from dataclasses import dataclass
 from enum import StrEnum
@@ -37,6 +40,7 @@ START_TIMEOUT = 5.0
 STOP_TIMEOUT = 5.0
 _MAX_REQUEST_BYTES = 64 * 1024
 _SAFE_UNIX_PATH_BYTES = 100
+_RESOURCE_SAMPLE_EVERY = 64
 
 
 class RuntimeHealth(StrEnum):
@@ -164,7 +168,7 @@ class DaemonClient:
 
     async def gate(
         self, event: TraceEvent, gates: GatesConfig, root: str | None
-    ) -> tuple[GateDecision, float]:
+    ) -> tuple[GateDecision, float, dict[str, int | float | str] | None]:
         response = await self.request(
             "gate",
             {
@@ -192,7 +196,8 @@ class DaemonClient:
             raise DaemonProtocolError("daemon returned an invalid gate reason")
         if isinstance(evaluation_ms, bool) or evaluation_ms < 0:
             raise DaemonProtocolError("daemon returned invalid gate timing")
-        return GateDecision(allowed, rule, reason), float(evaluation_ms)
+        sample = _resource_sample_from(response.get("runtime_sample"))
+        return GateDecision(allowed, rule, reason), float(evaluation_ms), sample
 
 
 class DaemonServer:
@@ -216,6 +221,9 @@ class DaemonServer:
         self.app_server_endpoint = app_server_endpoint
         self.journals_dir = journals_dir or spotter_home() / "sessions"
         self.recovery: RuntimeRecovery | None = None
+        self._runtime_id = uuid.uuid4().hex
+        self._gate_requests = 0
+        self._resource_sample_seq = 0
 
     def observe_trace(self, event: TraceEvent) -> ThreadState:
         """Increment daemon-owned hot state after adapter normalization and journaling."""
@@ -344,6 +352,8 @@ class DaemonServer:
                 response["detail"] = self.health_detail
             if method == "gate":
                 response.update(_evaluate_gate(request.get("params")))
+                if sample := self._maybe_sample_resources():
+                    response["runtime_sample"] = sample
         except (
             DaemonProtocolError,
             json.JSONDecodeError,
@@ -367,6 +377,27 @@ class DaemonServer:
                 await writer.wait_closed()
         if shutdown:
             self._shutdown.set()
+
+    def _maybe_sample_resources(self) -> dict[str, int | float | str] | None:
+        """Bounded resource sample, kept off all but one in 64 gate requests."""
+
+        self._gate_requests += 1
+        if self._gate_requests != 1 and self._gate_requests % _RESOURCE_SAMPLE_EVERY:
+            return None
+        try:
+            usage = resource.getrusage(resource.RUSAGE_SELF)
+        except OSError:
+            return None  # optional telemetry must never break a gate response
+        self._resource_sample_seq += 1
+        rss = int(usage.ru_maxrss)
+        if sys.platform != "darwin":
+            rss *= 1024  # Linux reports KiB; macOS reports bytes.
+        return {
+            "runtime_id": self._runtime_id,
+            "sample_seq": self._resource_sample_seq,
+            "cpu_seconds": usage.ru_utime + usage.ru_stime,
+            "peak_rss_bytes": rss,
+        }
 
 
 def _evaluate_gate(raw: object) -> dict[str, Any]:
@@ -408,6 +439,38 @@ def _evaluate_gate(raw: object) -> dict[str, Any]:
             "reason": decision.reason,
         },
         "evaluation_ms": evaluation_ms,
+    }
+
+
+def _resource_sample_from(raw: object) -> dict[str, int | float | str] | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    runtime_id = raw.get("runtime_id")
+    sample_seq = raw.get("sample_seq")
+    cpu_seconds = raw.get("cpu_seconds")
+    peak_rss_bytes = raw.get("peak_rss_bytes")
+    if (
+        not isinstance(runtime_id, str)
+        or not runtime_id
+        or not isinstance(sample_seq, int)
+        or isinstance(sample_seq, bool)
+        or sample_seq <= 0
+        or not isinstance(cpu_seconds, int | float)
+        or isinstance(cpu_seconds, bool)
+        or cpu_seconds < 0
+        or not math.isfinite(cpu_seconds)
+        or not isinstance(peak_rss_bytes, int)
+        or isinstance(peak_rss_bytes, bool)
+        or peak_rss_bytes < 0
+    ):
+        return None
+    return {
+        "runtime_id": runtime_id,
+        "sample_seq": sample_seq,
+        "cpu_seconds": float(cpu_seconds),
+        "peak_rss_bytes": peak_rss_bytes,
     }
 
 

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -295,9 +295,10 @@ def _gate_over_ipc(
     started = time.perf_counter_ns()
     status = "ok"
     evaluation_ms: float | None = None
+    runtime_sample: dict[str, int | float | str] | None = None
     error_detail: str | None = None
     try:
-        decision, evaluation_ms = asyncio.run(
+        decision, evaluation_ms, runtime_sample = asyncio.run(
             DaemonClient(timeout=GATE_TIMEOUT).gate(event, config.gates, root)
         )
     except DaemonTimeout as error:
@@ -323,4 +324,6 @@ def _gate_over_ipc(
     }
     if error_detail is not None:
         telemetry["error"] = error_detail[:300]
+    if runtime_sample is not None:
+        telemetry["runtime_sample"] = runtime_sample
     return decision, telemetry

--- a/src/spotter/runtime_metrics.py
+++ b/src/spotter/runtime_metrics.py
@@ -43,6 +43,9 @@ class RuntimeCostReport:
     hook_ms: tuple[float, ...]
     ipc_ms: tuple[float, ...]
     daemon_evaluation_ms: tuple[float, ...]
+    daemon_resource_samples: int
+    daemon_cpu_seconds: float | None
+    daemon_peak_rss_bytes: int | None
     source_timestamps: int
     receipt_timestamps: int
     journal_bytes: int
@@ -63,6 +66,7 @@ def measure_runtime_costs(
     hook_ms: list[float] = []
     ipc_ms: list[float] = []
     daemon_evaluation_ms: list[float] = []
+    daemon_samples: dict[tuple[str, int], tuple[float, int]] = {}
     source_timestamps = receipt_timestamps = 0
 
     for records_iter, size in journals:
@@ -139,6 +143,7 @@ def measure_runtime_costs(
                 _append_number(hook_ms, event.payload.get("hook_ms"))
                 _append_number(ipc_ms, event.payload.get("ipc_ms"))
                 _append_number(daemon_evaluation_ms, event.payload.get("daemon_evaluation_ms"))
+                _append_daemon_sample(daemon_samples, event.payload.get("runtime_sample"))
         current = surfaces[surface]
         surfaces[surface] = SurfaceCost(
             actions=current.actions + len(actions),
@@ -158,6 +163,12 @@ def measure_runtime_costs(
         if latest_reviewer_tokens is not None:
             reviewer_tokens_known = True
             reviewer_tokens += latest_reviewer_tokens
+
+    latest_samples: dict[str, tuple[int, float, int]] = {}
+    for (runtime_id, sample_seq), (cpu_seconds, peak_rss_bytes) in daemon_samples.items():
+        previous = latest_samples.get(runtime_id)
+        if previous is None or sample_seq > previous[0]:
+            latest_samples[runtime_id] = (sample_seq, cpu_seconds, peak_rss_bytes)
 
     return RuntimeCostReport(
         sessions,
@@ -179,6 +190,9 @@ def measure_runtime_costs(
         tuple(hook_ms),
         tuple(ipc_ms),
         tuple(daemon_evaluation_ms),
+        len(daemon_samples),
+        sum(sample[1] for sample in latest_samples.values()) if latest_samples else None,
+        max((sample[2] for sample in latest_samples.values()), default=None),
         source_timestamps,
         receipt_timestamps,
         journal_bytes,
@@ -219,6 +233,18 @@ def render_runtime_costs(report: RuntimeCostReport) -> str:
         f"hook={_sample(report.hook_ms, report.gate_calls)}, "
         f"ipc={_sample(report.ipc_ms, report.gate_calls)}, "
         f"daemon_eval={_sample(report.daemon_evaluation_ms, report.gate_calls)}"
+    )
+    cpu = (
+        f"{report.daemon_cpu_seconds:.3f}s" if report.daemon_cpu_seconds is not None else "unknown"
+    )
+    rss = (
+        f"{report.daemon_peak_rss_bytes} bytes"
+        if report.daemon_peak_rss_bytes is not None
+        else "unknown"
+    )
+    lines.append(
+        f"  Spotter resources: cpu={cpu}, peak_rss={rss}; "
+        f"samples={report.daemon_resource_samples}/{report.gate_calls} gate calls"
     )
     tool_outcomes = sum(cost.outcome_observations for cost in report.surfaces.values())
     lines.append(
@@ -291,6 +317,27 @@ def _append_number(target: list[float], value: object) -> None:
     parsed = _number(value)
     if parsed is not None:
         target.append(parsed)
+
+
+def _append_daemon_sample(target: dict[tuple[str, int], tuple[float, int]], value: object) -> None:
+    if not isinstance(value, Mapping):
+        return
+    runtime_id = value.get("runtime_id")
+    sample_seq = value.get("sample_seq")
+    cpu_seconds = _number(value.get("cpu_seconds"))
+    peak_rss_bytes = value.get("peak_rss_bytes")
+    if (
+        isinstance(runtime_id, str)
+        and runtime_id
+        and isinstance(sample_seq, int)
+        and not isinstance(sample_seq, bool)
+        and sample_seq > 0
+        and cpu_seconds is not None
+        and isinstance(peak_rss_bytes, int)
+        and not isinstance(peak_rss_bytes, bool)
+        and peak_rss_bytes >= 0
+    ):
+        target[(runtime_id, sample_seq)] = (cpu_seconds, peak_rss_bytes)
 
 
 def _sample(values: tuple[float, ...], eligible: int) -> str:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -142,15 +142,32 @@ def test_gate_roundtrip_preserves_policy_and_concurrency(socket_path: Path) -> N
             results = await asyncio.gather(
                 *(DaemonClient(socket_path).gate(event, gates, "/repo") for event, gates in cases)
             )
-            for (event, gates), (decision, evaluation_ms) in zip(cases, results, strict=True):
+            for (event, gates), (decision, evaluation_ms, _sample) in zip(
+                cases, results, strict=True
+            ):
                 assert decision == Gate(
                     gates.forbidden_paths, gates.block_dependency_changes, "/repo"
                 ).check(event)
                 assert evaluation_ms >= 0
+            assert sum(sample is not None for _, _, sample in results) == 1
         finally:
             await server.close()
 
     asyncio.run(scenario())
+
+
+def test_resource_sampling_is_bounded_and_runtime_addressable(socket_path: Path) -> None:
+    server = DaemonServer(socket_path)
+
+    samples = [server._maybe_sample_resources() for _ in range(65)]
+    observed = [sample for sample in samples if sample is not None]
+
+    assert len(observed) == 2
+    assert [sample["sample_seq"] for sample in observed] == [1, 2]
+    assert len({sample["runtime_id"] for sample in observed}) == 1
+    first_cpu, last_cpu = observed[0]["cpu_seconds"], observed[-1]["cpu_seconds"]
+    assert isinstance(first_cpu, int | float) and isinstance(last_cpu, int | float)
+    assert last_cpu >= first_cpu
 
 
 @pytest.mark.parametrize(
@@ -208,7 +225,7 @@ def test_gate_fails_open_for_an_unsupported_proposal_shape(socket_path: Path) ->
         server = DaemonServer(socket_path)
         await server.start()
         try:
-            decision, _ = await DaemonClient(socket_path).gate(
+            decision, _, _ = await DaemonClient(socket_path).gate(
                 TraceEvent("tool_proposal", {"command": 42, "files": "not-a-list"}),
                 GatesConfig(),
                 "/repo",
@@ -226,7 +243,7 @@ def test_gate_normalizes_missing_files_without_skipping_the_command(socket_path:
         server = DaemonServer(socket_path)
         await server.start()
         try:
-            decision, _ = await DaemonClient(socket_path).gate(
+            decision, _, _ = await DaemonClient(socket_path).gate(
                 TraceEvent("tool_proposal", {"command": "rm -rf /", "files": None}),
                 GatesConfig(),
                 "/repo",

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -95,6 +95,10 @@ def test_shadow_mode_allows_but_journals_the_block(spotter_home: Path, daemon: N
     assert records[2].event.payload["status"] == "ok"
     assert records[2].event.payload["ipc_ms"] >= 0
     assert records[2].event.payload["hook_ms"] >= records[2].event.payload["ipc_ms"]
+    sample = records[2].event.payload["runtime_sample"]
+    assert sample["sample_seq"] == 1
+    assert sample["cpu_seconds"] >= 0
+    assert sample["peak_rss_bytes"] >= 0
 
 
 def test_safe_command_allows_silently(daemon: None) -> None:

--- a/tests/test_runtime_metrics.py
+++ b/tests/test_runtime_metrics.py
@@ -34,7 +34,17 @@ def test_runtime_costs_keep_surfaces_domains_and_coverage_separate() -> None:
             2,
             TraceEvent(
                 "gate_ipc",
-                {"hook_ms": 3.0, "ipc_ms": 2.0, "daemon_evaluation_ms": 1.0},
+                {
+                    "hook_ms": 3.0,
+                    "ipc_ms": 2.0,
+                    "daemon_evaluation_ms": 1.0,
+                    "runtime_sample": {
+                        "runtime_id": "daemon-1",
+                        "sample_seq": 1,
+                        "cpu_seconds": 0.25,
+                        "peak_rss_bytes": 1024,
+                    },
+                },
             ),
         ),
         _record(
@@ -117,6 +127,9 @@ def test_runtime_costs_keep_surfaces_domains_and_coverage_separate() -> None:
     assert report.reviewer_inference_ms == (8.0,)
     assert report.turn_wall_ms == (2000.0,)
     assert report.gate_calls == 1
+    assert report.daemon_resource_samples == 1
+    assert report.daemon_cpu_seconds == 0.25
+    assert report.daemon_peak_rss_bytes == 1024
     assert report.tool_duration_ms == (10.0,)
     assert report.source_timestamps == 5
     assert report.receipt_timestamps == report.events == 11
@@ -129,6 +142,7 @@ def test_runtime_costs_keep_surfaces_domains_and_coverage_separate() -> None:
         "app_server: actions=1 (from 2 observations), outcomes=1 (from 1 observation)" in rendered
     )
     assert "jobs=1/1/1 decided/started/queued" in rendered
+    assert "cpu=0.250s, peak_rss=1024 bytes; samples=1/1 gate calls" in rendered
     assert "turn_wall(source)=avg=2000.00ms max=2000.00ms (1/1)" in rendered
 
 


### PR DESCRIPTION
## Summary
- sample daemon cumulative CPU and peak RSS on the first and every 64th gate request
- carry optional runtime-addressed samples through the existing gate telemetry without risking enforcement
- deduplicate samples by runtime/sequence and report latest resource costs with gate-call coverage

## Verification
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (400 passed)

Part of #33.