### PR TITLE
feat(tasks): preflight mechanical scorers

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,10 +351,11 @@ spotter observability [--session <id>]
 spotter fork --session <id> --step <n>
 spotter prune --repo /path/to/repo  # dry-run unless --apply is supplied
 spotter tasks validate path/to/task-set.toml
+spotter tasks preflight path/to/task-set.toml
 spotter experiment --session <id> --step <n> --guidance "..." --check "..."
 ```
 
-Task-set validation freezes task and fixture hashes and checks the versioned scorer/budget contract; it does not execute setup, prechecks, scorers, or agent arms yet. The experiment harness existing does **not** mean positive intervention advantage has been established. Preflight execution, a mechanically scored corpus, and enough executed runs remain evidence gaps.
+Task-set validation freezes task and fixture hashes and checks the versioned scorer/budget contract without executing commands. Preflight runs setup, the broken-state scorer, a declared known-good transform, and the positive scorer in a temporary fixture copy; it never runs agent arms. The experiment harness existing does **not** mean positive intervention advantage has been established. A frozen multi-task corpus and enough executed runs remain evidence gaps.
 
 ---
 

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -62,7 +62,13 @@ from spotter.snapshot import (
     snapshot_references,
     stale_journals,
 )
-from spotter.task_corpus import TaskCorpusError, validate_task_set
+from spotter.task_corpus import (
+    PreflightClassification,
+    TaskCorpusError,
+    TaskPreflight,
+    preflight_task_set,
+    validate_task_set,
+)
 from spotter.trace import TraceEvent
 
 
@@ -99,7 +105,7 @@ def build_parser() -> argparse.ArgumentParser:
             "label: record a human verdict on a gate flag, reviewer decision, or session; "
             "metrics: gate FP rate, reviewer precision and observability ceiling from labels; "
             "observability: compare Hook/App Server Trace IR and source-adapter coverage; "
-            "tasks: validate a frozen task-set manifest without running agents; "
+            "tasks: validate or preflight a frozen task set without running agents; "
             "status: what Spotter is storing, and whether it is actually running; "
             "doctor: verify supervision end to end (non-zero exit when broken); "
             "daemon: manually start, stop, restart, or inspect spotterd; "
@@ -109,7 +115,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "target",
         nargs="?",
-        choices=["start", "stop", "restart", "status", "codex", "validate"],
+        choices=["start", "stop", "restart", "status", "codex", "validate", "preflight"],
         help="daemon lifecycle action, integration target, or task action",
     )
     parser.add_argument("subject", nargs="?", help="task-set manifest path")
@@ -217,10 +223,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             dry_run=args.dry_run,
         )
     if args.command == "tasks":
-        if args.target != "validate" or not args.subject:
-            parser.error("tasks requires: spotter tasks validate <set.toml>")
+        if args.target not in {"validate", "preflight"} or not args.subject:
+            parser.error("tasks requires: spotter tasks validate|preflight <set.toml>")
+        preflight_results: tuple[TaskPreflight, ...]
         try:
-            task_set = validate_task_set(Path(args.subject))
+            if args.target == "validate":
+                task_set = validate_task_set(Path(args.subject))
+                preflight_results = ()
+            else:
+                task_set, preflight_results = preflight_task_set(Path(args.subject))
         except TaskCorpusError as error:
             print(f"task validation failed: {error}", file=sys.stderr)
             return 1
@@ -228,6 +239,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"validated {task_set.task_set_id} v{task_set.version} "
             f"({task_set.split}): {len(task_set.tasks)} task(s)"
         )
+        for result in preflight_results:
+            print(f"  {result.task_id}: {result.classification}")
+        if any(
+            result.classification != PreflightClassification.READY for result in preflight_results
+        ):
+            return 1
         return 0
     if args.target is not None:
         parser.error("the second positional argument requires daemon, setup, teardown, or tasks")

--- a/src/spotter/task_corpus.py
+++ b/src/spotter/task_corpus.py
@@ -1,8 +1,15 @@
 """Versioned, dependency-free task corpus manifests."""
 
 import hashlib
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
 import tomllib
+from contextlib import suppress
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -15,11 +22,28 @@ class TaskCorpusError(ValueError):
 
 
 @dataclass(frozen=True)
+class CommandSpec:
+    command: str
+    timeout_s: int
+
+
+@dataclass(frozen=True)
+class CheckSpec:
+    id: str
+    command: CommandSpec
+    required: bool
+
+
+@dataclass(frozen=True)
 class TaskManifest:
     task_id: str
     path: Path
     source: Path
     prompt: str
+    setup: CommandSpec
+    precheck: CommandSpec
+    checks: tuple[CheckSpec, ...]
+    known_good: CommandSpec | None
 
 
 @dataclass(frozen=True)
@@ -28,6 +52,30 @@ class TaskSetManifest:
     version: int
     split: str
     tasks: tuple[TaskManifest, ...]
+
+
+class PreflightClassification(StrEnum):
+    READY = "READY"
+    SETUP_FAIL = "SETUP_FAIL"
+    TIMEOUT_CHECK = "TIMEOUT_CHECK"
+    CHECK_ERROR = "CHECK_ERROR"
+    UNJUDGEABLE = "UNJUDGEABLE"
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    phase: str
+    returncode: int | None
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+
+
+@dataclass(frozen=True)
+class TaskPreflight:
+    task_id: str
+    classification: PreflightClassification
+    commands: tuple[CommandResult, ...]
 
 
 def validate_task_set(path: Path) -> TaskSetManifest:
@@ -74,17 +122,38 @@ def fixture_digest(path: Path) -> str:
     """Hash a fixture's paths and bytes; symlinks are deliberately unsupported."""
 
     digest = hashlib.sha256()
-    files = sorted(candidate for candidate in path.rglob("*") if candidate.is_file())
+    files: list[Path] = []
+    if path.is_symlink():
+        raise TaskCorpusError(f"{path}: fixture symlinks are unsupported")
+    for current, directories, names in os.walk(
+        path, followlinks=False, onerror=_fixture_walk_error
+    ):
+        base = Path(current)
+        for name in [*directories, *names]:
+            candidate = base / name
+            if candidate.is_symlink():
+                raise TaskCorpusError(f"{candidate}: fixture symlinks are unsupported")
+        files.extend(base / name for name in names)
+    files.sort()
     if not files:
         raise TaskCorpusError(f"{path}: fixture must contain at least one file")
     for candidate in files:
-        if candidate.is_symlink():
-            raise TaskCorpusError(f"{candidate}: fixture symlinks are unsupported")
         digest.update(candidate.relative_to(path).as_posix().encode())
         digest.update(b"\0")
         digest.update(candidate.read_bytes())
         digest.update(b"\0")
     return digest.hexdigest()
+
+
+def _fixture_walk_error(error: OSError) -> None:
+    raise TaskCorpusError(f"fixture cannot be read: {error}") from error
+
+
+def preflight_task_set(path: Path) -> tuple[TaskSetManifest, tuple[TaskPreflight, ...]]:
+    """Execute frozen scorer fixtures in isolated temporary copies."""
+
+    task_set = validate_task_set(path)
+    return task_set, tuple(_preflight_task(task) for task in task_set.tasks)
 
 
 def _validate_task(path: Path, corpus_root: Path) -> TaskManifest:
@@ -102,15 +171,16 @@ def _validate_task(path: Path, corpus_root: Path) -> TaskManifest:
     if fixture_digest(fixture) != _text(source, "sha256", path):
         raise TaskCorpusError(f"{path}: fixture sha256 mismatch")
 
-    _command(_table(data, "setup", path), path)
+    setup = _command(_table(data, "setup", path), path)
     precheck = _table(data, "precheck", path)
-    _command(precheck, path)
+    precheck_command = _command(precheck, path)
     if _text(precheck, "expected", path) != "failure":
         raise TaskCorpusError(f"{path}: precheck.expected must be failure")
     checks = data.get("checks")
     if not isinstance(checks, list) or not checks:
         raise TaskCorpusError(f"{path}: checks must be a non-empty array of tables")
     check_ids: set[str] = set()
+    parsed_checks: list[CheckSpec] = []
     for check in checks:
         if not isinstance(check, dict):
             raise TaskCorpusError(f"{path}: each check must be a table")
@@ -118,9 +188,19 @@ def _validate_task(path: Path, corpus_root: Path) -> TaskManifest:
         if check_id in check_ids:
             raise TaskCorpusError(f"{path}: duplicate check id {check_id!r}")
         check_ids.add(check_id)
-        _command(check, path)
+        command = _command(check, path)
         if not isinstance(check.get("required"), bool):
             raise TaskCorpusError(f"{path}: check {check_id!r} requires a boolean required")
+        parsed_checks.append(CheckSpec(check_id, command, check["required"]))
+    if not any(check.required for check in parsed_checks):
+        raise TaskCorpusError(f"{path}: at least one check must be required")
+
+    known_good_raw = data.get("known_good")
+    known_good = None
+    if known_good_raw is not None:
+        if not isinstance(known_good_raw, dict):
+            raise TaskCorpusError(f"{path}: known_good must be a table")
+        known_good = _command(known_good_raw, path)
 
     budget = _table(data, "budget", path)
     _positive_int(budget, "wall_time_s", path)
@@ -128,12 +208,128 @@ def _validate_task(path: Path, corpus_root: Path) -> TaskManifest:
     metadata = _table(data, "metadata", path)
     for key in ("family", "difficulty", "provenance"):
         _text(metadata, key, path)
-    return TaskManifest(task_id, path, fixture, prompt)
+    return TaskManifest(
+        task_id,
+        path,
+        fixture,
+        prompt,
+        setup,
+        precheck_command,
+        tuple(parsed_checks),
+        known_good,
+    )
 
 
-def _command(data: dict[str, Any], where: object) -> None:
-    _text(data, "command", where)
-    _positive_int(data, "timeout_s", where)
+def _command(data: dict[str, Any], where: object) -> CommandSpec:
+    return CommandSpec(_text(data, "command", where), _positive_int(data, "timeout_s", where))
+
+
+def _preflight_task(task: TaskManifest) -> TaskPreflight:
+    results: list[CommandResult] = []
+    with tempfile.TemporaryDirectory(prefix="spotter-task-") as scratch:
+        workspace = Path(scratch) / "workspace"
+        shutil.copytree(task.source, workspace)
+        setup = _run_command("setup", task.setup, workspace)
+        results.append(setup)
+        if setup.timed_out or setup.returncode != 0:
+            return TaskPreflight(task.task_id, PreflightClassification.SETUP_FAIL, tuple(results))
+
+        precheck = _run_command("precheck", task.precheck, workspace)
+        results.append(precheck)
+        if precheck.timed_out:
+            return TaskPreflight(
+                task.task_id, PreflightClassification.TIMEOUT_CHECK, tuple(results)
+            )
+        if precheck.returncode is None:
+            return TaskPreflight(task.task_id, PreflightClassification.CHECK_ERROR, tuple(results))
+        if precheck.returncode == 0:
+            return TaskPreflight(task.task_id, PreflightClassification.UNJUDGEABLE, tuple(results))
+
+        negative = [
+            _run_command(f"negative:{check.id}", check.command, workspace) for check in task.checks
+        ]
+        results.extend(negative)
+        required_negative = [
+            result for check, result in zip(task.checks, negative, strict=True) if check.required
+        ]
+        if any(result.timed_out for result in required_negative):
+            return TaskPreflight(
+                task.task_id, PreflightClassification.TIMEOUT_CHECK, tuple(results)
+            )
+        if any(result.returncode is None for result in required_negative):
+            return TaskPreflight(task.task_id, PreflightClassification.CHECK_ERROR, tuple(results))
+        if all(result.returncode == 0 for result in required_negative):
+            return TaskPreflight(task.task_id, PreflightClassification.UNJUDGEABLE, tuple(results))
+
+        if task.known_good is None:
+            return TaskPreflight(task.task_id, PreflightClassification.UNJUDGEABLE, tuple(results))
+        known_good = _run_command("known_good", task.known_good, workspace)
+        results.append(known_good)
+        if known_good.timed_out or known_good.returncode != 0:
+            return TaskPreflight(task.task_id, PreflightClassification.CHECK_ERROR, tuple(results))
+
+        positive = [
+            _run_command(f"positive:{check.id}", check.command, workspace) for check in task.checks
+        ]
+        results.extend(positive)
+        required_positive = [
+            result for check, result in zip(task.checks, positive, strict=True) if check.required
+        ]
+        if any(result.timed_out for result in required_positive):
+            return TaskPreflight(
+                task.task_id, PreflightClassification.TIMEOUT_CHECK, tuple(results)
+            )
+        if any(result.returncode is None for result in required_positive):
+            return TaskPreflight(task.task_id, PreflightClassification.CHECK_ERROR, tuple(results))
+        classification = (
+            PreflightClassification.READY
+            if all(result.returncode == 0 for result in required_positive)
+            else PreflightClassification.UNJUDGEABLE
+        )
+        return TaskPreflight(task.task_id, classification, tuple(results))
+
+
+_OUTPUT_LIMIT = 4000
+
+
+def _run_command(phase: str, spec: CommandSpec, workspace: Path) -> CommandResult:
+    try:
+        process = subprocess.Popen(
+            spec.command,
+            shell=True,
+            cwd=workspace,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+    except OSError as error:
+        return CommandResult(phase, None, "", str(error)[:_OUTPUT_LIMIT])
+    try:
+        stdout, stderr = process.communicate(timeout=spec.timeout_s)
+    except subprocess.TimeoutExpired:
+        with suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        stdout, stderr = process.communicate()
+        return CommandResult(
+            phase,
+            None,
+            _bounded_output(stdout),
+            _bounded_output(stderr),
+            timed_out=True,
+        )
+    return CommandResult(
+        phase,
+        process.returncode,
+        stdout[-_OUTPUT_LIMIT:],
+        stderr[-_OUTPUT_LIMIT:],
+    )
+
+
+def _bounded_output(value: str | bytes | None) -> str:
+    if isinstance(value, bytes):
+        value = value.decode(errors="replace")
+    return (value or "")[-_OUTPUT_LIMIT:]
 
 
 def _load_toml(path: Path) -> dict[str, Any]:

--- a/tests/test_task_corpus.py
+++ b/tests/test_task_corpus.py
@@ -4,13 +4,22 @@ from pathlib import Path
 import pytest
 
 from spotter.cli import main
-from spotter.task_corpus import TaskCorpusError, file_digest, fixture_digest, validate_task_set
+from spotter.task_corpus import (
+    PreflightClassification,
+    TaskCorpusError,
+    file_digest,
+    fixture_digest,
+    preflight_task_set,
+    validate_task_set,
+)
 
 
 def _corpus(root: Path) -> Path:
     fixture = root / "fixtures" / "parser"
     fixture.mkdir(parents=True)
-    (fixture / "parser.py").write_text("def parse(): return None\n")
+    (fixture / "parser.py").write_text("def parse(): return 0\n")
+    (fixture / "parser.good").write_text("def parse(): return 1\n")
+    (fixture / "check.py").write_text("from parser import parse\nassert parse() == 1\n")
     task = root / "tasks" / "parser.toml"
     task.parent.mkdir()
     task.write_text(
@@ -24,17 +33,21 @@ path = "fixtures/parser"
 sha256 = "{fixture_digest(fixture)}"
 
 [setup]
-command = "python -m compileall ."
+command = "python3 -m compileall ."
 timeout_s = 30
 
 [precheck]
-command = "python check.py"
+command = "python3 check.py"
 timeout_s = 30
 expected = "failure"
 
+[known_good]
+command = "cp parser.good parser.py && rm -rf __pycache__"
+timeout_s = 30
+
 [[checks]]
 id = "task-resolution"
-command = "python check.py"
+command = "python3 check.py"
 timeout_s = 30
 required = true
 
@@ -62,6 +75,13 @@ sha256 = "{file_digest(task)}"
 '''
     )
     return task_set
+
+
+def _refreeze_task(root: Path, task_set: Path) -> None:
+    task = root / "tasks" / "parser.toml"
+    set_text = task_set.read_text()
+    old_hash = set_text.split('sha256 = "', 1)[1].split('"', 1)[0]
+    task_set.write_text(set_text.replace(old_hash, file_digest(task)))
 
 
 def test_validates_versioned_task_set_and_cli(
@@ -113,3 +133,63 @@ def test_fixture_digest_includes_relative_paths(tmp_path: Path) -> None:
 
     assert fixture_digest(fixture) != first
     assert len(first) == hashlib.sha256().digest_size * 2
+
+
+def test_preflight_proves_negative_and_positive_scorer_states(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _corpus(tmp_path)
+
+    _, results = preflight_task_set(path)
+
+    assert results[0].classification == PreflightClassification.READY
+    assert [result.phase for result in results[0].commands] == [
+        "setup",
+        "precheck",
+        "negative:task-resolution",
+        "known_good",
+        "positive:task-resolution",
+    ]
+    assert main(["tasks", "preflight", str(path)]) == 0
+    assert "fixture/parser-001: READY" in capsys.readouterr().out
+
+
+def test_rejects_directory_symlinks_in_fixtures(tmp_path: Path) -> None:
+    fixture = tmp_path / "fixture"
+    outside = tmp_path / "outside"
+    fixture.mkdir()
+    outside.mkdir()
+    (fixture / "owned").write_text("inside")
+    (outside / "foreign").write_text("outside")
+    (fixture / "linked").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(TaskCorpusError, match="symlinks are unsupported"):
+        fixture_digest(fixture)
+
+
+def test_rejects_task_set_without_a_required_check(tmp_path: Path) -> None:
+    path = _corpus(tmp_path)
+    task = tmp_path / "tasks" / "parser.toml"
+    task.write_text(task.read_text().replace("required = true", "required = false"))
+    _refreeze_task(tmp_path, path)
+
+    with pytest.raises(TaskCorpusError, match="at least one check must be required"):
+        validate_task_set(path)
+
+
+def test_preflight_classifies_required_check_timeout(tmp_path: Path) -> None:
+    path = _corpus(tmp_path)
+    task = tmp_path / "tasks" / "parser.toml"
+    text = task.read_text()
+    text = text.replace(
+        '[[checks]]\nid = "task-resolution"\ncommand = "python3 check.py"\ntimeout_s = 30',
+        '[[checks]]\nid = "task-resolution"\n'
+        "command = \"python3 -c 'import time; time.sleep(2)'\"\ntimeout_s = 1",
+    )
+    task.write_text(text)
+    _refreeze_task(tmp_path, path)
+
+    _, results = preflight_task_set(path)
+
+    assert results[0].classification == PreflightClassification.TIMEOUT_CHECK
+    assert results[0].commands[-1].timed_out is True


### PR DESCRIPTION
## Summary
- reject fixture directory symlinks and task manifests without any required scorer
- add `spotter tasks preflight <set.toml>` to execute setup, broken-state checks, a known-good transform, and positive checks in temporary fixture copies
- classify setup/check/timeout/unjudgeable failures, retain bounded command diagnostics, and kill timed-out process groups

## Verification
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (409 passed)

Part of #21. Follow-up to #128.