### PR TITLE
feat(experiment): classify mechanically scored arm outcomes

### DIFF
--- a/corpus/README.md
+++ b/corpus/README.md
@@ -1,6 +1,6 @@
 # Spotter task corpus
 
-`dev-v1.toml` is for harness and supervision tuning. `validation-v1.toml` is the frozen held-out split for the first decision-quality measurements. Changing a fixture or task manifest requires a new set version and new hashes; do not rewrite an observed validation set in place.
+`dev-v1.toml` is for harness and supervision tuning. `validation-v1.toml` is the frozen held-out split for the first decision-quality measurements. Changing a fixture or task manifest requires a new set version and new hashes; do not rewrite an observed validation set in place. In-place re-freezing is allowed only before the set has been used in a recorded run.
 
 Static freeze validation is safe for untrusted input:
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -99,7 +99,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Shadow reviewer | ✅ | Produces `CONTINUE`, `VERIFY`, `NUDGE`; verdicts are recorded only | Move to event-driven candidates, then live delivery |
 | Audit / live state | 🟡 | Daemon-owned typed ThreadState distinguishes constraints, hypotheses, observations, verified facts, summaries, interventions, and coverage | Feed reviewer jobs and signals from immutable snapshots |
 | Evaluation labels / metrics | 🟡 | Coverage-aware labels plus durable Main action/token/timing, reviewer, gate-latency, and storage projections; unavailable values remain unknown | Add live resource/queue/delivery telemetry and objective outcome joins (#33, #38, #34) |
-| Counterfactual harness | ✅ | Control/guidance same-prefix pairs can be prepared/run | Add mechanically scored tasks (#21) |
+| Counterfactual harness | ✅ | Control/guidance same-prefix pairs persist explicit task/infra/timeout classifications and bounded check diagnostics | Execute frozen task sets as resumable batches (#21) |
 | Standalone runtime | 🟡 | Long-lived process, IPC, lifecycle, isolated per-thread state, and App Server recovery ownership | Select and verify the shared endpoint during setup |
 | Runtime identity | ✅ | Logical threads/turns remain separate from per-connection attachment IDs and monotonically recovered epochs | Propagate the identity into future reviewer jobs |
 | App Server primary observation | 🟡 | Configured endpoints route through `spotterd` into normalized durable Trace IR and incremental ThreadState; a bounded value-free source audit and conformance corpus measure projection coverage | Collect labeled App Server failures to finish #37, then reduce Hooks in #86 |
@@ -153,7 +153,7 @@ Implementation progress and research evidence remain separate.
 | Can Spotter produce plausible semantic reviewer verdicts? | Yes, in shadow mode |
 | Can Spotter branch a shared prefix for counterfactual experiments? | Yes |
 | Is the fork instrument's causal noise floor known? | **No — #42** |
-| Is there a reproducible mechanically scored task corpus? | **No — #21** |
+| Is there a reproducible mechanically scored task corpus? | **Partial — frozen synthetic dev/validation fixtures and preflight exist; resumable multi-task execution remains (#21)** |
 | Has live Spotter guidance been shown to improve outcomes? | **No** |
 | Is the App Server control boundary operationally viable? | **Yes for a configured Spotter-managed external path, including daemon reconnect/reconciliation** |
 | Is the post-App-Server visible-in-time ceiling measured? | **No — the instrument exists, but the current sample has 0 App Server sessions and 0/9 labeled sessions (#37)** |

--- a/src/spotter/experiment.py
+++ b/src/spotter/experiment.py
@@ -22,6 +22,7 @@ import uuid
 from contextlib import suppress
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
 
 from spotter.hook import journal_path
@@ -30,6 +31,19 @@ from spotter.replay import fork
 from spotter.snapshot import StepJournal
 
 CONTROL_PROMPT = "Continue the task."
+EXPERIMENT_RESULT_SCHEMA_VERSION = 1
+_OUTPUT_LIMIT = 4000
+
+
+class ArmClassification(StrEnum):
+    PASS = "PASS"
+    TASK_FAIL = "TASK_FAIL"
+    SETUP_FAIL = "SETUP_FAIL"
+    INFRA_FAIL = "INFRA_FAIL"
+    TIMEOUT_AGENT = "TIMEOUT_AGENT"
+    TIMEOUT_CHECK = "TIMEOUT_CHECK"
+    CHECK_ERROR = "CHECK_ERROR"
+    UNJUDGEABLE = "UNJUDGEABLE"
 
 
 @dataclass(frozen=True)
@@ -41,6 +55,11 @@ class ArmResult:
     worktree: str
     agent_exit: int | None  # None = not run
     check_exit: int | None  # None = no check command
+    classification: ArmClassification
+    check_stdout: str = ""
+    check_stderr: str = ""
+    infra_diagnostic: str | None = None
+    result_schema_version: int = EXPERIMENT_RESULT_SCHEMA_VERSION
 
 
 def results_path(session_id: str, step: int) -> Path:
@@ -107,6 +126,7 @@ def run_experiment(
     # conditions that produced them can be recovered and compared.
     meta = {
         "meta": True,
+        "result_schema_version": EXPERIMENT_RESULT_SCHEMA_VERSION,
         "experiment_id": experiment_id,
         "source_session": session_id,
         "step": step,
@@ -137,6 +157,10 @@ def run_experiment(
             plan = fork(session_id, step, codex_home=codex_home)
             agent_exit: int | None = None
             check_exit: int | None = None
+            classification = ArmClassification.UNJUDGEABLE
+            check_stdout = ""
+            check_stderr = ""
+            infra_diagnostic: str | None = None
             if run:
                 try:
                     agent_exit = _run_arm(
@@ -148,21 +172,52 @@ def run_experiment(
                         model=model,
                         codex_home=codex_home,
                     )
-                except subprocess.TimeoutExpired:
-                    agent_exit = 124
-                if check and agent_exit == 0:
+                except subprocess.TimeoutExpired as error:
+                    classification = ArmClassification.TIMEOUT_AGENT
+                    infra_diagnostic = str(error)
+                except OSError as error:
+                    classification = ArmClassification.INFRA_FAIL
+                    infra_diagnostic = str(error)
+                if agent_exit is not None and agent_exit != 0:
+                    classification = ArmClassification.INFRA_FAIL
+                    infra_diagnostic = f"agent exited {agent_exit}"
+                elif check and agent_exit == 0:
                     try:
-                        check_exit = subprocess.run(
+                        completed = subprocess.run(
                             check,
                             shell=True,
                             cwd=plan.worktree,
                             capture_output=True,
+                            text=True,
                             timeout=timeout,
-                        ).returncode
-                    except subprocess.TimeoutExpired:
-                        check_exit = 124
+                        )
+                        check_exit = completed.returncode
+                        check_stdout = _bounded_output(completed.stdout)
+                        check_stderr = _bounded_output(completed.stderr)
+                        classification = (
+                            ArmClassification.PASS
+                            if check_exit == 0
+                            else ArmClassification.TASK_FAIL
+                        )
+                    except subprocess.TimeoutExpired as error:
+                        classification = ArmClassification.TIMEOUT_CHECK
+                        check_stdout = _bounded_output(error.stdout)
+                        check_stderr = _bounded_output(error.stderr)
+                    except OSError as error:
+                        classification = ArmClassification.CHECK_ERROR
+                        infra_diagnostic = str(error)
             result = ArmResult(
-                experiment_id, pair, arm, plan.session_id, plan.worktree, agent_exit, check_exit
+                experiment_id,
+                pair,
+                arm,
+                plan.session_id,
+                plan.worktree,
+                agent_exit,
+                check_exit,
+                classification,
+                check_stdout,
+                check_stderr,
+                infra_diagnostic,
             )
             results.append(result)
             with out.open("a", encoding="utf-8") as sink:  # one row per run, crash-safe
@@ -224,37 +279,65 @@ def _source_snapshot(session_id: str, step: int) -> str | None:
     return next((r.snapshot for r in reversed(records[: step + 1]) if r.snapshot), None)
 
 
+def _bounded_output(value: str | bytes | None) -> str:
+    if isinstance(value, bytes):
+        value = value.decode(errors="replace")
+    return (value or "")[-_OUTPUT_LIMIT:]
+
+
 def summarize(results: list[ArmResult]) -> str:
     lines = []
     for arm in ("control", "guidance"):
         rows = [r for r in results if r.arm == arm]
-        ran = [r for r in rows if r.agent_exit is not None]
-        valid = [r for r in ran if r.agent_exit == 0]
-        invalid = len(ran) - len(valid)
-        passed = [r for r in valid if r.check_exit == 0]
-        checked = [r for r in valid if r.check_exit is not None]
-        if not ran:
+        attempted = [
+            r
+            for r in rows
+            if r.agent_exit is not None or r.classification != ArmClassification.UNJUDGEABLE
+        ]
+        judged = [
+            r
+            for r in rows
+            if r.classification in {ArmClassification.PASS, ArmClassification.TASK_FAIL}
+        ]
+        passed = [r for r in judged if r.classification == ArmClassification.PASS]
+        invalid = [
+            r
+            for r in rows
+            if r.classification
+            not in {
+                ArmClassification.PASS,
+                ArmClassification.TASK_FAIL,
+                ArmClassification.UNJUDGEABLE,
+            }
+        ]
+        if not attempted:
             lines.append(f"{arm}: {len(rows)} fork(s) prepared, not run")
-        elif not valid:
-            lines.append(f"{arm}: {invalid} invalid agent run(s), no result")
-        elif not checked:
+        elif not judged and not invalid:
             lines.append(
-                f"{arm}: {len(valid)} run(s), no --check given — completion is not success"
+                f"{arm}: {len(attempted)} run(s), no --check given — completion is not success"
             )
+        elif not judged:
+            counts = ", ".join(
+                f"{classification}={sum(r.classification == classification for r in invalid)}"
+                for classification in ArmClassification
+                if any(r.classification == classification for r in invalid)
+            )
+            lines.append(f"{arm}: {len(invalid)} invalid run(s), no result ({counts})")
         else:
-            suffix = f", {invalid} invalid agent run(s)" if invalid else ""
-            lines.append(f"{arm}: {len(passed)}/{len(checked)} passed check{suffix}")
+            suffix = f", {len(invalid)} invalid run(s)" if invalid else ""
+            lines.append(f"{arm}: {len(passed)}/{len(judged)} passed check{suffix}")
     pairs = {result.pair for result in results}
     guidance_better = control_better = tied = complete = 0
     for pair in pairs:
         pair_rows = {result.arm: result for result in results if result.pair == pair}
         if set(pair_rows) != {"control", "guidance"} or any(
-            row.agent_exit != 0 or row.check_exit is None for row in pair_rows.values()
+            row.classification not in {ArmClassification.PASS, ArmClassification.TASK_FAIL}
+            for row in pair_rows.values()
         ):
             continue
         complete += 1
-        control_passed = pair_rows["control"].check_exit == 0
-        guidance_passed = pair_rows["guidance"].check_exit == 0
+        control_passed = pair_rows["control"].classification == ArmClassification.PASS
+        guidance_passed = pair_rows["guidance"].classification == ArmClassification.PASS
         guidance_better += guidance_passed and not control_passed
         control_better += control_passed and not guidance_passed
         tied += control_passed == guidance_passed

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -8,7 +8,13 @@ import pytest
 
 import spotter.experiment as experiment
 from spotter.config import GatesConfig, MainAgentConfig, ReviewerConfig, SpotterConfig
-from spotter.experiment import ArmResult, results_path, run_experiment, summarize
+from spotter.experiment import (
+    ArmClassification,
+    ArmResult,
+    results_path,
+    run_experiment,
+    summarize,
+)
 from spotter.hook import journal_path, run_hook
 from spotter.paths import spotter_home
 from spotter.replay import ForkPlan
@@ -49,9 +55,11 @@ def test_results_carry_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
     assert meta["check"] == "pytest -q"
     assert meta["sandbox"] and meta["timeout"] and meta["started_at"]
     assert meta["pairs"] == 1
+    assert meta["result_schema_version"] == 1
     assert rows[-1]["complete"] is True and rows[-1]["finished_at"]
     # every row is linked to its conditions via the experiment id
     assert all(row["experiment_id"] == meta["experiment_id"] for row in rows[1:])
+    assert all(row.get("classification") == "UNJUDGEABLE" for row in rows[1:-1])
     assert all(r.experiment_id == meta["experiment_id"] for r in results)
     # a rerun with different conditions is distinguishable
     monkeypatch.setattr(experiment, "fork", _fake_fork({}))
@@ -100,6 +108,8 @@ def test_check_runs_in_each_fork_worktree(monkeypatch: pytest.MonkeyPatch) -> No
 
     class FakeCompleted:
         returncode = 0
+        stdout = "check output"
+        stderr = ""
 
     def fake_subprocess_run(cmd: object, **kwargs: object) -> FakeCompleted:
         if kwargs.get("cwd"):
@@ -110,12 +120,18 @@ def test_check_runs_in_each_fork_worktree(monkeypatch: pytest.MonkeyPatch) -> No
     results = run_experiment("s1", 5, "hint", run=True, check="pytest -q")
     assert checks == ["/wt/1", "/wt/2"]
     assert all(r.check_exit == 0 for r in results)
+    assert all(r.classification == ArmClassification.PASS for r in results)
+    assert all(r.check_stdout == "check output" for r in results)
 
 
 def test_summarize_refuses_to_call_completion_success() -> None:
-    ran_no_check = [ArmResult("e", 0, "control", "s", "/wt", 0, None)]
+    ran_no_check = [
+        ArmResult("e", 0, "control", "s", "/wt", 0, None, ArmClassification.UNJUDGEABLE)
+    ]
     assert "completion is not success" in summarize(ran_no_check)
-    prepared = [ArmResult("e", 0, "guidance", "s", "/wt", None, None)]
+    prepared = [
+        ArmResult("e", 0, "guidance", "s", "/wt", None, None, ArmClassification.UNJUDGEABLE)
+    ]
     assert "not run" in summarize(prepared)
 
 
@@ -196,7 +212,8 @@ def test_failed_agent_is_not_checked_or_counted_as_success(
     monkeypatch.setattr("spotter.experiment.subprocess.run", record_check)
     results = run_experiment("s1", 5, "hint", run=True, check="pytest -q")
     assert all(result.check_exit is None for result in results)
-    assert "invalid agent run" in summarize(results)
+    assert all(result.classification == ArmClassification.INFRA_FAIL for result in results)
+    assert "INFRA_FAIL=1" in summarize(results)
     assert not any(args and args[0] == "pytest -q" for args in checks)
 
 
@@ -215,7 +232,51 @@ def test_timeout_does_not_abort_experiment(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(experiment, "_cleanup", lambda worktree: None)
     results = run_experiment("s1", 5, "hint", pairs=3, run=True)
     assert len(results) == 6
-    assert [result.agent_exit for result in results].count(124) == 1
+    assert [result.classification for result in results].count(ArmClassification.TIMEOUT_AGENT) == 1
+    assert "TIMEOUT_AGENT=1" in summarize(results)
+
+
+def test_failed_check_is_task_failure_with_bounded_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(experiment, "fork", _fake_fork({}))
+    monkeypatch.setattr(experiment, "_run_arm", lambda *args, **kwargs: 0)
+    monkeypatch.setattr(experiment, "_codex_version", lambda: None)
+
+    def fail_check(*args: object, **kwargs: object) -> object:
+        return type(
+            "Completed",
+            (),
+            {"returncode": 1, "stdout": "x" * 5000, "stderr": "assertion failed"},
+        )()
+
+    monkeypatch.setattr("spotter.experiment.subprocess.run", fail_check)
+
+    results = run_experiment("s1", 5, "hint", run=True, check="python3 check.py")
+
+    assert all(result.classification == ArmClassification.TASK_FAIL for result in results)
+    assert all(result.check_exit == 1 for result in results)
+    assert all(len(result.check_stdout) == 4000 for result in results)
+    assert all(result.check_stderr == "assertion failed" for result in results)
+
+
+def test_check_timeout_is_not_counted_as_task_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(experiment, "fork", _fake_fork({}))
+    monkeypatch.setattr(experiment, "_run_arm", lambda *args, **kwargs: 0)
+    monkeypatch.setattr(experiment, "_codex_version", lambda: None)
+
+    def timeout_check(*args: object, **kwargs: object) -> object:
+        raise subprocess.TimeoutExpired("check", 1, output="partial", stderr="hung")
+
+    monkeypatch.setattr("spotter.experiment.subprocess.run", timeout_check)
+
+    results = run_experiment("s1", 5, "hint", run=True, check="python3 check.py")
+
+    assert all(result.classification == ArmClassification.TIMEOUT_CHECK for result in results)
+    assert all(result.check_exit is None for result in results)
+    assert all(result.check_stdout == "partial" for result in results)
 
 
 def test_cleanup_is_best_effort_and_preserves_rollout(
@@ -235,10 +296,10 @@ def test_cleanup_is_best_effort_and_preserves_rollout(
 
 def test_summary_compares_complete_pairs() -> None:
     rows = [
-        ArmResult("e", 0, "control", "s", "/wt", 0, 1),
-        ArmResult("e", 0, "guidance", "s", "/wt", 0, 0),
-        ArmResult("e", 1, "control", "s", "/wt", 124, None),
-        ArmResult("e", 1, "guidance", "s", "/wt", 0, 0),
+        ArmResult("e", 0, "control", "s", "/wt", 0, 1, ArmClassification.TASK_FAIL),
+        ArmResult("e", 0, "guidance", "s", "/wt", 0, 0, ArmClassification.PASS),
+        ArmResult("e", 1, "control", "s", "/wt", None, None, ArmClassification.TIMEOUT_AGENT),
+        ArmResult("e", 1, "guidance", "s", "/wt", 0, 0, ArmClassification.PASS),
     ]
     assert "n=1/2 complete; guidance better=1" in summarize(rows)
 


### PR DESCRIPTION
## Why

The counterfactual harness encoded timeouts and execution failures as overloaded exit codes, so task failures could not be separated reliably from infrastructure or scorer failures. This is the next bounded slice of #21.

Related: #21

## What changed

- persist the explicit arm classifications required by the task-corpus contract (`PASS`, `TASK_FAIL`, setup/infra/check failures, timeouts, and `UNJUDGEABLE`)
- keep bounded check stdout/stderr and infrastructure diagnostics in each result row
- version the enriched result rows and summarize pairs only when both arms have mechanically judgeable outcomes
- clarify that validation sets may only be re-frozen in place before any recorded run, following the #131 review
- update current-status documentation

## Validation

- `ruff format --check .`
- `ruff check .`
- `mypy src tests`
- `pytest` (413 passed)

## Notes

This PR does not add task-set batch execution or resume behavior; those remain the next #21 slices.