### PR TITLE
feat(replay): checkpoint session baseline for early forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,9 @@ spotter experiment --session <id> --step <n> --guidance "..." --check "..."
 spotter experiment --session <id> --step <n> --neutral --pairs 3 --check "..." --run
 ```
 
-`spotter fork` writes a durable manifest under `~/.spotter/fork-manifests/`. The manifest links the
+When snapshotting is enabled, `SessionStart` pins one baseline Git snapshot so read-only exploration
+before the first mutation has a fork anchor; mutation boundaries continue to add deduplicated
+snapshots. `spotter fork` writes a durable manifest under `~/.spotter/fork-manifests/`. The manifest links the
 source event, snapshot, rollout-prefix digest, external-effect warnings, and captured environment
 fingerprint. Counterfactual pairs are fully prepared and must pass shared-prefix and captured-
 environment parity checks before either agent arm runs. Ignored files, environment variables, and

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -798,6 +798,11 @@ captured environment fingerprint. The fingerprint covers tracked/untracked Git s
 status, Git/Python versions, and platform identity. Ignored files, environment variables, and agent
 configuration remain explicitly uncaptured limitations.
 
+With snapshotting enabled, the Codex `SessionStart` Hook pins a baseline snapshot for the reported
+Git working directory. Read-only proposals before the first mutation can therefore reuse that one
+anchor with their reconstructed rollout context; Spotter does not create a filesystem snapshot for
+every observation. Mutation boundaries keep the existing before/after snapshots and tree dedup.
+
 Forked worktree lifecycle:
 
 ```text

--- a/docs/research.md
+++ b/docs/research.md
@@ -263,7 +263,9 @@ Measure:
 The harness now has an explicit neutral-noise mode: each repeated pair receives the same control
 prompt after shared-prefix/environment preflight, and the summary separates mechanical outcome
 disagreement from environment mismatch and infrastructure failure. No representative real-prefix
-run has established the rate yet.
+run has established the rate yet. New Hook-observed sessions pin a baseline snapshot at
+`SessionStart`, removing the previous pre-mutation read-only blind region without snapshotting every
+observation; historical sessions whose snapshot objects were pruned remain non-recoverable.
 
 Intervention deltas smaller than the instrument noise floor should not be overinterpreted.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -98,8 +98,8 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Hook ingestion | ✅ | `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse` are journaled | Measure App Server parity in #37, then remove redundant Hooks in #86 |
 | Deterministic gate | ✅ | Shell-aware daemon evaluation over bounded local IPC; unavailable/timeout uses the local Gate, while incompatible responses fail open | Continue policy precision/miss-rate measurement |
 | Journal | ✅ | Crash-tolerant JSONL stores identity-rich App Server Trace IR with locking, fsync, torn-tail recovery, and recovery gaps | Add bounded retention/checkpoint lifecycle in #89 |
-| Snapshot | ✅ | Git-backed snapshots, deduplication, pruning, detached restore | Preserve lineage through runtime/retention migration (#89) |
-| Fork / replay | ✅ | Continue Codex from a shared prefix in a detached worktree; persist prefix/environment provenance, preflight pair parity, and run identical neutral-arm repetitions | Execute a representative neutral replay corpus and measure remaining uncaptured drift in #42 |
+| Snapshot | ✅ | Git-backed session baseline and mutation snapshots, deduplication, pruning, detached restore | Preserve lineage through runtime/retention migration (#89) |
+| Fork / replay | ✅ | Continue Codex from a shared prefix, including pre-mutation read-only exploration; persist provenance, preflight pair parity, and run identical neutral-arm repetitions | Execute a representative neutral replay corpus and quantify branch coverage in #42 |
 | Shadow reviewer | ✅ | Produces `CONTINUE`, `VERIFY`, `NUDGE`; verdicts are recorded only | Move to event-driven candidates, then live delivery |
 | Audit / live state | 🟡 | Daemon-owned typed ThreadState distinguishes constraints, hypotheses, observations, verified facts, summaries, interventions, and coverage | Feed reviewer jobs and signals from immutable snapshots |
 | Evaluation labels / metrics | 🟡 | Coverage-aware labels plus durable Main action/token/timing, reviewer, gate-latency, and storage projections; unavailable values remain unknown | Add live resource/queue/delivery telemetry and objective outcome joins (#33, #38, #34) |

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -306,6 +306,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "experiment":
         if not args.session or args.step is None or (not args.neutral and not args.guidance):
             parser.error("experiment requires --session, --step and either --guidance or --neutral")
+        if args.neutral and args.guidance:
+            parser.error("--neutral and --guidance cannot be used together")
         if args.pairs < 1:
             parser.error("--pairs must be >= 1")
         try:

--- a/src/spotter/experiment.py
+++ b/src/spotter/experiment.py
@@ -211,6 +211,8 @@ def run_experiment(
     """Build (and with run=True, execute) n counterfactual pairs."""
     if pairs < 1:
         raise ValueError("pairs must be >= 1 — an empty experiment is not a successful one")
+    if neutral and guidance:
+        raise ValueError("neutral noise mode cannot include guidance")
     if not neutral and not guidance:
         raise ValueError("guidance is required unless neutral noise mode is selected")
     experiment_mode = "neutral-noise" if neutral else "guidance"

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -249,14 +249,15 @@ def run_hook(
         )
     if event.kind == "tool_result":
         event.payload["checkpoint"] = journal.last_snapshot()
-    if (
+    baseline_snapshot = config.snapshot_on_patch and event.kind == "sessionstart"
+    mutation_snapshot = (
         config.snapshot_on_patch
         and event.kind in ("tool_proposal", "tool_result")
         and event.payload.get("reversibility_class") == "B"
-        and isinstance(cwd, str)
-    ):
-        # PreToolUse captures the state before a reversible local mutation;
-        # PostToolUse captures the state after it, preserving its lineage.
+    )
+    if (baseline_snapshot or mutation_snapshot) and isinstance(cwd, str):
+        # SessionStart makes early read-only proposals forkable. Pre/PostToolUse
+        # continue to capture state around reversible local mutations.
         # The global lock closes the ref-created-but-not-yet-journaled window
         # a concurrent prune --apply could otherwise exploit.
         with global_lock():

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -218,6 +218,11 @@ def test_guidance_is_required_outside_neutral_mode() -> None:
         run_experiment("s1", 5, None)
 
 
+def test_neutral_mode_rejects_guidance_provenance() -> None:
+    with pytest.raises(ValueError, match="cannot include guidance"):
+        run_experiment("s1", 5, "do something different", neutral=True)
+
+
 def test_cli_accepts_neutral_mode_without_guidance(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 
@@ -233,6 +238,22 @@ def test_cli_accepts_neutral_mode_without_guidance(monkeypatch: pytest.MonkeyPat
     assert main(["experiment", "--session", "s1", "--step", "5", "--neutral"]) == 0
     assert captured["guidance"] is None
     assert captured["neutral"] is True
+
+
+def test_cli_rejects_neutral_mode_with_guidance() -> None:
+    with pytest.raises(SystemExit):
+        main(
+            [
+                "experiment",
+                "--session",
+                "s1",
+                "--step",
+                "5",
+                "--neutral",
+                "--guidance",
+                "different",
+            ]
+        )
 
 
 def test_check_runs_in_each_fork_worktree(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -8,6 +8,7 @@ import pytest
 from spotter.config import GatesConfig, MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.daemon import DaemonClient, DaemonProtocolError, DaemonServer, DaemonTimeout
 from spotter.hook import event_from_hook, journal_path, run_hook
+from spotter.replay import fork
 from spotter.snapshot import StepJournal, restore_snapshot
 
 
@@ -236,6 +237,69 @@ def test_unknown_events_still_journal(spotter_home: Path) -> None:
     assert records[0].event.identity.provenance.legacy_session_id == "s2"
     assert records[0].event.provenance is not None
     assert records[0].event.provenance.source == "codex_hook"
+
+
+def test_session_start_takes_baseline_snapshot_for_early_forks(
+    tmp_path: Path, spotter_home: Path
+) -> None:
+    import subprocess
+
+    repo = tmp_path / "baseline-repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    (repo / "x.txt").write_text("baseline")
+    payload = {"hook_event_name": "SessionStart", "session_id": "baseline", "cwd": str(repo)}
+
+    assert run_hook(payload, _config(observation_only=True)) is None
+
+    record = StepJournal.load(journal_path(payload))[0]
+    assert record.event.kind == "sessionstart"
+    assert record.snapshot
+    restored = tmp_path / "baseline-restored"
+    restore_snapshot(repo, record.snapshot, restored)
+    assert (restored / "x.txt").read_text() == "baseline"
+
+    proposal = {
+        "hook_event_name": "PreToolUse",
+        "session_id": "baseline",
+        "cwd": str(repo),
+        "tool_name": "Bash",
+        "tool_use_id": "early-call",
+        "tool_input": {"command": "sed -n '1,20p' x.txt"},
+    }
+    assert run_hook(proposal, _config(observation_only=True)) is None
+    codex_home = tmp_path / "codex"
+    rollout = codex_home / "sessions" / "rollout-baseline.jsonl"
+    rollout.parent.mkdir(parents=True)
+    rollout.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "session_meta",
+                        "payload": {"session_id": "baseline", "id": "baseline"},
+                    }
+                ),
+                json.dumps({"type": "response_item", "payload": {"call_id": "early-call"}}),
+            ]
+        )
+        + "\n"
+    )
+    plan = fork("baseline", 1, codex_home=codex_home)
+    assert Path(plan.worktree, "x.txt").read_text() == "baseline"
+
+
+def test_session_start_snapshot_failure_fails_open(tmp_path: Path, spotter_home: Path) -> None:
+    payload = {
+        "hook_event_name": "SessionStart",
+        "session_id": "baseline-failure",
+        "cwd": str(tmp_path / "not-a-repo"),
+    }
+
+    assert run_hook(payload, _config(observation_only=True)) is None
+    assert StepJournal.load(journal_path(payload))[0].snapshot is None
 
 
 def test_apply_patch_takes_snapshot_for_fork(


### PR DESCRIPTION
## Summary
- pin a deduplicated Git baseline snapshot at Codex `SessionStart` so pre-mutation read-only proposals have a fork anchor
- verify the full `SessionStart -> first read-only proposal -> fork` path and preserve fail-open behavior outside Git repositories
- reject ambiguous `--neutral --guidance` experiments so neutral artifacts cannot carry guidance provenance

This is another bounded #42 slice. Historical sessions whose snapshot objects are already unavailable remain non-recoverable; representative neutral executions and the coverage report still remain.

## Validation
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (435 passed)

Related to #42.