### PR TITLE
feat(corpus): freeze heterogeneous v2 task sets

### DIFF
--- a/corpus/README.md
+++ b/corpus/README.md
@@ -1,12 +1,16 @@
 # Spotter task corpus
 
-`dev-v1.toml` is for harness and supervision tuning. `validation-v1.toml` is the frozen held-out split for the first decision-quality measurements. Changing a fixture or task manifest requires a new set version and new hashes; do not rewrite an observed validation set in place. In-place re-freezing is allowed only before the set has been used in a recorded run.
+`dev-v2.toml` is the current harness/supervision tuning set. `validation-v2.toml` is the current frozen held-out split for the first decision-quality measurements. Each contains three disjoint tasks; together they cover localized fixes, missing validation, regression avoidance, evidence inspection, and multi-file contracts. The v1 sets remain immutable for provenance.
+
+Changing a fixture or task manifest requires a new set version and new hashes; do not rewrite an observed validation set in place. In-place re-freezing is allowed only before the set has been used in a recorded run.
 
 Static freeze validation is safe for untrusted input:
 
 ```bash
 spotter tasks validate corpus/dev-v1.toml
 spotter tasks validate corpus/validation-v1.toml
+spotter tasks validate corpus/dev-v2.toml
+spotter tasks validate corpus/validation-v2.toml
 ```
 
 Preflight executes the repo-authored setup and scorer commands in temporary fixture copies:
@@ -14,13 +18,15 @@ Preflight executes the repo-authored setup and scorer commands in temporary fixt
 ```bash
 spotter tasks preflight corpus/dev-v1.toml
 spotter tasks preflight corpus/validation-v1.toml
+spotter tasks preflight corpus/dev-v2.toml
+spotter tasks preflight corpus/validation-v2.toml
 ```
 
 Run paid control/guidance arms from independent clean fixture copies:
 
 ```bash
-spotter tasks run corpus/dev-v1.toml --guidance "Inspect the failing check first." --run
-spotter tasks run corpus/dev-v1.toml --guidance "Inspect the failing check first." --run \
+spotter tasks run corpus/dev-v2.toml --guidance "Inspect the failing check first." --run
+spotter tasks run corpus/dev-v2.toml --guidance "Inspect the failing check first." --run \
   --resume ~/.spotter/experiments/task-batches/<batch>.jsonl
 ```
 

--- a/corpus/dev-v2.toml
+++ b/corpus/dev-v2.toml
@@ -1,0 +1,19 @@
+task_set_schema_version = 1
+task_set_id = "spotter-dev"
+version = 2
+split = "dev"
+
+[[tasks]]
+task_id = "fixture/query-parser-001"
+manifest = "tasks/query-parser.toml"
+sha256 = "e8f725c3d476c02c2a56580dbbacf238f700e1deed14b9ddd8e9ce9ec4b2d92f"
+
+[[tasks]]
+task_id = "fixture/settings-validation-001"
+manifest = "tasks/settings-validation.toml"
+sha256 = "7b05622ea7437140152c116cac81764a61f06d50c5b52ecbe0af60e404b8c4d8"
+
+[[tasks]]
+task_id = "fixture/cache-regression-001"
+manifest = "tasks/cache-regression.toml"
+sha256 = "e9413fe0c3b72865a600c0774108f02e8424c6ac28898be28b656a8c1fbde759"

--- a/corpus/fixtures/cache-regression/cache.py
+++ b/corpus/fixtures/cache-regression/cache.py
@@ -1,0 +1,2 @@
+def cache_key(namespace: str, item_key: str) -> str:
+    return f"{namespace.strip().lower()}:{item_key.lower()}"

--- a/corpus/fixtures/cache-regression/check.py
+++ b/corpus/fixtures/cache-regression/check.py
@@ -1,0 +1,5 @@
+from cache import cache_key
+
+assert cache_key(" Users ", "AbC-123") == "users:AbC-123"
+assert cache_key("USERS", "abc-123") == "users:abc-123"
+assert cache_key("USERS", " abc ") == "users: abc "

--- a/corpus/fixtures/record-contract/check.py
+++ b/corpus/fixtures/record-contract/check.py
@@ -1,0 +1,15 @@
+from records import normalize_record
+from renderer import render_record
+
+raw: dict[str, object] = {
+    "name": " Example ",
+    "tags": [" API ", "Bug", "api", "  ", "BUG"],
+}
+record = normalize_record(raw)
+assert record == {"name": "Example", "tags": ["api", "bug"]}
+assert render_record(record) == "Example [api, bug]"
+assert raw == {
+    "name": " Example ",
+    "tags": [" API ", "Bug", "api", "  ", "BUG"],
+}
+assert render_record(normalize_record({"name": "Plain"})) == "Plain"

--- a/corpus/fixtures/record-contract/records.py
+++ b/corpus/fixtures/record-contract/records.py
@@ -1,0 +1,5 @@
+def normalize_record(raw: dict[str, object]) -> dict[str, object]:
+    return {
+        "name": str(raw["name"]).strip(),
+        "tags": list(raw.get("tags", [])),
+    }

--- a/corpus/fixtures/record-contract/renderer.py
+++ b/corpus/fixtures/record-contract/renderer.py
@@ -1,0 +1,2 @@
+def render_record(record: dict[str, object]) -> str:
+    return str(record["name"])

--- a/corpus/fixtures/routing-investigation/app.py
+++ b/corpus/fixtures/routing-investigation/app.py
@@ -1,0 +1,5 @@
+from routing import route
+
+
+def dispatch(method: str, path: str) -> str | None:
+    return route(method, path)

--- a/corpus/fixtures/routing-investigation/check.py
+++ b/corpus/fixtures/routing-investigation/check.py
@@ -1,0 +1,7 @@
+from app import dispatch
+
+assert dispatch("get", "/health/") == "healthy"
+assert dispatch("post", "/items/") == "created"
+assert dispatch("get", "/") == "root"
+assert dispatch("get", "/health//") is None
+assert dispatch("delete", "/items/") is None

--- a/corpus/fixtures/routing-investigation/routing.py
+++ b/corpus/fixtures/routing-investigation/routing.py
@@ -1,0 +1,9 @@
+HANDLERS = {
+    ("GET", "/"): "root",
+    ("GET", "/health"): "healthy",
+    ("POST", "/items"): "created",
+}
+
+
+def route(method: str, path: str) -> str | None:
+    return HANDLERS.get((method, path))

--- a/corpus/fixtures/settings-validation/check.py
+++ b/corpus/fixtures/settings-validation/check.py
@@ -1,0 +1,15 @@
+from settings import normalize_settings
+
+assert normalize_settings({"endpoint": " https://api.test ", "retries": "2"}) == {
+    "endpoint": "https://api.test",
+    "retries": 2,
+}
+assert normalize_settings({"endpoint": "https://api.test"})["retries"] == 3
+
+for invalid in (0, -1, "many", None):
+    try:
+        normalize_settings({"endpoint": "https://api.test", "retries": invalid})
+    except ValueError:
+        pass
+    else:
+        raise AssertionError(f"retries={invalid!r} should be rejected")

--- a/corpus/fixtures/settings-validation/settings.py
+++ b/corpus/fixtures/settings-validation/settings.py
@@ -1,0 +1,5 @@
+def normalize_settings(raw: dict[str, object]) -> dict[str, object]:
+    return {
+        "endpoint": raw["endpoint"],
+        "retries": int(raw.get("retries", 3)),
+    }

--- a/corpus/tasks/cache-regression.toml
+++ b/corpus/tasks/cache-regression.toml
@@ -1,0 +1,36 @@
+task_schema_version = 1
+task_id = "fixture/cache-regression-001"
+prompt = "Normalize cache namespaces by trimming and lowercasing them without changing case or whitespace in item keys."
+
+[source]
+kind = "fixture"
+path = "fixtures/cache-regression"
+sha256 = "759a67fa2022315811afa6566f613e3fa7c8f47d0849f22163ab3a7c3a8a692d"
+
+[setup]
+command = "python3 -m compileall -q ."
+timeout_s = 30
+
+[precheck]
+command = "python3 check.py"
+timeout_s = 30
+expected = "failure"
+
+[known_good]
+command = '''python3 -c "from pathlib import Path; Path('cache.py').write_text('def cache_key(namespace: str, item_key: str) -> str:\n    return f\"{namespace.strip().lower()}:{item_key}\"\n')"'''
+timeout_s = 30
+
+[[checks]]
+id = "task-resolution"
+command = "python3 check.py"
+timeout_s = 30
+required = true
+
+[budget]
+wall_time_s = 600
+max_turns = 20
+
+[metadata]
+family = "regression-avoidance"
+difficulty = "dev"
+provenance = "spotter synthetic fixture v2"

--- a/corpus/tasks/record-contract.toml
+++ b/corpus/tasks/record-contract.toml
@@ -1,0 +1,36 @@
+task_schema_version = 1
+task_id = "fixture/record-contract-001"
+prompt = "Normalize record tags by trimming and lowercasing them, discard blanks, deduplicate in first-seen order, and render non-empty tags without mutating the input."
+
+[source]
+kind = "fixture"
+path = "fixtures/record-contract"
+sha256 = "ec4a4665e848239bbb5005cc5032bb68915ac1bfa0fb0ece3f6bea9e2a1b66fd"
+
+[setup]
+command = "python3 -m compileall -q ."
+timeout_s = 30
+
+[precheck]
+command = "python3 check.py"
+timeout_s = 30
+expected = "failure"
+
+[known_good]
+command = '''python3 -c "from pathlib import Path; Path('records.py').write_text('def normalize_record(raw: dict[str, object]) -> dict[str, object]:\n    tags: list[str] = []\n    for value in raw.get(\"tags\", []):\n        tag = str(value).strip().lower()\n        if tag and tag not in tags:\n            tags.append(tag)\n    return {\"name\": str(raw[\"name\"]).strip(), \"tags\": tags}\n'); Path('renderer.py').write_text('def render_record(record: dict[str, object]) -> str:\n    tags = list(record.get(\"tags\", []))\n    suffix = \" [{}]\".format(\", \".join(str(tag) for tag in tags)) if tags else \"\"\n    return \"{}{}\".format(record[\"name\"], suffix)\n')"'''
+timeout_s = 30
+
+[[checks]]
+id = "task-resolution"
+command = "python3 check.py"
+timeout_s = 30
+required = true
+
+[budget]
+wall_time_s = 900
+max_turns = 30
+
+[metadata]
+family = "multi-file-contract"
+difficulty = "validation"
+provenance = "spotter synthetic fixture v2"

--- a/corpus/tasks/routing-investigation.toml
+++ b/corpus/tasks/routing-investigation.toml
@@ -1,0 +1,36 @@
+task_schema_version = 1
+task_id = "fixture/routing-investigation-001"
+prompt = "Make request dispatch honor the existing route table when callers use lowercase methods and one trailing slash, without broadening unknown routes."
+
+[source]
+kind = "fixture"
+path = "fixtures/routing-investigation"
+sha256 = "46b470659d16919f37c566173f8e57df78d7844b5055a962b82715005d064efe"
+
+[setup]
+command = "python3 -m compileall -q ."
+timeout_s = 30
+
+[precheck]
+command = "python3 check.py"
+timeout_s = 30
+expected = "failure"
+
+[known_good]
+command = '''python3 -c "from pathlib import Path; Path('routing.py').write_text('HANDLERS = {(\"GET\", \"/\"): \"root\", (\"GET\", \"/health\"): \"healthy\", (\"POST\", \"/items\"): \"created\"}\n\ndef route(method: str, path: str) -> str | None:\n    normalized_path = path.removesuffix(\"/\") if path != \"/\" else path\n    return HANDLERS.get((method.upper(), normalized_path))\n')"'''
+timeout_s = 30
+
+[[checks]]
+id = "task-resolution"
+command = "python3 check.py"
+timeout_s = 30
+required = true
+
+[budget]
+wall_time_s = 900
+max_turns = 30
+
+[metadata]
+family = "evidence-inspection"
+difficulty = "validation"
+provenance = "spotter synthetic fixture v2"

--- a/corpus/tasks/settings-validation.toml
+++ b/corpus/tasks/settings-validation.toml
@@ -1,0 +1,36 @@
+task_schema_version = 1
+task_id = "fixture/settings-validation-001"
+prompt = "Normalize endpoint whitespace and require retries to be a positive integer while preserving the settings dictionary API."
+
+[source]
+kind = "fixture"
+path = "fixtures/settings-validation"
+sha256 = "40527e696e5fc66f5f1f8742a003b3b131b3ed189a202c99692be46b7bdf881a"
+
+[setup]
+command = "python3 -m compileall -q ."
+timeout_s = 30
+
+[precheck]
+command = "python3 check.py"
+timeout_s = 30
+expected = "failure"
+
+[known_good]
+command = '''python3 -c "from pathlib import Path; Path('settings.py').write_text('def normalize_settings(raw: dict[str, object]) -> dict[str, object]:\n    endpoint = str(raw[\"endpoint\"]).strip()\n    try:\n        retries = int(raw.get(\"retries\", 3))\n    except (TypeError, ValueError) as error:\n        raise ValueError(\"retries must be a positive integer\") from error\n    if retries < 1:\n        raise ValueError(\"retries must be a positive integer\")\n    return {\"endpoint\": endpoint, \"retries\": retries}\n')"'''
+timeout_s = 30
+
+[[checks]]
+id = "task-resolution"
+command = "python3 check.py"
+timeout_s = 30
+required = true
+
+[budget]
+wall_time_s = 600
+max_turns = 20
+
+[metadata]
+family = "missing-validation"
+difficulty = "dev"
+provenance = "spotter synthetic fixture v2"

--- a/corpus/validation-v2.toml
+++ b/corpus/validation-v2.toml
@@ -1,0 +1,19 @@
+task_set_schema_version = 1
+task_set_id = "spotter-validation"
+version = 2
+split = "validation"
+
+[[tasks]]
+task_id = "fixture/profile-contract-001"
+manifest = "tasks/profile-contract.toml"
+sha256 = "986d658545d3def14adfda2b3a01c7e7647ff30fba5f56db3eda88a9447f6529"
+
+[[tasks]]
+task_id = "fixture/routing-investigation-001"
+manifest = "tasks/routing-investigation.toml"
+sha256 = "a1c3f6ff58abba22c50d8c4a0f71281d53621b7f4b8efe0ca2f7f2bca836348a"
+
+[[tasks]]
+task_id = "fixture/record-contract-001"
+manifest = "tasks/record-contract.toml"
+sha256 = "b7619253dcf1fcc85195208af48d3887cec8736f8e5dfaaa22cff1b7420f153a"

--- a/docs/status.md
+++ b/docs/status.md
@@ -99,7 +99,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Shadow reviewer | ✅ | Produces `CONTINUE`, `VERIFY`, `NUDGE`; verdicts are recorded only | Move to event-driven candidates, then live delivery |
 | Audit / live state | 🟡 | Daemon-owned typed ThreadState distinguishes constraints, hypotheses, observations, verified facts, summaries, interventions, and coverage | Feed reviewer jobs and signals from immutable snapshots |
 | Evaluation labels / metrics | 🟡 | Coverage-aware labels plus durable Main action/token/timing, reviewer, gate-latency, and storage projections; unavailable values remain unknown | Add live resource/queue/delivery telemetry and objective outcome joins (#33, #38, #34) |
-| Counterfactual harness | ✅ | Same-prefix experiments plus resumable frozen task-set batches persist explicit classifications and bounded diagnostics | Expand the corpus and execute the first reportable multi-task control/guidance run (#21) |
+| Counterfactual harness | ✅ | Same-prefix experiments plus resumable frozen task-set batches; v2 has six disjoint synthetic tasks across five failure families | Execute and report the first real multi-task control/guidance run (#21) |
 | Standalone runtime | 🟡 | Long-lived process, IPC, lifecycle, isolated per-thread state, and App Server recovery ownership | Select and verify the shared endpoint during setup |
 | Runtime identity | ✅ | Logical threads/turns remain separate from per-connection attachment IDs and monotonically recovered epochs | Propagate the identity into future reviewer jobs |
 | App Server primary observation | 🟡 | Configured endpoints route through `spotterd` into normalized durable Trace IR and incremental ThreadState; a bounded value-free source audit and conformance corpus measure projection coverage | Collect labeled App Server failures to finish #37, then reduce Hooks in #86 |
@@ -153,7 +153,7 @@ Implementation progress and research evidence remain separate.
 | Can Spotter produce plausible semantic reviewer verdicts? | Yes, in shadow mode |
 | Can Spotter branch a shared prefix for counterfactual experiments? | Yes |
 | Is the fork instrument's causal noise floor known? | **No — #42** |
-| Is there a reproducible mechanically scored task corpus? | **Partial — frozen fixtures, preflight, isolated control/guidance execution, and condition-checked resume exist; corpus breadth and a real reportable run remain (#21)** |
+| Is there a reproducible mechanically scored task corpus? | **Partial — six frozen v2 tasks, preflight, isolated execution, and condition-checked resume exist; a real reportable run remains (#21)** |
 | Has live Spotter guidance been shown to improve outcomes? | **No** |
 | Is the App Server control boundary operationally viable? | **Yes for a configured Spotter-managed external path, including daemon reconnect/reconciliation** |
 | Is the post-App-Server visible-in-time ceiling measured? | **No — the instrument exists, but the current sample has 0 App Server sessions and 0/9 labeled sessions (#37)** |

--- a/tests/test_task_corpus.py
+++ b/tests/test_task_corpus.py
@@ -202,14 +202,32 @@ def test_preflight_classifies_required_check_timeout(tmp_path: Path) -> None:
     assert results[0].commands[-1].timed_out is True
 
 
-@pytest.mark.parametrize("name", ["dev-v1.toml", "validation-v1.toml"])
-def test_repo_corpus_is_frozen_and_preflight_ready(name: str) -> None:
+@pytest.mark.parametrize(
+    ("name", "expected_tasks"),
+    [
+        ("dev-v1.toml", 1),
+        ("validation-v1.toml", 1),
+        ("dev-v2.toml", 3),
+        ("validation-v2.toml", 3),
+    ],
+)
+def test_repo_corpus_is_frozen_and_preflight_ready(name: str, expected_tasks: int) -> None:
     path = Path(__file__).parents[1] / "corpus" / name
 
     task_set, results = preflight_task_set(path)
 
-    assert task_set.tasks
+    assert len(task_set.tasks) == expected_tasks
     assert all(result.classification == PreflightClassification.READY for result in results)
+
+
+def test_repo_v2_dev_and_validation_tasks_are_disjoint() -> None:
+    corpus = Path(__file__).parents[1] / "corpus"
+    dev = validate_task_set(corpus / "dev-v2.toml")
+    validation = validate_task_set(corpus / "validation-v2.toml")
+
+    assert {task.task_id for task in dev.tasks}.isdisjoint(
+        task.task_id for task in validation.tasks
+    )
 
 
 def test_task_batch_runs_clean_control_and_guidance_arms(


### PR DESCRIPTION
## Why

#21 has a resumable executor, but the v1 dev and validation sets each contained only one task. That is not broad enough for the first meaningful multi-task control/guidance run.

Related: #21

## What changed

- preserve the immutable v1 sets and add disjoint `dev-v2` / `validation-v2` sets with three tasks each
- add four mechanically scored fixtures covering missing validation, regression avoidance, evidence inspection, and a mutation-sensitive multi-file contract
- retain the existing localized parser fix and profile contract, yielding six tasks across five failure families
- freeze fixture and task-manifest hashes and prove every new scorer against both broken and known-good states
- document v2 as the current tuning/held-out split and update status without claiming intervention evidence

## Validation

- `ruff format --check .`
- `ruff check .`
- `mypy src tests`
- `pytest` (423 passed)
- `spotter tasks preflight corpus/dev-v2.toml` (3/3 `READY`)
- `spotter tasks preflight corpus/validation-v2.toml` (3/3 `READY`)

## Notes

No paid agent arms were run. This PR freezes the broader corpus; the first real reportable control/guidance batch remains the final #21 evidence step.