### PR TITLE
experiment(tasks): report first dev v2 batch

### DIFF
--- a/docs/experiments/dev-v2-first-run.json
+++ b/docs/experiments/dev-v2-first-run.json
@@ -1,0 +1,119 @@
+{
+  "schema_version": 1,
+  "run_id": "16532470-1be0-41e8-a0ea-b52f6f92b0a8",
+  "task_set": {
+    "id": "spotter-dev",
+    "version": 2,
+    "sha256": "ed6e398fa569b7dc556403cc6ca8c1cbf2b1c31f1eca0f4c76551d830edc0677"
+  },
+  "condition": {
+    "control_suffix": "Continue the task.",
+    "guidance_suffix": "Before editing, inspect the failing check and relevant code. Preserve unaffected behavior, make the smallest justified fix, and run the task check afterward."
+  },
+  "environment": {
+    "requested_model": "codex-config-default",
+    "resolved_rollout_model": "gpt-5.6-sol",
+    "resolved_from_rollout_headers": 6,
+    "codex_version": "codex-cli 0.147.0",
+    "python": "3.12.13",
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "sandbox": "workspace-write"
+  },
+  "started_at": "2026-08-13T10:42:10.078014+00:00",
+  "finished_at": "2026-08-13T10:45:23.578849+00:00",
+  "elapsed_seconds": 193.500835,
+  "summary": {
+    "executed_arms": 6,
+    "mechanically_judged_arms": 6,
+    "usable_pairs": 3,
+    "guidance_better": 0,
+    "control_better": 0,
+    "tie_success": 3,
+    "tie_failure": 0,
+    "infrastructure_failures": 0,
+    "non_fatal_mcp_shutdown_warning_arms": 6,
+    "control_agent_reported_tokens": 41912,
+    "guidance_agent_reported_tokens": 39270,
+    "control_elapsed_seconds": 96.720279,
+    "guidance_elapsed_seconds": 96.772302
+  },
+  "arms": [
+    {
+      "task_id": "fixture/query-parser-001",
+      "arm": "control",
+      "classification": "PASS",
+      "setup_exit": 0,
+      "agent_exit": 0,
+      "required_check_exits": [0],
+      "agent_reported_tokens": 12595,
+      "started_at": "2026-08-13T10:42:10.078468+00:00",
+      "ended_at": "2026-08-13T10:42:38.696471+00:00",
+      "non_fatal_mcp_shutdown_warning": true
+    },
+    {
+      "task_id": "fixture/query-parser-001",
+      "arm": "guidance",
+      "classification": "PASS",
+      "setup_exit": 0,
+      "agent_exit": 0,
+      "required_check_exits": [0],
+      "agent_reported_tokens": 13511,
+      "started_at": "2026-08-13T10:42:38.697484+00:00",
+      "ended_at": "2026-08-13T10:43:04.616268+00:00",
+      "non_fatal_mcp_shutdown_warning": true
+    },
+    {
+      "task_id": "fixture/settings-validation-001",
+      "arm": "guidance",
+      "classification": "PASS",
+      "setup_exit": 0,
+      "agent_exit": 0,
+      "required_check_exits": [0],
+      "agent_reported_tokens": 16401,
+      "started_at": "2026-08-13T10:43:04.619105+00:00",
+      "ended_at": "2026-08-13T10:43:46.717175+00:00",
+      "non_fatal_mcp_shutdown_warning": true
+    },
+    {
+      "task_id": "fixture/settings-validation-001",
+      "arm": "control",
+      "classification": "PASS",
+      "setup_exit": 0,
+      "agent_exit": 0,
+      "required_check_exits": [0],
+      "agent_reported_tokens": 14749,
+      "started_at": "2026-08-13T10:43:46.718189+00:00",
+      "ended_at": "2026-08-13T10:44:25.512717+00:00",
+      "non_fatal_mcp_shutdown_warning": true
+    },
+    {
+      "task_id": "fixture/cache-regression-001",
+      "arm": "control",
+      "classification": "PASS",
+      "setup_exit": 0,
+      "agent_exit": 0,
+      "required_check_exits": [0],
+      "agent_reported_tokens": 14568,
+      "started_at": "2026-08-13T10:44:25.513696+00:00",
+      "ended_at": "2026-08-13T10:44:54.821444+00:00",
+      "non_fatal_mcp_shutdown_warning": true
+    },
+    {
+      "task_id": "fixture/cache-regression-001",
+      "arm": "guidance",
+      "classification": "PASS",
+      "setup_exit": 0,
+      "agent_exit": 0,
+      "required_check_exits": [0],
+      "agent_reported_tokens": 9358,
+      "started_at": "2026-08-13T10:44:54.822417+00:00",
+      "ended_at": "2026-08-13T10:45:23.577865+00:00",
+      "non_fatal_mcp_shutdown_warning": true
+    }
+  ],
+  "raw_result": {
+    "spotter_home_relative_path": "experiments/task-batches/spotter-dev-v2-16532470-1be0-41e8-a0ea-b52f6f92b0a8.jsonl",
+    "sha256": "948226a9d1fcd768b69023b22d0a2fedc121bc058220e8550bdbc6bf4fb9f434",
+    "committed": false
+  }
+}

--- a/docs/experiments/dev-v2-first-run.md
+++ b/docs/experiments/dev-v2-first-run.md
@@ -1,0 +1,98 @@
+# Dev v2 first multi-task run
+
+Date: 2026-08-13
+
+Issue: [#21](https://github.com/spotter-agent/spotter/issues/21)
+
+Status: complete
+
+## Protocol frozen before execution
+
+Hypothesis: one generic evidence-first guidance message may preserve or improve mechanical task
+success versus the neutral continuation, particularly on validation and regression-sensitive tasks.
+
+The development set `corpus/dev-v2.toml` is used for this harness qualification run. The held-out
+`validation-v2` set remains unexecuted. Each of the three tasks receives one control arm and one
+guidance arm from independent clean fixture copies; order is counterbalanced by the frozen batch
+runner. This is six paid agent arms in total.
+
+Control suffix:
+
+```text
+Continue the task.
+```
+
+Guidance suffix:
+
+```text
+Before editing, inspect the failing check and relevant code. Preserve unaffected behavior, make the
+smallest justified fix, and run the task check afterward.
+```
+
+Each task's required mechanical scorer is the only success criterion. Agent, setup, check, timeout,
+and infrastructure outcomes remain separate classifications. Declared wall-time and max-turn
+budgets come from the frozen task manifests; the Codex backend enforces wall time but cannot enforce
+the recorded max-turn declaration.
+
+Decision rule: the instrument qualifies if all six arms produce durable explicit classifications
+and all mechanically judgeable pairs can be reported without infrastructure outcomes entering the
+task-success numerator. With only three development tasks and one continuation per arm, any observed
+benefit, harm, or tie is descriptive and must not enable live intervention or tune the held-out set.
+
+Execution command:
+
+```bash
+spotter tasks run corpus/dev-v2.toml \
+  --guidance "Before editing, inspect the failing check and relevant code. Preserve unaffected behavior, make the smallest justified fix, and run the task check afterward." \
+  --run
+```
+
+## Result
+
+The batch completed successfully from 2026-08-13 10:42:10Z through 10:45:23Z (193.50 seconds).
+All six arms produced durable `PASS` classifications with setup and required-check exit code 0.
+
+| Task | Control | Guidance | Pair outcome |
+| --- | --- | --- | --- |
+| `fixture/query-parser-001` | `PASS` | `PASS` | tie-success |
+| `fixture/settings-validation-001` | `PASS` | `PASS` | tie-success |
+| `fixture/cache-regression-001` | `PASS` | `PASS` | tie-success |
+
+Coverage and paired counts:
+
+```text
+executed arms:       6/6
+mechanically judged: 6/6
+usable pairs:        3/3
+guidance better:     0
+control better:      0
+tie-success:         3
+tie-failure:         0
+infrastructure loss: 0
+```
+
+The requested model was the Codex configuration default. All six retained Codex rollout headers
+resolved it to `gpt-5.6-sol`; the runner was `codex-cli 0.147.0`, Python was 3.12.13, and the sandbox
+was `workspace-write`. Agent-reported token totals were 41,912 for control and 39,270 for guidance.
+Summed arm elapsed time was 96.72 seconds for control and 96.77 seconds for guidance. These cost
+numbers are descriptive only: one continuation per task is not a stable efficiency estimate.
+
+All six agent stderr tails contained non-fatal MCP shutdown warnings. Agent exits and scorers still
+returned 0, so they did not reduce mechanical coverage; they remain an operational diagnostic rather
+than a task failure.
+
+The raw result remains under Spotter-owned storage as
+`experiments/task-batches/spotter-dev-v2-16532470-1be0-41e8-a0ea-b52f6f92b0a8.jsonl` relative to
+`SPOTTER_HOME`. Its SHA-256 is
+`948226a9d1fcd768b69023b22d0a2fedc121bc058220e8550bdbc6bf4fb9f434`. It is not committed because
+it contains bounded transcript-derived agent output; the checked-in
+[derived result](dev-v2-first-run.json) omits that content while preserving per-arm outcomes and
+provenance.
+
+## Interpretation
+
+This run qualifies the #21 instrument end to end: frozen multi-task set, preflight, independent
+arms, durable classified outcomes, coverage reporting, and a reproducible derived record all worked.
+The observed result is a descriptive null/tie on three easy development tasks. It does not establish
+intervention advantage, does not estimate the replay noise floor, and does not justify changing live
+intervention defaults. `validation-v2` remains held out.

--- a/docs/research.md
+++ b/docs/research.md
@@ -25,7 +25,7 @@ The literature and implementation precedents behind these hypotheses are catalog
 | prefix-only early auditing | AgentForesight | detection timing / first-deviation metrics | measurement design, not fully executed |
 | evidence-conditioned action gating | ECLoop / interwhen | bounded deterministic/evidence gates | selected deterministic gates implemented; broader evidence gates unproven |
 | stop/restart bad trajectories | FailFast-RestartSmart | `INTERRUPT` / `RESTART` | target only |
-| intervention advantage | Calibration Is Not Control | same-prefix counterfactual experiment | harness implemented; evidence missing |
+| intervention advantage | Calibration Is Not Control | same-prefix counterfactual experiment | dev-v2 qualification was 3/3 tie-success; causal evidence missing |
 | claim/evidence invalidation | Grounded Continuation | audit ledger + stale propagation | implemented, observation-limited |
 | neutral exploration awareness | AgentProcessBench | candidates are not verdicts | design principle |
 | normalized runtime traces | HarnessFix / NeMo Relay | Trace IR / adapter boundary | partial implementation / target expansion |
@@ -48,8 +48,8 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 needs experiment · ❌ m
 | snapshot/fork/replay | ✅ | machinery exists and can branch from recorded prefixes |
 | model-backed semantic judgment | ✅ shadow | reviewer produces plausible structured verdicts but does not affect Main |
 | claim/evidence ledger | 🟡 | works only where the observation surface exposes usable outcomes |
-| counterfactual experiment framework | ✅ | machinery exists; not enough executed ground-truth runs |
-| ground-truth task set | ❌ | major current evaluation blocker |
+| counterfactual experiment framework | ✅ | frozen/resumable machinery completed its first 6-arm development qualification run |
+| ground-truth task set | 🟡 | six synthetic frozen tasks across five failure families; external/ecosystem breadth remains missing |
 | positive intervention advantage | ❌ | not established |
 | event-driven reviewer dispatch | ❌ | current reviewer trigger is cadence-based |
 | live `VERIFY / NUDGE` delivery | ❌ | target: `turn/steer` |
@@ -57,6 +57,10 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 needs experiment · ❌ m
 | App Server observation/control viability | ✅ PoC | #78 proved a Spotter-managed external App Server can be shared by the real TUI and Spotter and can steer the active turn |
 | production App Server observation path | 🟡 | async client/control surface exists; normalized event routing, identity reconciliation, and reconnect remain |
 | speculative supervision | ❌ | no measured lookahead/prediction/intervention pipeline yet |
+
+The first [dev-v2 multi-task run](experiments/dev-v2-first-run.md) completed all six arms and produced
+three tie-success pairs. This qualifies the task instrument; it is a small development-set null result,
+not positive intervention evidence. The held-out validation set remains unexecuted.
 
 The Hook-collected corpus exposed a concrete observation limit for the audit ledger: directly usable outcomes were present in only a small fraction of real tool results. The App Server migration must **re-measure** that ceiling rather than assume it is permanent.
 
@@ -393,7 +397,8 @@ RESTART
 
 # Current top evidence gaps
 
-1. **No ground-truth task set** large enough to run meaningful counterfactual experiments.
+1. **No broad ground-truth task set** beyond the six-task synthetic v2 foundation; ecosystem and
+   sample-size coverage remain too small for a meaningful intervention claim.
 2. **No measured positive intervention advantage** for Spotter guidance.
 3. **No sampled miss-rate/recall estimate** for semantic detector behavior.
 4. **No post-migration App Server observability-ceiling measurement** yet. The coverage taxonomy,

--- a/docs/status.md
+++ b/docs/status.md
@@ -78,10 +78,14 @@ App Server strategy as pending; it does not invent an endpoint or claim ownershi
 
 In parallel, the highest-value evidence foundations remain:
 
-- [#21](https://github.com/spotter-agent/spotter/issues/21) — mechanically scored task set;
 - [#42](https://github.com/spotter-agent/spotter/issues/42) — replay/fork fidelity and noise floor;
 - [#37](https://github.com/spotter-agent/spotter/issues/37) — observability ceiling baseline/post-migration measurement;
 - [#33](https://github.com/spotter-agent/spotter/issues/33) — runtime cost/timing/outcome telemetry.
+
+[#21](https://github.com/spotter-agent/spotter/issues/21) now has frozen dev/validation v2 sets,
+preflight, resumable classified execution, and a [first real three-task development run](experiments/dev-v2-first-run.md).
+All three pairs were tie-success; this qualifies the instrument but is not evidence of intervention
+advantage.
 
 ---
 
@@ -99,7 +103,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Shadow reviewer | ✅ | Produces `CONTINUE`, `VERIFY`, `NUDGE`; verdicts are recorded only | Move to event-driven candidates, then live delivery |
 | Audit / live state | 🟡 | Daemon-owned typed ThreadState distinguishes constraints, hypotheses, observations, verified facts, summaries, interventions, and coverage | Feed reviewer jobs and signals from immutable snapshots |
 | Evaluation labels / metrics | 🟡 | Coverage-aware labels plus durable Main action/token/timing, reviewer, gate-latency, and storage projections; unavailable values remain unknown | Add live resource/queue/delivery telemetry and objective outcome joins (#33, #38, #34) |
-| Counterfactual harness | ✅ | Same-prefix experiments plus resumable frozen task-set batches; v2 has six disjoint synthetic tasks across five failure families | Execute and report the first real multi-task control/guidance run (#21) |
+| Counterfactual harness | ✅ | Same-prefix experiments plus resumable frozen task-set batches; the first real dev-v2 run completed 6/6 arms with three tie-success pairs | Measure replay noise (#42) before interpreting intervention effects |
 | Standalone runtime | 🟡 | Long-lived process, IPC, lifecycle, isolated per-thread state, and App Server recovery ownership | Select and verify the shared endpoint during setup |
 | Runtime identity | ✅ | Logical threads/turns remain separate from per-connection attachment IDs and monotonically recovered epochs | Propagate the identity into future reviewer jobs |
 | App Server primary observation | 🟡 | Configured endpoints route through `spotterd` into normalized durable Trace IR and incremental ThreadState; a bounded value-free source audit and conformance corpus measure projection coverage | Collect labeled App Server failures to finish #37, then reduce Hooks in #86 |
@@ -153,7 +157,7 @@ Implementation progress and research evidence remain separate.
 | Can Spotter produce plausible semantic reviewer verdicts? | Yes, in shadow mode |
 | Can Spotter branch a shared prefix for counterfactual experiments? | Yes |
 | Is the fork instrument's causal noise floor known? | **No — #42** |
-| Is there a reproducible mechanically scored task corpus? | **Partial — six frozen v2 tasks, preflight, isolated execution, and condition-checked resume exist; a real reportable run remains (#21)** |
+| Is there a reproducible mechanically scored task corpus? | **Yes for the synthetic v2 foundation — six frozen tasks and a reportable 6/6-arm dev run; external/ecosystem breadth remains future work (#21)** |
 | Has live Spotter guidance been shown to improve outcomes? | **No** |
 | Is the App Server control boundary operationally viable? | **Yes for a configured Spotter-managed external path, including daemon reconnect/reconciliation** |
 | Is the post-App-Server visible-in-time ceiling measured? | **No — the instrument exists, but the current sample has 0 App Server sessions and 0/9 labeled sessions (#37)** |


### PR DESCRIPTION
## Question / hypothesis

Can the frozen #21 corpus and resumable runner complete a real multi-task control/guidance experiment with mechanically judgeable outcomes and no infrastructure failures entering task-success counts? A generic evidence-first nudge may preserve or improve success, but this three-task dev run is an instrument qualification rather than an intervention-effect measurement.

Closes #21

## Method

- froze the protocol in the report before execution
- ran `dev-v2` only; `validation-v2` remains held out
- executed one control and one guidance arm for each of three tasks from independent clean copies
- used the generic guidance: inspect the failing check/relevant code, preserve unaffected behavior, make the smallest justified fix, then run the task check
- judged outcomes only with frozen required scorers
- retained the raw Spotter JSONL locally and committed a transcript-free per-arm derived result tied to its SHA-256

## Evidence

- executed/mechanically judged arms: 6/6
- usable pairs: 3/3
- guidance better: 0
- control better: 0
- tie-success: 3
- infrastructure failures: 0
- control/guidance agent-reported tokens: 41,912 / 39,270 (descriptive only)
- control/guidance summed elapsed seconds: 96.72 / 96.77
- all six arms emitted non-fatal MCP shutdown warnings, but agent/setup/check exits were 0
- raw JSONL SHA-256: `948226a9d1fcd768b69023b22d0a2fedc121bc058220e8550bdbc6bf4fb9f434`
- full repository validation: `ruff format --check .`, `ruff check .`, `mypy src tests`, `pytest` (423 passed)
- derived JSON was programmatically checked against all six raw arm rows and passed the repository secret-pattern scan

## Decision impact

#21 is complete as an evaluation foundation: freeze, preflight, isolated execution, classification, resume, and a real multi-task report all work. The observed result is a small dev-set null/tie, not evidence of intervention advantage. Do not change live-intervention defaults or tune the held-out set. Measure replay noise under #42 before interpreting later same-prefix intervention effects.