### PR TITLE
feat(experiment): pin reasoning effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,8 @@ spotter tasks run path/to/task-set.toml --guidance "..." --run
 # --resume ~/.spotter/experiments/task-batches/<batch>.jsonl
 spotter experiment --session <id> --step <n> --guidance "..." --check "..."
 # repeat the same neutral continuation to measure replay/model outcome noise:
-spotter experiment --session <id> --step <n> --neutral --pairs 3 --check "..." --run
+spotter experiment --session <id> --step <n> --neutral --pairs 3 --check "..." \
+  --model gpt-5.6 --reasoning-effort low --run
 ```
 
 When snapshotting is enabled, `SessionStart` pins one baseline Git snapshot so read-only exploration
@@ -367,7 +368,8 @@ snapshots. `spotter fork` writes a durable manifest under `~/.spotter/fork-manif
 source event, snapshot, rollout-prefix digest, external-effect warnings, and captured environment
 fingerprint. Counterfactual pairs are fully prepared and must pass shared-prefix and captured-
 environment parity checks before either agent arm runs. Ignored files, environment variables, and
-agent configuration are explicitly marked as not captured rather than assumed equal.
+agent configuration are explicitly marked as not captured rather than assumed equal. Experiments
+can pin both the Codex model and reasoning effort, and persist both values in result provenance.
 Neutral mode gives both arms the exact control prompt and reports mechanically judgeable outcome
 disagreement, environment-preflight mismatch, and infrastructure-failure rates separately. The
 command provides the measurement path; a representative executed corpus is still required before

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -169,6 +169,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--model", help="review/experiment: pin the Codex model")
     parser.add_argument(
+        "--reasoning-effort", help="experiment: pin the Codex model reasoning effort"
+    )
+    parser.add_argument(
         "--reservation",
         help="review: token for a budget slot the caller already reserved (internal)",
     )
@@ -336,6 +339,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 check=args.check,
                 run=args.run,
                 model=args.model,
+                reasoning_effort=args.reasoning_effort,
                 keep_artifacts=args.keep_artifacts,
                 neutral=args.neutral,
             )

--- a/src/spotter/experiment.py
+++ b/src/spotter/experiment.py
@@ -82,11 +82,14 @@ def _run_arm(
     sandbox: str,
     timeout: int,
     model: str | None = None,
+    reasoning_effort: str | None = None,
     codex_home: Path | None = None,
 ) -> int:
     args = ["codex", "exec", "-C", worktree]
     if model:
         args += ["--model", model]
+    if reasoning_effort:
+        args += ["--config", f'model_reasoning_effort="{reasoning_effort}"']
     args += [
         "--skip-git-repo-check",
         "--sandbox",
@@ -138,6 +141,7 @@ def _execute_arm(
     sandbox: str,
     timeout: int,
     model: str | None,
+    reasoning_effort: str | None,
     codex_home: Path | None,
 ) -> tuple[int | None, int | None, ArmClassification, str, str, str | None]:
     if environment_preflight != "MATCHED":
@@ -150,6 +154,7 @@ def _execute_arm(
             sandbox=sandbox,
             timeout=timeout,
             model=model,
+            reasoning_effort=reasoning_effort,
             codex_home=codex_home,
         )
     except subprocess.TimeoutExpired as error:
@@ -205,6 +210,7 @@ def run_experiment(
     timeout: int = 1800,
     codex_home: Path | None = None,
     model: str | None = None,
+    reasoning_effort: str | None = None,
     keep_artifacts: bool = False,
     neutral: bool = False,
 ) -> list[ArmResult]:
@@ -236,6 +242,7 @@ def run_experiment(
         "run": run,
         "pairs": pairs,
         "model": model or "codex-config-default",
+        "reasoning_effort": reasoning_effort or "codex-config-default",
         "codex_version": _codex_version(),
         "codex_home": str(codex_home or os.environ.get("CODEX_HOME") or Path.home() / ".codex"),
         "source_snapshot": source_snapshot,
@@ -266,6 +273,7 @@ def run_experiment(
                     sandbox=sandbox,
                     timeout=timeout,
                     model=model,
+                    reasoning_effort=reasoning_effort,
                     codex_home=codex_home,
                 )
             else:

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -57,7 +57,9 @@ def test_experiment_without_run_only_prepares(monkeypatch: pytest.MonkeyPatch) -
 def test_results_carry_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
     """PR #15 review P1: rows without conditions are not measurements."""
     monkeypatch.setattr(experiment, "fork", _fake_fork({}))
-    results = run_experiment("s1", 5, "look at the trace", check="pytest -q")
+    results = run_experiment(
+        "s1", 5, "look at the trace", check="pytest -q", reasoning_effort="low"
+    )
     rows = [json.loads(line) for line in results_path("s1", 5).read_text().splitlines()]
     meta = rows[0]
     assert meta["meta"] is True
@@ -65,6 +67,7 @@ def test_results_carry_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
     assert meta["check"] == "pytest -q"
     assert meta["sandbox"] and meta["timeout"] and meta["started_at"]
     assert meta["pairs"] == 1
+    assert meta["reasoning_effort"] == "low"
     assert meta["result_schema_version"] == 2
     assert rows[-1]["complete"] is True and rows[-1]["finished_at"]
     # every row is linked to its conditions via the experiment id
@@ -235,9 +238,24 @@ def test_cli_accepts_neutral_mode_without_guidance(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr("spotter.cli.run_experiment", record_run)
     monkeypatch.setattr("spotter.cli.summarize", lambda results: "neutral summary")
 
-    assert main(["experiment", "--session", "s1", "--step", "5", "--neutral"]) == 0
+    assert (
+        main(
+            [
+                "experiment",
+                "--session",
+                "s1",
+                "--step",
+                "5",
+                "--neutral",
+                "--reasoning-effort",
+                "low",
+            ]
+        )
+        == 0
+    )
     assert captured["guidance"] is None
     assert captured["neutral"] is True
+    assert captured["reasoning_effort"] == "low"
 
 
 def test_cli_rejects_neutral_mode_with_guidance() -> None:
@@ -459,7 +477,7 @@ def test_summary_compares_complete_pairs() -> None:
     assert "n=1/2 complete; guidance better=1" in summarize(rows)
 
 
-def test_run_arm_forwards_model_and_codex_home(
+def test_run_arm_forwards_model_reasoning_effort_and_codex_home(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     calls: list[tuple[list[str], dict[str, object]]] = []
@@ -479,9 +497,11 @@ def test_run_arm_forwards_model_and_codex_home(
         sandbox="workspace-write",
         timeout=1,
         model="gpt-test",
+        reasoning_effort="low",
         codex_home=tmp_path,
     )
     assert calls[0][0][4:6] == ["--model", "gpt-test"]
+    assert calls[0][0][6:8] == ["--config", 'model_reasoning_effort="low"']
     assert calls[0][1]["env"]["CODEX_HOME"] == str(tmp_path)  # type: ignore[index]
 
 


### PR DESCRIPTION
Part of #42.

Summary:
- add an experiment-only `--reasoning-effort` option
- forward the pinned effort to Codex as `model_reasoning_effort`
- persist the selected effort beside model/runtime provenance
- document reproducible lower-effort neutral calibration runs

Verification:
- ruff format --check .
- ruff check .
- mypy src tests
- pytest: 443 passed