### PR TITLE
feat(tasks): freeze initial dev and validation corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ spotter tasks preflight path/to/task-set.toml
 spotter experiment --session <id> --step <n> --guidance "..." --check "..."
 ```
 
-Task-set validation freezes task and fixture hashes and checks the versioned scorer/budget contract without executing commands. Preflight runs setup, the broken-state scorer, a declared known-good transform, and the positive scorer in a temporary fixture copy; it never runs agent arms. The experiment harness existing does **not** mean positive intervention advantage has been established. A frozen multi-task corpus and enough executed runs remain evidence gaps.
+Task-set validation freezes task and fixture hashes and checks the versioned scorer/budget contract without executing commands. Preflight runs setup, the broken-state scorer, a declared known-good transform, and the positive scorer in a temporary fixture copy; it never runs agent arms. Because preflight executes corpus-declared shell commands, use `validate` only for untrusted task sets. The experiment harness existing does **not** mean positive intervention advantage has been established. A frozen multi-task corpus and enough executed runs remain evidence gaps.
 
 ---
 

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -1,0 +1,19 @@
+# Spotter task corpus
+
+`dev-v1.toml` is for harness and supervision tuning. `validation-v1.toml` is the frozen held-out split for the first decision-quality measurements. Changing a fixture or task manifest requires a new set version and new hashes; do not rewrite an observed validation set in place.
+
+Static freeze validation is safe for untrusted input:
+
+```bash
+spotter tasks validate corpus/dev-v1.toml
+spotter tasks validate corpus/validation-v1.toml
+```
+
+Preflight executes the repo-authored setup and scorer commands in temporary fixture copies:
+
+```bash
+spotter tasks preflight corpus/dev-v1.toml
+spotter tasks preflight corpus/validation-v1.toml
+```
+
+These synthetic fixtures establish harness behavior. They are not evidence of intervention advantage and do not replace the later multi-task executed experiment.

--- a/corpus/dev-v1.toml
+++ b/corpus/dev-v1.toml
@@ -1,0 +1,9 @@
+task_set_schema_version = 1
+task_set_id = "spotter-dev"
+version = 1
+split = "dev"
+
+[[tasks]]
+task_id = "fixture/query-parser-001"
+manifest = "tasks/query-parser.toml"
+sha256 = "e8f725c3d476c02c2a56580dbbacf238f700e1deed14b9ddd8e9ce9ec4b2d92f"

--- a/corpus/fixtures/profile-contract/check.py
+++ b/corpus/fixtures/profile-contract/check.py
@@ -1,0 +1,7 @@
+from profile import normalize_profile
+
+from renderer import render_profile
+
+profile = normalize_profile({"name": " Ada ", "role": "ADMIN"})
+assert profile == {"name": "Ada", "role": "admin"}
+assert render_profile(profile) == "Ada (admin)"

--- a/corpus/fixtures/profile-contract/profile.py
+++ b/corpus/fixtures/profile-contract/profile.py
@@ -1,0 +1,2 @@
+def normalize_profile(raw: dict[str, str]) -> dict[str, str]:
+    return {"name": raw["name"].strip()}

--- a/corpus/fixtures/profile-contract/renderer.py
+++ b/corpus/fixtures/profile-contract/renderer.py
@@ -1,0 +1,2 @@
+def render_profile(profile: dict[str, str]) -> str:
+    return profile["name"]

--- a/corpus/fixtures/query-parser/check.py
+++ b/corpus/fixtures/query-parser/check.py
@@ -1,0 +1,3 @@
+from query import parse
+
+assert parse("token=a=b") == ("token", "a=b")

--- a/corpus/fixtures/query-parser/query.py
+++ b/corpus/fixtures/query-parser/query.py
@@ -1,0 +1,3 @@
+def parse(text: str) -> tuple[str, str]:
+    key, value = text.split("=")
+    return key, value

--- a/corpus/tasks/profile-contract.toml
+++ b/corpus/tasks/profile-contract.toml
@@ -1,0 +1,36 @@
+task_schema_version = 1
+task_id = "fixture/profile-contract-001"
+prompt = "Update profile normalization and rendering so role is normalized and included in the rendered contract."
+
+[source]
+kind = "fixture"
+path = "fixtures/profile-contract"
+sha256 = "5208dad460a3f8f20405e4f1d3829a30ca4931420f4a83d4730ea6a331d68416"
+
+[setup]
+command = "python3 -m compileall -q ."
+timeout_s = 30
+
+[precheck]
+command = "python3 check.py"
+timeout_s = 30
+expected = "failure"
+
+[known_good]
+command = '''python3 -c "from pathlib import Path; Path('profile.py').write_text('def normalize_profile(raw: dict[str, str]) -> dict[str, str]:\n    return {\"name\": raw[\"name\"].strip(), \"role\": raw[\"role\"].strip().lower()}\n'); Path('renderer.py').write_text('def render_profile(profile: dict[str, str]) -> str:\n    return f\"{profile[\\\"name\\\"]} ({profile[\\\"role\\\"]})\"\n')"'''
+timeout_s = 30
+
+[[checks]]
+id = "task-resolution"
+command = "python3 check.py"
+timeout_s = 30
+required = true
+
+[budget]
+wall_time_s = 900
+max_turns = 30
+
+[metadata]
+family = "multi-file-contract"
+difficulty = "validation"
+provenance = "spotter synthetic fixture v1"

--- a/corpus/tasks/query-parser.toml
+++ b/corpus/tasks/query-parser.toml
@@ -1,0 +1,36 @@
+task_schema_version = 1
+task_id = "fixture/query-parser-001"
+prompt = "Fix the query parser so values may contain equals signs without changing its key/value API."
+
+[source]
+kind = "fixture"
+path = "fixtures/query-parser"
+sha256 = "c7ff67882112f07c7aa16cfea3e08b97ad857f2c33a7d1e52f95ed3bd0d46b37"
+
+[setup]
+command = "python3 -m compileall -q ."
+timeout_s = 30
+
+[precheck]
+command = "python3 check.py"
+timeout_s = 30
+expected = "failure"
+
+[known_good]
+command = '''python3 -c "from pathlib import Path; Path('query.py').write_text('def parse(text: str) -> tuple[str, str]:\n    key, value = text.split(\"=\", 1)\n    return key, value\n')"'''
+timeout_s = 30
+
+[[checks]]
+id = "task-resolution"
+command = "python3 check.py"
+timeout_s = 30
+required = true
+
+[budget]
+wall_time_s = 600
+max_turns = 20
+
+[metadata]
+family = "localized-bug-fix"
+difficulty = "dev"
+provenance = "spotter synthetic fixture v1"

--- a/corpus/validation-v1.toml
+++ b/corpus/validation-v1.toml
@@ -1,0 +1,9 @@
+task_set_schema_version = 1
+task_set_id = "spotter-validation"
+version = 1
+split = "validation"
+
+[[tasks]]
+task_id = "fixture/profile-contract-001"
+manifest = "tasks/profile-contract.toml"
+sha256 = "32bf56a59420ab881d07d66fc0e0ff299a677120058c4609f6fdb088ca1a286e"

--- a/src/spotter/task_corpus.py
+++ b/src/spotter/task_corpus.py
@@ -307,10 +307,25 @@ def _run_command(phase: str, spec: CommandSpec, workspace: Path) -> CommandResul
         return CommandResult(phase, None, "", str(error)[:_OUTPUT_LIMIT])
     try:
         stdout, stderr = process.communicate(timeout=spec.timeout_s)
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as initial_timeout:
         with suppress(ProcessLookupError):
             os.killpg(process.pid, signal.SIGKILL)
-        stdout, stderr = process.communicate()
+        try:
+            stdout, stderr = process.communicate(timeout=1)
+        except subprocess.TimeoutExpired as escaped_child:
+            if process.stdout is not None:
+                process.stdout.close()
+            if process.stderr is not None:
+                process.stderr.close()
+            with suppress(subprocess.TimeoutExpired):
+                process.wait(timeout=1)
+            return CommandResult(
+                phase,
+                None,
+                _bounded_output(escaped_child.stdout or initial_timeout.stdout),
+                _bounded_output(escaped_child.stderr or initial_timeout.stderr),
+                timed_out=True,
+            )
         return CommandResult(
             phase,
             None,

--- a/tests/test_task_corpus.py
+++ b/tests/test_task_corpus.py
@@ -193,3 +193,13 @@ def test_preflight_classifies_required_check_timeout(tmp_path: Path) -> None:
 
     assert results[0].classification == PreflightClassification.TIMEOUT_CHECK
     assert results[0].commands[-1].timed_out is True
+
+
+@pytest.mark.parametrize("name", ["dev-v1.toml", "validation-v1.toml"])
+def test_repo_corpus_is_frozen_and_preflight_ready(name: str) -> None:
+    path = Path(__file__).parents[1] / "corpus" / name
+
+    task_set, results = preflight_task_set(path)
+
+    assert task_set.tasks
+    assert all(result.classification == PreflightClassification.READY for result in results)


### PR DESCRIPTION
## Summary
- add hash-frozen dev and validation task sets with localized and multi-file mechanical fixtures
- prove both repository task sets READY through broken-state and known-good scorer preflight in CI
- bound post-timeout pipe cleanup for escaped child sessions and document the preflight command trust boundary

## Verification
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (411 passed)
- `.venv/bin/spotter tasks preflight corpus/dev-v1.toml`
- `.venv/bin/spotter tasks preflight corpus/validation-v1.toml`

Part of #21. Follow-up to #129.