### PR TITLE
fix(integration): ignore owned hook order

### DIFF
--- a/src/spotter/doctor.py
+++ b/src/spotter/doctor.py
@@ -287,7 +287,9 @@ def check_integration() -> IntegrationInspection:
             False,
         )
     expected = [(entry.get("event"), entry.get("matcher"), entry.get("hook")) for entry in owned]
-    if spotter_hooks != expected:
+    if sorted(json.dumps(entry, sort_keys=True) for entry in spotter_hooks) != sorted(
+        json.dumps(entry, sort_keys=True) for entry in expected
+    ):
         return IntegrationInspection(
             manifest,
             Check(

--- a/src/spotter/integration.py
+++ b/src/spotter/integration.py
@@ -414,7 +414,9 @@ class IntegrationManager:
                     if self._is_spotter_hook(hook):
                         matches.append((event, group.get("matcher"), hook))
         expected = [(entry["event"], entry["matcher"], entry["hook"]) for entry in owned]
-        if matches != expected:
+        if sorted(json.dumps(entry, sort_keys=True) for entry in matches) != sorted(
+            json.dumps(entry, sort_keys=True) for entry in expected
+        ):
             raise IntegrationError(
                 "Codex Hook verification found duplicate or drifted Spotter hooks"
             )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -144,6 +144,18 @@ def test_setup_and_teardown_remove_a_hooks_file_created_by_spotter(
     assert not manager.hooks_path.exists()
 
 
+def test_setup_verification_ignores_owned_hook_order(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manager, _ = _manager(homes)
+    owned = list(reversed(manager._owned_hooks()))  # noqa: SLF001
+    monkeypatch.setattr(manager, "_owned_hooks", lambda: owned)
+
+    manifest = manager.setup()
+
+    assert manifest.owned_hooks == owned
+
+
 def test_setup_records_app_server_endpoint_as_pending(
     homes: tuple[Path, Path],
 ) -> None:

--- a/tests/test_runtime_diagnostics.py
+++ b/tests/test_runtime_diagnostics.py
@@ -117,6 +117,16 @@ def test_integration_check_detects_duplicate_owned_hooks(homes: tuple[Path, Path
     assert "duplicated" in check.detail
 
 
+def test_integration_check_ignores_owned_hook_order(homes: tuple[Path, Path]) -> None:
+    _ready_manifest(homes)
+    path = homes[0] / "integrations/codex.json"
+    raw = json.loads(path.read_text())
+    raw["owned_hooks"].reverse()
+    path.write_text(json.dumps(raw))
+
+    assert check_integration().check.status == OK
+
+
 def test_integration_check_detects_a_stale_legacy_plugin(homes: tuple[Path, Path]) -> None:
     manifest = _ready_manifest(homes)
     (Path(manifest.codex_home) / "config.toml").write_text(


### PR DESCRIPTION
## Bug

PR #142 made Hook ownership a list, but verification compared that list in serialization order. A valid manifest order differing from sorted `hooks.json` order could be reported as drift.

Follow-up to #142. Related to #42.

## Root cause

Both setup verification and doctor used order-sensitive list equality for an unordered Hook ownership set.

## Fix

Canonicalize each `(event, matcher, hook)` entry and compare sorted values while retaining duplicate detection.

## Verification

- regression coverage for reversed setup/manifest order and duplicate detection
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (440 passed)