### PR TITLE
fix(integration): retain observation hooks before parity

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -388,9 +388,9 @@ Plan
   Runtime mode: managed/login-scoped
   Hooks:
     add SessionStart
+    add UserPromptSubmit
     add PreToolUse
-    remove legacy PostToolUse
-    remove legacy UserPromptSubmit
+    add PostToolUse
   Legacy plugin: migrate
   Existing data: preserve
   Agent config backup/fingerprint: required
@@ -463,7 +463,7 @@ Example manifest:
 
 ```json
 {
-  "schema": 2,
+  "schema": 3,
   "agent": "codex",
   "setup_by": "0.6.0",
   "agent_path": "/opt/homebrew/bin/codex",
@@ -474,7 +474,9 @@ Example manifest:
   "service_owned": true,
   "owned_hooks": [
     {"event": "PreToolUse", "matcher": ".*", "hook": {"type": "command"}},
-    {"event": "SessionStart", "matcher": null, "hook": {"type": "command"}}
+    {"event": "SessionStart", "matcher": null, "hook": {"type": "command"}},
+    {"event": "UserPromptSubmit", "matcher": null, "hook": {"type": "command"}},
+    {"event": "PostToolUse", "matcher": ".*", "hook": {"type": "command"}}
   ],
   "legacy_hooks_removed": [{"event": "PostToolUse"}],
   "config_fingerprint_before": "...",
@@ -1284,15 +1286,15 @@ preserve current data/config
       ↓
 install standalone runtime integration
       ↓
-remove observation hooks replaced by App Server
+retain observation hooks until App Server responsibility parity is measured
       ↓
-retain SessionStart baseline plus required PreToolUse gate until #86 proves lifecycle parity
+remove SessionStart, UserPromptSubmit, and PostToolUse under #86; retain PreToolUse
 ```
 
 Migration rules:
 
 - never register duplicate Spotter Hooks;
-- migrate schema 1 manifests to the owned-Hook list and reconcile the missing `SessionStart` Hook;
+- migrate schema 1/2 manifests to the complete owned-Hook list and reconcile all observation Hooks;
 - preserve existing `~/.spotter` data;
 - record which legacy mutations were removed;
 - keep rollback information until verification succeeds;

--- a/docs/status.md
+++ b/docs/status.md
@@ -107,7 +107,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Standalone runtime | 🟡 | Long-lived process, IPC, lifecycle, isolated per-thread state, and App Server recovery ownership | Select and verify the shared endpoint during setup |
 | Runtime identity | ✅ | Logical threads/turns remain separate from per-connection attachment IDs and monotonically recovered epochs | Propagate the identity into future reviewer jobs |
 | App Server primary observation | 🟡 | Configured endpoints route through `spotterd` into normalized durable Trace IR and incremental ThreadState; a bounded value-free source audit and conformance corpus measure projection coverage | Collect labeled App Server failures to finish #37, then reduce Hooks in #86 |
-| Managed Codex lifecycle | 🟡 | Transactional setup/teardown, managed service, diagnostics, configured-endpoint recovery, and a temporary `SessionStart` baseline Hook until #86 parity | Add verified endpoint selection without claiming shared-process ownership |
+| Managed Codex lifecycle | 🟡 | Transactional setup/teardown, managed service, diagnostics, configured-endpoint recovery, and temporary observation Hooks until #86 parity | Add verified endpoint selection without claiming shared-process ownership |
 | Runtime reconnect/recovery | ✅ | Explicit connect/reconcile/backoff states, restart hydration, durable gaps, capability/server fingerprints, and stale-control fencing | Add retention/checkpoints in #89 |
 | Event-driven detection | ❌ | Reviewer is still cadence-based | #28 after Runtime/Observe |
 | Live `VERIFY` / `NUDGE` | ❌ | Reviewer decisions stop at the journal | #22 via `turn/steer` |

--- a/src/spotter/integration.py
+++ b/src/spotter/integration.py
@@ -29,7 +29,7 @@ from spotter.daemon import (
 from spotter.doctor import OK, check_roundtrip
 from spotter.paths import secure_dir, spotter_home
 
-MANIFEST_SCHEMA = 2
+MANIFEST_SCHEMA = 3
 
 
 class IntegrationError(RuntimeError):
@@ -190,13 +190,28 @@ class IntegrationManifest:
         if not isinstance(raw, dict):
             raise IntegrationError("integration manifest must be a JSON object")
         schema = raw.get("schema")
-        if schema == 1:
-            owned = raw.pop("owned_hook", None)
-            raw["owned_hooks"] = [owned]
-            if isinstance(owned, dict) and isinstance(owned.get("hook"), dict):
-                raw["owned_hooks"].append(
-                    {"event": "SessionStart", "matcher": None, "hook": owned["hook"]}
+        if schema in {1, 2}:
+            if schema == 1:
+                raw["owned_hooks"] = [raw.pop("owned_hook", None)]
+            owned = raw.get("owned_hooks")
+            if isinstance(owned, list):
+                hook = next(
+                    (
+                        entry.get("hook")
+                        for entry in owned
+                        if isinstance(entry, dict) and isinstance(entry.get("hook"), dict)
+                    ),
+                    None,
                 )
+                if hook is not None:
+                    for event, matcher in (
+                        ("SessionStart", None),
+                        ("UserPromptSubmit", None),
+                        ("PostToolUse", ".*"),
+                    ):
+                        entry = {"event": event, "matcher": matcher, "hook": hook}
+                        if entry not in owned:
+                            owned.append(entry)
             raw["schema"] = MANIFEST_SCHEMA
         elif schema != MANIFEST_SCHEMA:
             raise IntegrationError(f"unsupported integration manifest schema {raw.get('schema')!r}")
@@ -280,6 +295,8 @@ class IntegrationManager:
         return [
             {"event": "PreToolUse", "matcher": ".*", "hook": hook},
             {"event": "SessionStart", "matcher": None, "hook": hook},
+            {"event": "UserPromptSubmit", "matcher": None, "hook": hook},
+            {"event": "PostToolUse", "matcher": ".*", "hook": hook},
         ]
 
     @staticmethod

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -115,7 +115,12 @@ def test_setup_is_idempotent_and_teardown_preserves_unowned_config(
     assert first.state == second.state == "ready"
     assert first.created_at == second.created_at
     assert len(second.legacy_hooks_removed) == 3
-    assert [event for event, _ in _spotter_hooks(hooks_path)] == ["PreToolUse", "SessionStart"]
+    assert {event for event, _ in _spotter_hooks(hooks_path)} == {
+        "PostToolUse",
+        "PreToolUse",
+        "SessionStart",
+        "UserPromptSubmit",
+    }
     assert service.starts == 2
     assert hooks_path.read_bytes() == first_hooks
 
@@ -129,7 +134,12 @@ def test_setup_is_idempotent_and_teardown_preserves_unowned_config(
     assert not manager.manifest_path.exists()
 
     manager.setup()
-    assert [event for event, _ in _spotter_hooks(hooks_path)] == ["PreToolUse", "SessionStart"]
+    assert {event for event, _ in _spotter_hooks(hooks_path)} == {
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+    }
 
 
 def test_setup_and_teardown_remove_a_hooks_file_created_by_spotter(
@@ -346,7 +356,7 @@ def test_newer_manifest_schema_is_refused(homes: tuple[Path, Path]) -> None:
         IntegrationManifest.load(manager.manifest_path)
 
 
-def test_schema_one_manifest_is_reconciled_with_session_start(
+def test_schema_one_manifest_is_reconciled_with_observation_hooks(
     homes: tuple[Path, Path],
 ) -> None:
     manager, _ = _manager(homes)
@@ -361,11 +371,38 @@ def test_schema_one_manifest_is_reconciled_with_session_start(
 
     upgraded = manager.setup()
 
-    assert upgraded.schema == 2
-    assert [event for event, _ in _spotter_hooks(manager.hooks_path)] == [
-        "PreToolUse",
+    assert upgraded.schema == 3
+    assert {event for event, _ in _spotter_hooks(manager.hooks_path)} == {
         "SessionStart",
-    ]
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+    }
+
+
+def test_schema_two_manifest_is_reconciled_with_observation_hooks(
+    homes: tuple[Path, Path],
+) -> None:
+    manager, _ = _manager(homes)
+    manager.setup()
+    manifest = json.loads(manager.manifest_path.read_text())
+    manifest["schema"] = 2
+    manifest["owned_hooks"] = manifest["owned_hooks"][:2]
+    manager.manifest_path.write_text(json.dumps(manifest))
+    hooks = json.loads(manager.hooks_path.read_text())
+    hooks["hooks"].pop("UserPromptSubmit")
+    hooks["hooks"].pop("PostToolUse")
+    manager.hooks_path.write_text(json.dumps(hooks))
+
+    upgraded = manager.setup()
+
+    assert upgraded.schema == 3
+    assert {event for event, _ in _spotter_hooks(manager.hooks_path)} == {
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+    }
 
 
 def test_invalid_spotter_config_fails_before_external_mutation(

--- a/tests/test_runtime_diagnostics.py
+++ b/tests/test_runtime_diagnostics.py
@@ -34,6 +34,8 @@ def _ready_manifest(homes: tuple[Path, Path]) -> IntegrationManifest:
         "hooks": {
             "PreToolUse": [{"matcher": owned["matcher"], "hooks": [owned["hook"]]}],
             "SessionStart": [{"hooks": [owned["hook"]]}],
+            "UserPromptSubmit": [{"hooks": [owned["hook"]]}],
+            "PostToolUse": [{"matcher": ".*", "hooks": [owned["hook"]]}],
         }
     }
     hooks_path = codex / "hooks.json"
@@ -59,6 +61,8 @@ def _ready_manifest(homes: tuple[Path, Path]) -> IntegrationManifest:
         owned_hooks=[
             owned,
             {"event": "SessionStart", "matcher": None, "hook": owned["hook"]},
+            {"event": "UserPromptSubmit", "matcher": None, "hook": owned["hook"]},
+            {"event": "PostToolUse", "matcher": ".*", "hook": owned["hook"]},
         ],
     )
     manifest.save(spotter / "integrations/codex.json")


### PR DESCRIPTION
## Bug

Standalone setup removed `UserPromptSubmit` and `PostToolUse` even though no App Server endpoint was configured and #86 has not proven responsibility parity. Applying setup would therefore reduce observation coverage while trying to enable fresh #42 sessions.

Related to #86 and #42.

## Root cause

The integration lifecycle implemented the target minimal Hook set before its documented measurement gate had passed.

## Fix

- own all four current observation/enforcement Hooks until #86 explicitly removes the redundant three
- bump the integration manifest to schema 3 and reconcile schema 1/2 installations to the complete Hook set
- keep setup, teardown, doctor fixtures, lifecycle docs, and current status aligned

## Verification

- schema 1 and schema 2 reconciliation regressions
- setup/setup/teardown/setup coverage preserves unrelated commands
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (441 passed)