### PR TITLE
fix(tasks): keep validation scorer Python 3.11 compatible

### DIFF
--- a/corpus/tasks/profile-contract.toml
+++ b/corpus/tasks/profile-contract.toml
@@ -17,7 +17,7 @@ timeout_s = 30
 expected = "failure"
 
 [known_good]
-command = '''python3 -c "from pathlib import Path; Path('profile.py').write_text('def normalize_profile(raw: dict[str, str]) -> dict[str, str]:\n    return {\"name\": raw[\"name\"].strip(), \"role\": raw[\"role\"].strip().lower()}\n'); Path('renderer.py').write_text('def render_profile(profile: dict[str, str]) -> str:\n    return f\"{profile[\\\"name\\\"]} ({profile[\\\"role\\\"]})\"\n')"'''
+command = '''python3 -c "from pathlib import Path; Path('profile.py').write_text('def normalize_profile(raw: dict[str, str]) -> dict[str, str]:\n    return {\"name\": raw[\"name\"].strip(), \"role\": raw[\"role\"].strip().lower()}\n'); Path('renderer.py').write_text('def render_profile(profile: dict[str, str]) -> str:\n    return \"{} ({})\".format(profile[\"name\"], profile[\"role\"])\n')"'''
 timeout_s = 30
 
 [[checks]]

--- a/corpus/validation-v1.toml
+++ b/corpus/validation-v1.toml
@@ -6,4 +6,4 @@ split = "validation"
 [[tasks]]
 task_id = "fixture/profile-contract-001"
 manifest = "tasks/profile-contract.toml"
-sha256 = "32bf56a59420ab881d07d66fc0e0ff299a677120058c4609f6fdb088ca1a286e"
+sha256 = "986d658545d3def14adfda2b3a01c7e7647ff30fba5f56db3eda88a9447f6529"


### PR DESCRIPTION
## Summary
- replace Python 3.12-only nested f-string syntax in the validation known-good transform with Python 3.11-compatible formatting
- update the frozen validation task-set hash

## Root cause
PR #130 passed locally on Python 3.12/3.14 but its validation preflight became `UNJUDGEABLE` on CI Python 3.11. Both CI jobs failed before #130 was merged.

## Verification
- full repository checks (411 passed)
- dev and validation preflight READY with Python 3.11 selected as `python3`

Follow-up to #130. Part of #21.