### PR TITLE
fix(integration): retain session-start hook

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -387,6 +387,7 @@ Plan
   App Server strategy: codex-managed-external
   Runtime mode: managed/login-scoped
   Hooks:
+    add SessionStart
     add PreToolUse
     remove legacy PostToolUse
     remove legacy UserPromptSubmit
@@ -462,7 +463,7 @@ Example manifest:
 
 ```json
 {
-  "schema": 1,
+  "schema": 2,
   "agent": "codex",
   "setup_by": "0.6.0",
   "agent_path": "/opt/homebrew/bin/codex",
@@ -471,7 +472,10 @@ Example manifest:
   "app_server_endpoint": null,
   "runtime_mode": "managed",
   "service_owned": true,
-  "owned_hook": {"event": "PreToolUse", "matcher": ".*", "hook": {"type": "command"}},
+  "owned_hooks": [
+    {"event": "PreToolUse", "matcher": ".*", "hook": {"type": "command"}},
+    {"event": "SessionStart", "matcher": null, "hook": {"type": "command"}}
+  ],
   "legacy_hooks_removed": [{"event": "PostToolUse"}],
   "config_fingerprint_before": "...",
   "created_at": "..."
@@ -1282,12 +1286,13 @@ install standalone runtime integration
       ↓
 remove observation hooks replaced by App Server
       ↓
-retain only required PreToolUse gate
+retain SessionStart baseline plus required PreToolUse gate until #86 proves lifecycle parity
 ```
 
 Migration rules:
 
 - never register duplicate Spotter Hooks;
+- migrate schema 1 manifests to the owned-Hook list and reconcile the missing `SessionStart` Hook;
 - preserve existing `~/.spotter` data;
 - record which legacy mutations were removed;
 - keep rollback information until verification succeeds;

--- a/docs/status.md
+++ b/docs/status.md
@@ -107,7 +107,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Standalone runtime | 🟡 | Long-lived process, IPC, lifecycle, isolated per-thread state, and App Server recovery ownership | Select and verify the shared endpoint during setup |
 | Runtime identity | ✅ | Logical threads/turns remain separate from per-connection attachment IDs and monotonically recovered epochs | Propagate the identity into future reviewer jobs |
 | App Server primary observation | 🟡 | Configured endpoints route through `spotterd` into normalized durable Trace IR and incremental ThreadState; a bounded value-free source audit and conformance corpus measure projection coverage | Collect labeled App Server failures to finish #37, then reduce Hooks in #86 |
-| Managed Codex lifecycle | 🟡 | Transactional setup/teardown, managed service, diagnostics, and configured-endpoint recovery | Add verified endpoint selection without claiming shared-process ownership |
+| Managed Codex lifecycle | 🟡 | Transactional setup/teardown, managed service, diagnostics, configured-endpoint recovery, and a temporary `SessionStart` baseline Hook until #86 parity | Add verified endpoint selection without claiming shared-process ownership |
 | Runtime reconnect/recovery | ✅ | Explicit connect/reconcile/backoff states, restart hydration, durable gaps, capability/server fingerprints, and stale-control fencing | Add retention/checkpoints in #89 |
 | Event-driven detection | ❌ | Reviewer is still cadence-based | #28 after Runtime/Observe |
 | Live `VERIFY` / `NUDGE` | ❌ | Reviewer decisions stop at the journal | #22 via `turn/steer` |

--- a/src/spotter/doctor.py
+++ b/src/spotter/doctor.py
@@ -277,21 +277,23 @@ def check_integration() -> IntegrationInspection:
             Check("Codex integration", FAIL, f"manifest state is {manifest.state!r}"),
             False,
         )
-    owned = manifest.owned_hook
-    if not isinstance(owned, dict) or not isinstance(owned.get("hook"), dict):
+    owned = manifest.owned_hooks
+    if not isinstance(owned, list) or not all(
+        isinstance(entry, dict) and isinstance(entry.get("hook"), dict) for entry in owned
+    ):
         return IntegrationInspection(
             manifest,
-            Check("Codex integration", FAIL, "manifest owned Hook is invalid"),
+            Check("Codex integration", FAIL, "manifest owned Hooks are invalid"),
             False,
         )
-    expected = (owned.get("event"), owned.get("matcher"), owned.get("hook"))
-    if spotter_hooks != [expected]:
+    expected = [(entry.get("event"), entry.get("matcher"), entry.get("hook")) for entry in owned]
+    if spotter_hooks != expected:
         return IntegrationInspection(
             manifest,
             Check(
                 "Codex integration",
                 FAIL,
-                "owned Hook is missing, user-modified, or duplicated "
+                "owned Hooks are missing, user-modified, or duplicated "
                 f"({len(spotter_hooks)} found); run `spotter setup codex` to reconcile",
             ),
             False,

--- a/src/spotter/integration.py
+++ b/src/spotter/integration.py
@@ -29,7 +29,7 @@ from spotter.daemon import (
 from spotter.doctor import OK, check_roundtrip
 from spotter.paths import secure_dir, spotter_home
 
-MANIFEST_SCHEMA = 1
+MANIFEST_SCHEMA = 2
 
 
 class IntegrationError(RuntimeError):
@@ -167,7 +167,7 @@ class IntegrationManifest:
     service_owned: bool
     hooks_file: str
     hooks_file_created: bool
-    owned_hook: dict[str, Any]
+    owned_hooks: list[dict[str, Any]]
     legacy_hooks_removed: list[dict[str, Any]] = field(default_factory=list)
     legacy_plugins_removed: list[str] = field(default_factory=list)
     config_fingerprint_before: str | None = None
@@ -189,7 +189,16 @@ class IntegrationManifest:
             raise IntegrationError(f"integration manifest is unreadable: {error}") from error
         if not isinstance(raw, dict):
             raise IntegrationError("integration manifest must be a JSON object")
-        if raw.get("schema") != MANIFEST_SCHEMA:
+        schema = raw.get("schema")
+        if schema == 1:
+            owned = raw.pop("owned_hook", None)
+            raw["owned_hooks"] = [owned]
+            if isinstance(owned, dict) and isinstance(owned.get("hook"), dict):
+                raw["owned_hooks"].append(
+                    {"event": "SessionStart", "matcher": None, "hook": owned["hook"]}
+                )
+            raw["schema"] = MANIFEST_SCHEMA
+        elif schema != MANIFEST_SCHEMA:
             raise IntegrationError(f"unsupported integration manifest schema {raw.get('schema')!r}")
         try:
             return cls(**raw)
@@ -266,12 +275,12 @@ class IntegrationManager:
             command += f" --config {shlex.quote(str(self.config_path))}"
         return command + " || true"
 
-    def _owned_hook(self) -> dict[str, Any]:
-        return {
-            "event": "PreToolUse",
-            "matcher": ".*",
-            "hook": {"type": "command", "command": self._hook_command()},
-        }
+    def _owned_hooks(self) -> list[dict[str, Any]]:
+        hook = {"type": "command", "command": self._hook_command()}
+        return [
+            {"event": "PreToolUse", "matcher": ".*", "hook": hook},
+            {"event": "SessionStart", "matcher": None, "hook": hook},
+        ]
 
     @staticmethod
     def _is_spotter_hook(hook: object) -> bool:
@@ -299,17 +308,17 @@ class IntegrationManager:
         updated = copy.deepcopy(raw)
         events = cast(dict[str, list[dict[str, Any]]], updated.setdefault("hooks", {}))
         removed: list[dict[str, Any]] = []
-        owned = self._owned_hook()
+        owned = self._owned_hooks()
         for event, groups in list(events.items()):
             kept_groups: list[dict[str, Any]] = []
             for group in groups:
                 kept_hooks = []
                 for hook in cast(list[dict[str, Any]], group["hooks"]):
                     if self._is_spotter_hook(hook):
-                        if (event, group.get("matcher"), hook) != (
-                            owned["event"],
-                            owned["matcher"],
-                            owned["hook"],
+                        if not any(
+                            (event, group.get("matcher"), hook)
+                            == (entry["event"], entry["matcher"], entry["hook"])
+                            for entry in owned
                         ):
                             removed.append(
                                 {"event": event, "matcher": group.get("matcher"), "hook": hook}
@@ -324,9 +333,11 @@ class IntegrationManager:
             else:
                 events.pop(event, None)
 
-        events.setdefault("PreToolUse", []).append(
-            {"matcher": owned["matcher"], "hooks": [owned["hook"]]}
-        )
+        for entry in owned:
+            group = {"hooks": [entry["hook"]]}
+            if entry["matcher"] is not None:
+                group["matcher"] = entry["matcher"]
+            events.setdefault(entry["event"], []).append(group)
         return updated, removed
 
     def _legacy_plugins(self) -> tuple[str, ...]:
@@ -389,7 +400,7 @@ class IntegrationManager:
         _atomic_write(self.hooks_path, content)
         return content
 
-    def _verify(self, owned: dict[str, Any]) -> None:
+    def _verify(self, owned: list[dict[str, Any]]) -> None:
         status = asyncio.run(self.service.status())
         if status.health != RuntimeHealth.HEALTHY:
             raise IntegrationError(
@@ -402,7 +413,8 @@ class IntegrationManager:
                 for hook in cast(list[dict[str, Any]], group["hooks"]):
                     if self._is_spotter_hook(hook):
                         matches.append((event, group.get("matcher"), hook))
-        if matches != [(owned["event"], owned["matcher"], owned["hook"])]:
+        expected = [(entry["event"], entry["matcher"], entry["hook"]) for entry in owned]
+        if matches != expected:
             raise IntegrationError(
                 "Codex Hook verification found duplicate or drifted Spotter hooks"
             )
@@ -462,7 +474,7 @@ class IntegrationManager:
                     raise IntegrationError(
                         f"spotterd failed to start: {started.detail or started.health}"
                     )
-                owned = self._owned_hook()
+                owned = self._owned_hooks()
                 self._verify(owned)
             except Exception as error:
                 rollback()
@@ -491,7 +503,7 @@ class IntegrationManager:
                 hooks_file_created=(
                     hooks_before is None if existing is None else existing.hooks_file_created
                 ),
-                owned_hook=self._owned_hook(),
+                owned_hooks=self._owned_hooks(),
                 legacy_hooks_removed=previous_hooks + removed_hooks,
                 legacy_plugins_removed=list(
                     dict.fromkeys([*previous_plugins, *plan.legacy_plugins])
@@ -548,19 +560,20 @@ class IntegrationManager:
                     else ManagedServiceManager()
                 )
             hooks, before = self._read_hooks()
-            owned = manifest.owned_hook
             events = cast(dict[str, list[dict[str, Any]]], hooks["hooks"])
-            groups = events.get(cast(str, owned["event"]), [])
-            kept_groups = []
-            for group in groups:
-                kept = [hook for hook in group["hooks"] if hook != owned["hook"]]
-                if kept:
-                    group["hooks"] = kept
-                    kept_groups.append(group)
-            if kept_groups:
-                events[cast(str, owned["event"])] = kept_groups
-            else:
-                events.pop(cast(str, owned["event"]), None)
+            for owned in manifest.owned_hooks:
+                event = cast(str, owned["event"])
+                groups = events.get(event, [])
+                kept_groups = []
+                for group in groups:
+                    kept = [hook for hook in group["hooks"] if hook != owned["hook"]]
+                    if kept:
+                        group["hooks"] = kept
+                        kept_groups.append(group)
+                if kept_groups:
+                    events[event] = kept_groups
+                else:
+                    events.pop(event, None)
             try:
                 if manifest.hooks_file_created and hooks == {"hooks": {}}:
                     self.hooks_path.unlink(missing_ok=True)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -115,7 +115,7 @@ def test_setup_is_idempotent_and_teardown_preserves_unowned_config(
     assert first.state == second.state == "ready"
     assert first.created_at == second.created_at
     assert len(second.legacy_hooks_removed) == 3
-    assert [event for event, _ in _spotter_hooks(hooks_path)] == ["PreToolUse"]
+    assert [event for event, _ in _spotter_hooks(hooks_path)] == ["PreToolUse", "SessionStart"]
     assert service.starts == 2
     assert hooks_path.read_bytes() == first_hooks
 
@@ -129,7 +129,7 @@ def test_setup_is_idempotent_and_teardown_preserves_unowned_config(
     assert not manager.manifest_path.exists()
 
     manager.setup()
-    assert [event for event, _ in _spotter_hooks(hooks_path)] == ["PreToolUse"]
+    assert [event for event, _ in _spotter_hooks(hooks_path)] == ["PreToolUse", "SessionStart"]
 
 
 def test_setup_and_teardown_remove_a_hooks_file_created_by_spotter(
@@ -332,6 +332,28 @@ def test_newer_manifest_schema_is_refused(homes: tuple[Path, Path]) -> None:
 
     with pytest.raises(IntegrationError, match="unsupported"):
         IntegrationManifest.load(manager.manifest_path)
+
+
+def test_schema_one_manifest_is_reconciled_with_session_start(
+    homes: tuple[Path, Path],
+) -> None:
+    manager, _ = _manager(homes)
+    manager.setup()
+    manifest = json.loads(manager.manifest_path.read_text())
+    manifest["schema"] = 1
+    manifest["owned_hook"] = manifest.pop("owned_hooks")[0]
+    manager.manifest_path.write_text(json.dumps(manifest))
+    hooks = json.loads(manager.hooks_path.read_text())
+    hooks["hooks"].pop("SessionStart")
+    manager.hooks_path.write_text(json.dumps(hooks))
+
+    upgraded = manager.setup()
+
+    assert upgraded.schema == 2
+    assert [event for event, _ in _spotter_hooks(manager.hooks_path)] == [
+        "PreToolUse",
+        "SessionStart",
+    ]
 
 
 def test_invalid_spotter_config_fails_before_external_mutation(

--- a/tests/test_runtime_diagnostics.py
+++ b/tests/test_runtime_diagnostics.py
@@ -30,7 +30,12 @@ def _ready_manifest(homes: tuple[Path, Path]) -> IntegrationManifest:
         "matcher": ".*",
         "hook": {"type": "command", "command": "/bin/spotter hook || true"},
     }
-    hooks = {"hooks": {"PreToolUse": [{"matcher": owned["matcher"], "hooks": [owned["hook"]]}]}}
+    hooks = {
+        "hooks": {
+            "PreToolUse": [{"matcher": owned["matcher"], "hooks": [owned["hook"]]}],
+            "SessionStart": [{"hooks": [owned["hook"]]}],
+        }
+    }
     hooks_path = codex / "hooks.json"
     hooks_path.write_text(json.dumps(hooks))
     registration = spotter / "service/spotterd"
@@ -51,7 +56,10 @@ def _ready_manifest(homes: tuple[Path, Path]) -> IntegrationManifest:
         service_owned=True,
         hooks_file=str(hooks_path),
         hooks_file_created=True,
-        owned_hook=owned,
+        owned_hooks=[
+            owned,
+            {"event": "SessionStart", "matcher": None, "hook": owned["hook"]},
+        ],
     )
     manifest.save(spotter / "integrations/codex.json")
     return manifest
@@ -125,13 +133,13 @@ def test_integration_check_reports_a_malformed_owned_hook(homes: tuple[Path, Pat
     _ready_manifest(homes)
     path = homes[0] / "integrations/codex.json"
     raw = json.loads(path.read_text())
-    raw["owned_hook"] = "broken"
+    raw["owned_hooks"] = "broken"
     path.write_text(json.dumps(raw))
 
     check = check_integration().check
 
     assert check.status == FAIL
-    assert "owned Hook is invalid" in check.detail
+    assert "owned Hooks are invalid" in check.detail
 
 
 def test_doctor_probe_reports_an_unreachable_configured_app_server(


### PR DESCRIPTION
## Bug

Standalone Codex setup removed legacy observation Hooks and retained only `PreToolUse`, so `SessionStart` never reached Spotter. That prevented the baseline checkpoint required for early pre-mutation forks in #42.

Related to #42.

## Root cause

The integration manifest and migration path modeled exactly one owned Hook even though `SessionStart` remains required until #86 proves App Server lifecycle parity.

## Fix

- register and transactionally own both `PreToolUse` and `SessionStart` while preserving unrelated commands
- upgrade schema 1 manifests to schema 2 `owned_hooks` in memory and reconcile them on the next setup
- validate and tear down the complete owned Hook set
- document the temporary lifecycle contract until #86

## Verification

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (438 passed)