### PR TITLE
feat(tasks): validate frozen corpus manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,10 +350,11 @@ spotter metrics
 spotter observability [--session <id>]
 spotter fork --session <id> --step <n>
 spotter prune --repo /path/to/repo  # dry-run unless --apply is supplied
+spotter tasks validate path/to/task-set.toml
 spotter experiment --session <id> --step <n> --guidance "..." --check "..."
 ```
 
-The experiment harness existing does **not** mean positive intervention advantage has been established. A mechanically scored task set and enough executed runs remain evidence gaps.
+Task-set validation freezes task and fixture hashes and checks the versioned scorer/budget contract; it does not execute setup, prechecks, scorers, or agent arms yet. The experiment harness existing does **not** mean positive intervention advantage has been established. Preflight execution, a mechanically scored corpus, and enough executed runs remain evidence gaps.
 
 ---
 

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -62,6 +62,7 @@ from spotter.snapshot import (
     snapshot_references,
     stale_journals,
 )
+from spotter.task_corpus import TaskCorpusError, validate_task_set
 from spotter.trace import TraceEvent
 
 
@@ -86,6 +87,7 @@ def build_parser() -> argparse.ArgumentParser:
             "daemon",
             "setup",
             "teardown",
+            "tasks",
         ],
         default="observe",
         help=(
@@ -97,6 +99,7 @@ def build_parser() -> argparse.ArgumentParser:
             "label: record a human verdict on a gate flag, reviewer decision, or session; "
             "metrics: gate FP rate, reviewer precision and observability ceiling from labels; "
             "observability: compare Hook/App Server Trace IR and source-adapter coverage; "
+            "tasks: validate a frozen task-set manifest without running agents; "
             "status: what Spotter is storing, and whether it is actually running; "
             "doctor: verify supervision end to end (non-zero exit when broken); "
             "daemon: manually start, stop, restart, or inspect spotterd; "
@@ -106,9 +109,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "target",
         nargs="?",
-        choices=["start", "stop", "restart", "status", "codex"],
-        help="daemon lifecycle action or integration target",
+        choices=["start", "stop", "restart", "status", "codex", "validate"],
+        help="daemon lifecycle action, integration target, or task action",
     )
+    parser.add_argument("subject", nargs="?", help="task-set manifest path")
     parser.add_argument("--config", type=Path, help="path to Spotter TOML config")
     parser.add_argument(
         "--session", help="session id (fork; analyze/metrics/observability filter to it)"
@@ -212,8 +216,21 @@ def main(argv: Sequence[str] | None = None) -> int:
             portable=args.portable,
             dry_run=args.dry_run,
         )
+    if args.command == "tasks":
+        if args.target != "validate" or not args.subject:
+            parser.error("tasks requires: spotter tasks validate <set.toml>")
+        try:
+            task_set = validate_task_set(Path(args.subject))
+        except TaskCorpusError as error:
+            print(f"task validation failed: {error}", file=sys.stderr)
+            return 1
+        print(
+            f"validated {task_set.task_set_id} v{task_set.version} "
+            f"({task_set.split}): {len(task_set.tasks)} task(s)"
+        )
+        return 0
     if args.target is not None:
-        parser.error("the second positional argument requires daemon, setup, or teardown")
+        parser.error("the second positional argument requires daemon, setup, teardown, or tasks")
     if args.dry_run or args.portable:
         parser.error("--dry-run and --portable require setup")
 

--- a/src/spotter/task_corpus.py
+++ b/src/spotter/task_corpus.py
@@ -1,0 +1,184 @@
+"""Versioned, dependency-free task corpus manifests."""
+
+import hashlib
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+TASK_SCHEMA_VERSION = 1
+TASK_SET_SCHEMA_VERSION = 1
+
+
+class TaskCorpusError(ValueError):
+    """A task corpus cannot be reproduced from its declared inputs."""
+
+
+@dataclass(frozen=True)
+class TaskManifest:
+    task_id: str
+    path: Path
+    source: Path
+    prompt: str
+
+
+@dataclass(frozen=True)
+class TaskSetManifest:
+    task_set_id: str
+    version: int
+    split: str
+    tasks: tuple[TaskManifest, ...]
+
+
+def validate_task_set(path: Path) -> TaskSetManifest:
+    """Validate immutable task/set identities without executing task commands."""
+
+    set_path = path.resolve()
+    data = _load_toml(set_path)
+    _schema(data, "task_set_schema_version", TASK_SET_SCHEMA_VERSION, set_path)
+    task_set_id = _text(data, "task_set_id", set_path)
+    version = _positive_int(data, "version", set_path)
+    split = _text(data, "split", set_path)
+    if split not in {"dev", "validation"}:
+        raise TaskCorpusError(f"{set_path}: split must be dev or validation")
+    refs = data.get("tasks")
+    if not isinstance(refs, list) or not refs:
+        raise TaskCorpusError(f"{set_path}: tasks must be a non-empty array of tables")
+
+    tasks: list[TaskManifest] = []
+    seen: set[str] = set()
+    for index, raw in enumerate(refs):
+        where = f"{set_path}: tasks[{index}]"
+        if not isinstance(raw, dict):
+            raise TaskCorpusError(f"{where} must be a table")
+        task_id = _text(raw, "task_id", where)
+        if task_id in seen:
+            raise TaskCorpusError(f"{set_path}: duplicate task_id {task_id!r}")
+        seen.add(task_id)
+        manifest = _contained_file(set_path.parent, _text(raw, "manifest", where), where)
+        expected = _text(raw, "sha256", where)
+        if file_digest(manifest) != expected:
+            raise TaskCorpusError(f"{where}: manifest sha256 mismatch")
+        task = _validate_task(manifest, set_path.parent)
+        if task.task_id != task_id:
+            raise TaskCorpusError(f"{where}: task_id does not match {manifest}")
+        tasks.append(task)
+    return TaskSetManifest(task_set_id, version, split, tuple(tasks))
+
+
+def file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def fixture_digest(path: Path) -> str:
+    """Hash a fixture's paths and bytes; symlinks are deliberately unsupported."""
+
+    digest = hashlib.sha256()
+    files = sorted(candidate for candidate in path.rglob("*") if candidate.is_file())
+    if not files:
+        raise TaskCorpusError(f"{path}: fixture must contain at least one file")
+    for candidate in files:
+        if candidate.is_symlink():
+            raise TaskCorpusError(f"{candidate}: fixture symlinks are unsupported")
+        digest.update(candidate.relative_to(path).as_posix().encode())
+        digest.update(b"\0")
+        digest.update(candidate.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _validate_task(path: Path, corpus_root: Path) -> TaskManifest:
+    data = _load_toml(path)
+    _schema(data, "task_schema_version", TASK_SCHEMA_VERSION, path)
+    task_id = _text(data, "task_id", path)
+    prompt = _text(data, "prompt", path)
+
+    source = _table(data, "source", path)
+    if _text(source, "kind", path) != "fixture":
+        raise TaskCorpusError(f"{path}: source.kind must be fixture")
+    fixture = _contained_path(corpus_root, _text(source, "path", path), path)
+    if not fixture.is_dir():
+        raise TaskCorpusError(f"{path}: fixture source does not exist: {fixture}")
+    if fixture_digest(fixture) != _text(source, "sha256", path):
+        raise TaskCorpusError(f"{path}: fixture sha256 mismatch")
+
+    _command(_table(data, "setup", path), path)
+    precheck = _table(data, "precheck", path)
+    _command(precheck, path)
+    if _text(precheck, "expected", path) != "failure":
+        raise TaskCorpusError(f"{path}: precheck.expected must be failure")
+    checks = data.get("checks")
+    if not isinstance(checks, list) or not checks:
+        raise TaskCorpusError(f"{path}: checks must be a non-empty array of tables")
+    check_ids: set[str] = set()
+    for check in checks:
+        if not isinstance(check, dict):
+            raise TaskCorpusError(f"{path}: each check must be a table")
+        check_id = _text(check, "id", path)
+        if check_id in check_ids:
+            raise TaskCorpusError(f"{path}: duplicate check id {check_id!r}")
+        check_ids.add(check_id)
+        _command(check, path)
+        if not isinstance(check.get("required"), bool):
+            raise TaskCorpusError(f"{path}: check {check_id!r} requires a boolean required")
+
+    budget = _table(data, "budget", path)
+    _positive_int(budget, "wall_time_s", path)
+    _positive_int(budget, "max_turns", path)
+    metadata = _table(data, "metadata", path)
+    for key in ("family", "difficulty", "provenance"):
+        _text(metadata, key, path)
+    return TaskManifest(task_id, path, fixture, prompt)
+
+
+def _command(data: dict[str, Any], where: object) -> None:
+    _text(data, "command", where)
+    _positive_int(data, "timeout_s", where)
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("rb") as source:
+            return tomllib.load(source)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise TaskCorpusError(f"{path}: {error}") from error
+
+
+def _schema(data: dict[str, Any], key: str, expected: int, where: object) -> None:
+    if data.get(key) != expected:
+        raise TaskCorpusError(f"{where}: {key} must be {expected}")
+
+
+def _table(data: dict[str, Any], key: str, where: object) -> dict[str, Any]:
+    value = data.get(key)
+    if not isinstance(value, dict):
+        raise TaskCorpusError(f"{where}: {key} must be a table")
+    return value
+
+
+def _text(data: dict[str, Any], key: str, where: object) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise TaskCorpusError(f"{where}: {key} must be non-empty text")
+    return value.strip()
+
+
+def _positive_int(data: dict[str, Any], key: str, where: object) -> int:
+    value = data.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise TaskCorpusError(f"{where}: {key} must be a positive integer")
+    return value
+
+
+def _contained_file(root: Path, value: str, where: object) -> Path:
+    path = _contained_path(root, value, where)
+    if not path.is_file():
+        raise TaskCorpusError(f"{where}: manifest does not exist: {path}")
+    return path
+
+
+def _contained_path(root: Path, value: str, where: object) -> Path:
+    path = (root / value).resolve()
+    if not path.is_relative_to(root.resolve()):
+        raise TaskCorpusError(f"{where}: path escapes the corpus: {value}")
+    return path

--- a/tests/test_task_corpus.py
+++ b/tests/test_task_corpus.py
@@ -1,0 +1,115 @@
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from spotter.cli import main
+from spotter.task_corpus import TaskCorpusError, file_digest, fixture_digest, validate_task_set
+
+
+def _corpus(root: Path) -> Path:
+    fixture = root / "fixtures" / "parser"
+    fixture.mkdir(parents=True)
+    (fixture / "parser.py").write_text("def parse(): return None\n")
+    task = root / "tasks" / "parser.toml"
+    task.parent.mkdir()
+    task.write_text(
+        f'''task_schema_version = 1
+task_id = "fixture/parser-001"
+prompt = "Fix the parser regression."
+
+[source]
+kind = "fixture"
+path = "fixtures/parser"
+sha256 = "{fixture_digest(fixture)}"
+
+[setup]
+command = "python -m compileall ."
+timeout_s = 30
+
+[precheck]
+command = "python check.py"
+timeout_s = 30
+expected = "failure"
+
+[[checks]]
+id = "task-resolution"
+command = "python check.py"
+timeout_s = 30
+required = true
+
+[budget]
+wall_time_s = 600
+max_turns = 20
+
+[metadata]
+family = "localized-fix"
+difficulty = "dev"
+provenance = "spotter synthetic fixture"
+'''
+    )
+    task_set = root / "dev.toml"
+    task_set.write_text(
+        f'''task_set_schema_version = 1
+task_set_id = "spotter-dev"
+version = 1
+split = "dev"
+
+[[tasks]]
+task_id = "fixture/parser-001"
+manifest = "tasks/parser.toml"
+sha256 = "{file_digest(task)}"
+'''
+    )
+    return task_set
+
+
+def test_validates_versioned_task_set_and_cli(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _corpus(tmp_path)
+
+    task_set = validate_task_set(path)
+
+    assert task_set.task_set_id == "spotter-dev"
+    assert task_set.split == "dev"
+    assert task_set.tasks[0].task_id == "fixture/parser-001"
+    assert main(["tasks", "validate", str(path)]) == 0
+    assert "validated spotter-dev v1 (dev): 1 task(s)" in capsys.readouterr().out
+
+
+def test_manifest_hash_detects_task_set_drift(tmp_path: Path) -> None:
+    path = _corpus(tmp_path)
+    task = tmp_path / "tasks" / "parser.toml"
+    task.write_text(task.read_text() + "\n# changed after set freeze\n")
+
+    with pytest.raises(TaskCorpusError, match="manifest sha256 mismatch"):
+        validate_task_set(path)
+
+
+def test_fixture_hash_detects_environment_drift(tmp_path: Path) -> None:
+    path = _corpus(tmp_path)
+    (tmp_path / "fixtures" / "parser" / "parser.py").write_text("changed\n")
+
+    with pytest.raises(TaskCorpusError, match="fixture sha256 mismatch"):
+        validate_task_set(path)
+
+
+def test_rejects_duplicate_task_ids(tmp_path: Path) -> None:
+    path = _corpus(tmp_path)
+    first = path.read_text().split("[[tasks]]", 1)[1]
+    path.write_text(path.read_text() + "\n[[tasks]]" + first)
+
+    with pytest.raises(TaskCorpusError, match="duplicate task_id"):
+        validate_task_set(path)
+
+
+def test_fixture_digest_includes_relative_paths(tmp_path: Path) -> None:
+    fixture = tmp_path / "fixture"
+    fixture.mkdir()
+    (fixture / "a").write_text("same")
+    first = fixture_digest(fixture)
+    (fixture / "a").rename(fixture / "b")
+
+    assert fixture_digest(fixture) != first
+    assert len(first) == hashlib.sha256().digest_size * 2


### PR DESCRIPTION
## Summary
- define dependency-free versioned TOML contracts for task and task-set manifests
- freeze ordered task manifests and fixture trees with SHA-256 identities, rejecting drift, duplicates, traversal, and unsupported schemas
- add `spotter tasks validate <set.toml>` for static corpus validation without agent or scorer execution

## Verification
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (405 passed)

Part of #21.