### PR TITLE
Emit versioned release artifacts and runtime build identity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,9 @@ mypy src tests
 pytest
 ```
 
+Release artifacts are built only from an exact version tag. See
+[`docs/releasing.md`](docs/releasing.md) for the artifact, checksum, and build-identity contract.
+
 Use focused tests during iteration, but run the relevant full checks before requesting review whenever practical.
 
 ## Pull requests

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Evaluation labels / metrics | ✅ | Coverage-aware evaluation and precision/FP metrics |
 | Counterfactual experiment harness | ✅ | Control/guidance same-prefix pairs |
 | Standalone `spotterd` runtime | 🟡 | Process, gate IPC, per-thread immutable state, and App Server recovery ownership implemented; setup endpoint selection remains |
+| Versioned release artifacts | 🟡 | Tag-only sdist/wheel builds, SHA256 sums, and CLI/daemon/bridge build identity exist; GitHub Release/Homebrew publication remains |
 | App Server primary observation | 🟡 | Configured endpoints route through daemon-owned epoch/reconciliation into durable Trace IR and ThreadState; setup does not select an endpoint yet |
 | Event-driven signal engine | ❌ | Current reviewer trigger is periodic |
 | Live `VERIFY / NUDGE` | ❌ | Target: `turn/steer` |
@@ -301,8 +302,9 @@ python -m pip install -e '.[dev]'
 ```
 
 The package has one runtime dependency, `websockets`, which pip installs automatically. The `dev`
-extra adds only the repository's test, type-checking, and formatting tools; use `pip install -e .`
-when those tools are not needed.
+extra adds the repository's test, type-checking, formatting, and release-build tools; use
+`pip install -e .` when those tools are not needed. Tagged artifact production is documented in
+[Release artifacts and build identity](docs/releasing.md).
 
 Configuration:
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -5,9 +5,10 @@
 > for current
 > implementation state, see [Status](status.md). `spotter setup|teardown codex`, versioned ownership
 > manifests, managed `launchd`/`systemd --user` registration, portable startup, legacy Hook/plugin
-> migration, and runtime-aware diagnostics exist. App Server event ingestion also exists, but daemon
-> connection ownership, reconnect/reconciliation, Homebrew distribution, `spotter version`,
-> `spotter purge`, and transparent plain-`codex` launch remain target behavior.
+> migration, runtime-aware diagnostics, tag-derived release artifacts, and packaged `--version`
+> identity exist. App Server event ingestion also exists, but Homebrew publication,
+> package-vs-running-daemon upgrade policy, `spotter purge`, and transparent plain-`codex` launch
+> remain target behavior.
 
 ---
 
@@ -190,7 +191,7 @@ Installed by the package manager:
 ```text
 spotter
 spotterd
-spotter-hook
+spotter hook  # minimal Hook bridge within the packaged CLI
 package metadata
 ```
 
@@ -288,7 +289,8 @@ Package installation and agent integration are separate transactions.
 ### Success check
 
 ```bash
-spotter version
+spotter --version
+spotterd --version
 spotter status
 ```
 
@@ -306,7 +308,7 @@ Integration:  not configured
 - Homebrew formula and release artifacts;
 - stable executable paths;
 - package provenance detection (`homebrew`, source, standalone, etc.);
-- `spotter version`;
+- `spotter --version` and `spotterd --version`;
 - package-vs-running-daemon version comparison.
 
 ---
@@ -1362,6 +1364,14 @@ GitHub Release
   ↓
 Homebrew formula update
 ```
+
+The repository now implements the package/build portion of this pipeline. An exact
+`vMAJOR.MINOR.PATCH` tag produces a source distribution, universal wheel, machine-readable release
+manifest, and versioned SHA256 file. Both installed entry points expose the embedded tag+commit build
+identity, while the Hook bridge identifies itself independently on daemon requests. See
+[Release artifacts and build identity](releasing.md) for the authoritative artifact and identity
+contract. GitHub Release publication remains tracked by #105, and Homebrew-specific layout remains
+outside the core artifacts.
 
 Release verification should include fixtures for:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,80 @@
+# Release artifacts and build identity
+
+Spotter's repository-owned release builder produces package-manager-neutral Python artifacts from an
+exact tag. GitHub Release publication is a separate automation step tracked by
+[#105](https://github.com/spotter-agent/spotter/issues/105); Homebrew Formula layout remains owned by
+the dedicated tap.
+
+## Artifact contract
+
+For a supported tag `vX.Y.Z`, the release set is:
+
+| Artifact | Purpose |
+| --- | --- |
+| `spotter_agent-X.Y.Z.tar.gz` | Source distribution consumed by source-based packagers such as the initial Homebrew Formula |
+| `spotter_agent-X.Y.Z-py3-none-any.whl` | Platform-independent Python wheel containing the runtime package |
+| `spotter-agent-X.Y.Z-release.json` | Machine-readable tag, commit, build, protocol, entry-point, size, and digest metadata |
+| `spotter-agent-X.Y.Z-SHA256SUMS` | SHA256 digests for the sdist, wheel, and release manifest |
+
+The wheel declares `spotter` and `spotterd` console entry points. The minimal enforcement bridge is
+the packaged `spotter hook` command, so no plugin checkout or copied Python source is needed after
+standalone installation. The release manifest records those three component entry points explicitly.
+
+The artifacts contain no Homebrew prefix, Cellar path, or Formula layout. A Formula can consume the
+sdist URL and SHA256 and install its declared Python/runtime dependencies without consulting `main`.
+
+## Build a release set
+
+Install the development tools, create the release tag, and run:
+
+```bash
+python -m pip install -e '.[dev]'
+python scripts/build_release.py --tag vX.Y.Z
+```
+
+In a tag-triggered workflow, `--tag` may be omitted when `GITHUB_REF_NAME` is set. The default output
+directory is `dist/release`; use `--output-dir` for an isolated validation build.
+
+The builder deliberately does not build the working tree or a branch name. It:
+
+1. accepts only `vMAJOR.MINOR.PATCH`;
+2. resolves `refs/tags/<tag>` to its commit;
+3. archives that tag directly, ignoring moving or dirty working-tree content;
+4. derives the Python package version from the tag and the build ID from `<tag>@<full-commit>`;
+5. uses the tagged commit timestamp as `SOURCE_DATE_EPOCH`;
+6. builds and validates one sdist and one wheel;
+7. verifies embedded identity, package metadata, and the `spotter` / `spotterd` entry points;
+8. emits a release manifest and checksums; and
+9. refuses to overwrite an existing versioned release set.
+
+An unknown tag, branch name, malformed tag, failed package build, identity mismatch, or incomplete
+entry-point set aborts before artifacts are published to the requested output directory.
+
+## Runtime identity contract
+
+Packaged runtime components share four independent facts:
+
+```text
+spotter_version       # Python package/release version
+build_id              # exact release tag + commit
+component             # cli | daemon | hook_bridge
+ipc_protocol_version  # local control compatibility identifier
+```
+
+The user-facing commands report the same packaged release identity:
+
+```console
+$ spotter --version
+spotter X.Y.Z (build vX.Y.Z@<commit>; ipc 1)
+
+$ spotterd --version
+spotterd X.Y.Z (build vX.Y.Z@<commit>; ipc 1)
+```
+
+CLI and Hook-bridge control requests identify their component/build, and successful daemon responses
+identify the running daemon build. Build equality and protocol compatibility are deliberately
+separate; negotiation, stale-daemon classification, and upgrade policy remain governed by
+[#90](https://github.com/spotter-agent/spotter/issues/90).
+
+Source/editable installations use the explicit build identity `source` rather than masquerading as
+a tagged release, even when their semantic version matches a release.

--- a/docs/status.md
+++ b/docs/status.md
@@ -112,7 +112,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Event-driven detection | ❌ | Reviewer is still cadence-based | #28 after Runtime/Observe |
 | Live `VERIFY` / `NUDGE` | ❌ | Reviewer decisions stop at the journal | #22 via `turn/steer` |
 | `INTERRUPT` / `RESTART` | ❌ | No live recovery path | #26 + #30 after soft intervention is understood |
-| Packaging / long-term operations | 🎯 | Current paths are source/plugin installs; local `prune` exists | #88 packaging, #89 purge/retention, #90 upgrade/config lifecycle |
+| Packaging / long-term operations | 🟡 | Exact version tags build validated sdist/wheel artifacts, release metadata, SHA256 sums, and shared CLI/daemon/bridge build identity; Homebrew publication is not yet implemented | #105 release automation, #106–#108 packaged layout/tap/smoke, #89 retention, #90 upgrade compatibility |
 
 ---
 
@@ -195,6 +195,7 @@ Labels are exceptional contributor signals only (`good first issue`, `help wante
 | What is implemented right now | **This document** |
 | Exact process/data/control boundaries | [Architecture](architecture.md) |
 | Install → setup → run → recover → upgrade → remove | [Lifecycle](lifecycle.md) |
+| Build immutable package artifacts from a version tag | [Releasing](releasing.md) |
 | What should be built in what order | [Roadmap](roadmap.md) |
 | Prior work, hypotheses, and evidence | [Research](research.md) |
 | Repository/issue conventions | [Conventions](conventions.md) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling>=1.24"]
+requires = ["hatchling>=1.24,<2"]
 build-backend = "hatchling.build"
 
 [project]
 name = "spotter-agent"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Runtime trajectory supervision for coding agents"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -14,6 +14,7 @@ dependencies = ["websockets>=17,<18"]
 
 [project.optional-dependencies]
 dev = [
+  "build>=1.2,<2",
   "mypy>=1.10,<2",
   "pytest>=8,<9",
   "ruff>=0.5,<1",
@@ -22,6 +23,18 @@ dev = [
 [project.scripts]
 spotter = "spotter.cli:main"
 spotterd = "spotter.daemon:main"
+
+[tool.hatch.version]
+source = "code"
+path = "src/spotter/_version.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/LICENSE",
+  "/README.md",
+  "/pyproject.toml",
+  "/src",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/spotter"]
@@ -40,4 +53,5 @@ files = ["src", "tests"]
 
 [tool.pytest.ini_options]
 addopts = "-q"
+pythonpath = [".", "src"]
 testpaths = ["tests"]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance scripts."""

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Build immutable Spotter package artifacts from an exact version tag."""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import hashlib
+import json
+import os
+import re
+import runpy
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zipfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from email.parser import Parser
+from pathlib import Path
+from typing import Any
+
+PACKAGE_NAME = "spotter-agent"
+TAG_PATTERN = re.compile(r"v(?P<version>\d+\.\d+\.\d+)")
+RELEASE_MANIFEST_SCHEMA = 1
+
+
+class ReleaseBuildError(RuntimeError):
+    """The requested release cannot produce a trustworthy artifact set."""
+
+
+@dataclass(frozen=True)
+class ReleaseContext:
+    tag: str
+    version: str
+    commit: str
+    source_date_epoch: int
+
+    @property
+    def build_id(self) -> str:
+        return f"{self.tag}@{self.commit}"
+
+
+@dataclass(frozen=True)
+class ReleaseArtifact:
+    filename: str
+    kind: str
+    sha256: str
+    size: int
+
+    def to_json(self) -> dict[str, str | int]:
+        return {
+            "filename": self.filename,
+            "kind": self.kind,
+            "sha256": self.sha256,
+            "size": self.size,
+        }
+
+
+def parse_version_tag(tag: str) -> str:
+    match = TAG_PATTERN.fullmatch(tag)
+    if match is None:
+        raise ReleaseBuildError(f"unsupported release tag {tag!r}; expected vMAJOR.MINOR.PATCH")
+    return match.group("version")
+
+
+def _git(repo: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *arguments],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise ReleaseBuildError(f"git {' '.join(arguments)} failed: {detail}")
+    return result.stdout.strip()
+
+
+def resolve_release_context(repo: Path, tag: str) -> ReleaseContext:
+    """Resolve identity only through refs/tags, never a branch or working tree."""
+    version = parse_version_tag(tag)
+    tag_ref = f"refs/tags/{tag}"
+    commit = _git(repo, "rev-parse", "--verify", f"{tag_ref}^{{commit}}")
+    timestamp_text = _git(repo, "show", "-s", "--format=%ct", commit)
+    try:
+        timestamp = int(timestamp_text)
+    except ValueError as error:
+        raise ReleaseBuildError(f"tag {tag!r} has an invalid commit timestamp") from error
+    return ReleaseContext(tag, version, commit, timestamp)
+
+
+def _archive_tag(repo: Path, context: ReleaseContext, destination: Path) -> None:
+    archive = destination.parent / "source.tar"
+    with archive.open("wb") as output:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "archive", "--format=tar", f"refs/tags/{context.tag}"],
+            stdout=output,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    if result.returncode != 0:
+        detail = result.stderr.decode(errors="replace").strip()
+        raise ReleaseBuildError(f"could not archive tag {context.tag!r}: {detail}")
+    destination.mkdir()
+    with tarfile.open(archive) as source:
+        source.extractall(destination, filter="data")
+
+
+def _protocol_version(source: Path) -> int:
+    protocol = runpy.run_path(str(source / "src/spotter/protocol.py")).get(
+        "CONTROL_PROTOCOL_VERSION"
+    )
+    if not isinstance(protocol, int) or isinstance(protocol, bool):
+        raise ReleaseBuildError("tagged source has no integer control protocol version")
+    return protocol
+
+
+def _write_generated_identity(source: Path, context: ReleaseContext) -> str:
+    version_source = (
+        f'"""Generated release version. Do not edit."""\n\n__version__ = {context.version!r}\n'
+    )
+    (source / "src/spotter/_version.py").write_text(version_source)
+    content = (
+        '"""Generated release identity. Do not edit."""\n\n'
+        f"VERSION = {context.version!r}\n"
+        f"RELEASE_TAG = {context.tag!r}\n"
+        f"COMMIT = {context.commit!r}\n"
+        f"BUILD_ID = {context.build_id!r}\n"
+    )
+    path = source / "src/spotter/_generated_build.py"
+    path.write_text(content)
+    return content
+
+
+def _build_packages(source: Path, output: Path, context: ReleaseContext) -> None:
+    environment = {
+        **os.environ,
+        "PYTHONHASHSEED": "0",
+        "SOURCE_DATE_EPOCH": str(context.source_date_epoch),
+        "SPOTTER_BUILD_VERSION": context.version,
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--sdist",
+            "--wheel",
+            "--outdir",
+            str(output),
+            str(source),
+        ],
+        env=environment,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ReleaseBuildError("Python package build failed")
+
+
+def _wheel_metadata(archive: zipfile.ZipFile, suffix: str) -> str:
+    names = [name for name in archive.namelist() if name.endswith(suffix)]
+    if len(names) != 1:
+        raise ReleaseBuildError(f"wheel must contain exactly one {suffix}")
+    return archive.read(names[0]).decode()
+
+
+def _verify_wheel(path: Path, context: ReleaseContext, generated_identity: str) -> None:
+    with zipfile.ZipFile(path) as wheel:
+        try:
+            embedded = wheel.read("spotter/_generated_build.py").decode()
+        except KeyError as error:
+            raise ReleaseBuildError("wheel does not contain embedded build identity") from error
+        if embedded != generated_identity:
+            raise ReleaseBuildError("wheel build identity differs from release tag context")
+        version_source = wheel.read("spotter/_version.py").decode()
+        if f"__version__ = {context.version!r}\n" not in version_source:
+            raise ReleaseBuildError("wheel version source differs from release tag context")
+
+        metadata = Parser().parsestr(_wheel_metadata(wheel, ".dist-info/METADATA"))
+        if metadata.get("Name") != PACKAGE_NAME or metadata.get("Version") != context.version:
+            raise ReleaseBuildError("wheel package metadata differs from release tag context")
+
+        entry_points = configparser.ConfigParser()
+        entry_points.read_string(_wheel_metadata(wheel, ".dist-info/entry_points.txt"))
+        expected = {
+            "spotter": "spotter.cli:main",
+            "spotterd": "spotter.daemon:main",
+        }
+        actual = dict(entry_points.items("console_scripts"))
+        if actual != expected:
+            raise ReleaseBuildError(f"wheel console entry points differ: {actual!r}")
+
+
+def _verify_sdist(path: Path, context: ReleaseContext, generated_identity: str) -> None:
+    with tarfile.open(path, "r:gz") as sdist:
+        names = sdist.getnames()
+        identity_names = [
+            name for name in names if name.endswith("/src/spotter/_generated_build.py")
+        ]
+        version_names = [name for name in names if name.endswith("/src/spotter/_version.py")]
+        metadata_names = [name for name in names if name.endswith("/PKG-INFO")]
+        if len(identity_names) != 1 or len(version_names) != 1 or len(metadata_names) != 1:
+            raise ReleaseBuildError("sdist is missing build identity or package metadata")
+        identity_file = sdist.extractfile(identity_names[0])
+        version_file = sdist.extractfile(version_names[0])
+        metadata_file = sdist.extractfile(metadata_names[0])
+        if identity_file is None or identity_file.read().decode() != generated_identity:
+            raise ReleaseBuildError("sdist build identity differs from release tag context")
+        if version_file is None or (
+            f"__version__ = {context.version!r}\n" not in version_file.read().decode()
+        ):
+            raise ReleaseBuildError("sdist version source differs from release tag context")
+        if metadata_file is None:
+            raise ReleaseBuildError("sdist package metadata is unreadable")
+        metadata = Parser().parsestr(metadata_file.read().decode())
+        if metadata.get("Name") != PACKAGE_NAME or metadata.get("Version") != context.version:
+            raise ReleaseBuildError("sdist package metadata differs from release tag context")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as artifact:
+        for chunk in iter(lambda: artifact.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _artifact(path: Path, kind: str) -> ReleaseArtifact:
+    return ReleaseArtifact(path.name, kind, _sha256(path), path.stat().st_size)
+
+
+def _find_packages(output: Path) -> tuple[Path, Path]:
+    sdists = sorted(output.glob("*.tar.gz"))
+    wheels = sorted(output.glob("*.whl"))
+    if len(sdists) != 1 or len(wheels) != 1:
+        raise ReleaseBuildError(
+            f"expected one sdist and one wheel, found {len(sdists)} and {len(wheels)}"
+        )
+    return sdists[0], wheels[0]
+
+
+def _write_release_metadata(
+    output: Path,
+    context: ReleaseContext,
+    protocol: int,
+    artifacts: list[ReleaseArtifact],
+) -> tuple[Path, Path]:
+    manifest = output / f"spotter-agent-{context.version}-release.json"
+    payload: dict[str, Any] = {
+        "schema": RELEASE_MANIFEST_SCHEMA,
+        "package": PACKAGE_NAME,
+        "version": context.version,
+        "release_tag": context.tag,
+        "commit": context.commit,
+        "build_id": context.build_id,
+        "ipc_protocol_version": protocol,
+        "entry_points": {
+            "cli": "spotter",
+            "daemon": "spotterd",
+            "hook_bridge": "spotter hook",
+        },
+        "artifacts": [artifact.to_json() for artifact in artifacts],
+    }
+    manifest.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+    checksummed = [*artifacts, _artifact(manifest, "release_manifest")]
+    checksums = output / f"spotter-agent-{context.version}-SHA256SUMS"
+    checksums.write_text(
+        "".join(
+            f"{artifact.sha256}  {artifact.filename}\n"
+            for artifact in sorted(checksummed, key=lambda item: item.filename)
+        )
+    )
+    return manifest, checksums
+
+
+def _publish(source_paths: Sequence[Path], output: Path) -> tuple[Path, ...]:
+    output.mkdir(parents=True, exist_ok=True)
+    destinations = tuple(output / source.name for source in source_paths)
+    existing = [path for path in destinations if path.exists()]
+    if existing:
+        raise ReleaseBuildError(
+            "refusing to overwrite immutable release artifact(s): "
+            + ", ".join(path.name for path in existing)
+        )
+
+    created: list[Path] = []
+    try:
+        for source, destination in zip(source_paths, destinations, strict=True):
+            with source.open("rb") as incoming, destination.open("xb") as outgoing:
+                shutil.copyfileobj(incoming, outgoing)
+            created.append(destination)
+    except Exception:
+        for path in created:
+            path.unlink(missing_ok=True)
+        raise
+    return destinations
+
+
+def build_release(repo: Path, tag: str, output: Path) -> tuple[Path, ...]:
+    repo = repo.resolve()
+    context = resolve_release_context(repo, tag)
+    with tempfile.TemporaryDirectory(prefix="spotter-release-") as temporary:
+        root = Path(temporary)
+        source = root / "source"
+        built = root / "built"
+        built.mkdir()
+        _archive_tag(repo, context, source)
+        protocol = _protocol_version(source)
+        generated_identity = _write_generated_identity(source, context)
+        _build_packages(source, built, context)
+        sdist, wheel = _find_packages(built)
+        _verify_sdist(sdist, context, generated_identity)
+        _verify_wheel(wheel, context, generated_identity)
+        artifacts = [_artifact(sdist, "sdist"), _artifact(wheel, "wheel")]
+        manifest, checksums = _write_release_metadata(built, context, protocol, artifacts)
+        return _publish((sdist, wheel, manifest, checksums), output.resolve())
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build Spotter release artifacts from an exact vMAJOR.MINOR.PATCH tag"
+    )
+    parser.add_argument(
+        "--tag",
+        help="version tag to archive (defaults to GITHUB_REF_NAME)",
+    )
+    parser.add_argument("--repo", type=Path, default=Path.cwd(), help="Git repository")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("dist/release"),
+        help="new artifact destination",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _parser()
+    arguments = parser.parse_args(argv)
+    tag = arguments.tag or os.environ.get("GITHUB_REF_NAME")
+    if not tag:
+        parser.error("--tag is required outside a tag-triggered GitHub workflow")
+    try:
+        artifacts = build_release(arguments.repo, tag, arguments.output_dir)
+    except (OSError, ReleaseBuildError, tarfile.TarError, zipfile.BadZipFile) as error:
+        print(f"release build failed: {error}", file=sys.stderr)
+        return 1
+    for artifact in artifacts:
+        print(artifact)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/spotter/__init__.py
+++ b/src/spotter/__init__.py
@@ -1,6 +1,9 @@
 """Spotter runtime supervision prototype."""
 
+from spotter.build_identity import current_build_identity
 from spotter.config import SpotterConfig
 from spotter.core import SpotterRuntime
 
-__all__ = ["SpotterConfig", "SpotterRuntime"]
+__version__ = current_build_identity().version
+
+__all__ = ["SpotterConfig", "SpotterRuntime", "__version__"]

--- a/src/spotter/_version.py
+++ b/src/spotter/_version.py
@@ -1,0 +1,10 @@
+"""Build-backend version source.
+
+Release builds set ``SPOTTER_BUILD_VERSION`` from an exact version tag. The
+fallback keeps source/editable builds installable without pretending that they
+are release artifacts.
+"""
+
+import os
+
+__version__ = os.environ.get("SPOTTER_BUILD_VERSION", "0.1.0")

--- a/src/spotter/build_identity.py
+++ b/src/spotter/build_identity.py
@@ -1,0 +1,86 @@
+"""Packaged release identity shared by the CLI, daemon, and Hook bridge."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import import_module
+from importlib.metadata import PackageNotFoundError, version
+from typing import Literal, cast
+
+from spotter._version import __version__ as source_version
+from spotter.protocol import CONTROL_PROTOCOL_VERSION
+
+PACKAGE_NAME = "spotter-agent"
+RuntimeComponent = Literal["cli", "daemon", "hook_bridge"]
+
+
+@dataclass(frozen=True)
+class BuildIdentity:
+    """Immutable package identity, distinct from protocol compatibility."""
+
+    version: str
+    build_id: str
+    release_tag: str | None
+    commit: str | None
+
+    @property
+    def is_release(self) -> bool:
+        return self.release_tag is not None and self.commit is not None
+
+    def peer_metadata(self, component: RuntimeComponent) -> dict[str, str | int]:
+        metadata: dict[str, str | int] = {
+            "component": component,
+            "spotter_version": self.version,
+            "build_id": self.build_id,
+            "ipc_protocol_version": CONTROL_PROTOCOL_VERSION,
+        }
+        if self.release_tag is not None:
+            metadata["release_tag"] = self.release_tag
+        if self.commit is not None:
+            metadata["commit"] = self.commit
+        return metadata
+
+
+def _distribution_version() -> str:
+    try:
+        return version(PACKAGE_NAME)
+    except PackageNotFoundError:
+        return source_version
+
+
+@lru_cache(maxsize=1)
+def current_build_identity() -> BuildIdentity:
+    """Return embedded release identity, or an explicit source-build identity."""
+    package_version = _distribution_version()
+    try:
+        generated = import_module("spotter._generated_build")
+    except ModuleNotFoundError as error:
+        if error.name != "spotter._generated_build":
+            raise
+        return BuildIdentity(package_version, "source", None, None)
+
+    embedded_version = cast(str, generated.VERSION)
+    if embedded_version != package_version:
+        # This should be impossible for artifacts produced by build_release.py.
+        # Keep the mismatch visible instead of silently choosing one identity.
+        return BuildIdentity(
+            package_version,
+            f"invalid:{generated.BUILD_ID}",
+            cast(str, generated.RELEASE_TAG),
+            cast(str, generated.COMMIT),
+        )
+    return BuildIdentity(
+        package_version,
+        cast(str, generated.BUILD_ID),
+        cast(str, generated.RELEASE_TAG),
+        cast(str, generated.COMMIT),
+    )
+
+
+def version_line(executable: str) -> str:
+    identity = current_build_identity()
+    return (
+        f"{executable} {identity.version} "
+        f"(build {identity.build_id}; ipc {CONTROL_PROTOCOL_VERSION})"
+    )

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -23,6 +23,7 @@ from spotter.budget import (
 from spotter.budget import (
     read as read_spend,
 )
+from spotter.build_identity import version_line
 from spotter.codex import CodexAdapter
 from spotter.config import ConfigurationError, MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.core import SpotterRuntime
@@ -82,6 +83,7 @@ from spotter.trace import TraceEvent
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Observe a coding-agent trajectory")
+    parser.add_argument("--version", action="version", version=version_line("spotter"))
     parser.add_argument(
         "command",
         nargs="?",
@@ -741,6 +743,10 @@ def _daemon_main(action: str, manager: ServiceManager | None = None) -> int:
         details.append(f"pid={status.pid}")
     if status.protocol is not None:
         details.append(f"protocol={status.protocol}")
+    if status.version is not None:
+        details.append(f"version={status.version}")
+    if status.build_id is not None:
+        details.append(f"build={status.build_id}")
     if status.detail:
         details.append(status.detail)
     suffix = f" ({', '.join(details)})" if details else ""

--- a/src/spotter/daemon.py
+++ b/src/spotter/daemon.py
@@ -22,10 +22,12 @@ from io import TextIOWrapper
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
+from spotter.build_identity import RuntimeComponent, current_build_identity, version_line
 from spotter.config import GatesConfig
 from spotter.gates import Gate, GateDecision
 from spotter.identity import ThreadId
 from spotter.paths import secure_dir, spotter_home
+from spotter.protocol import CONTROL_PROTOCOL_VERSION
 from spotter.snapshot import StepRecord
 from spotter.thread_state import ThreadState, ThreadStateStore
 from spotter.trace import TraceEvent
@@ -33,7 +35,7 @@ from spotter.trace import TraceEvent
 if TYPE_CHECKING:
     from spotter.runtime_connection import RecoveryState
 
-PROTOCOL_VERSION = 1
+PROTOCOL_VERSION = CONTROL_PROTOCOL_VERSION
 CONTROL_TIMEOUT = 1.0
 GATE_TIMEOUT = 0.2
 START_TIMEOUT = 5.0
@@ -55,6 +57,8 @@ class DaemonStatus:
     health: RuntimeHealth
     pid: int | None = None
     protocol: int | None = None
+    version: str | None = None
+    build_id: str | None = None
     detail: str | None = None
 
     @property
@@ -101,10 +105,15 @@ class DaemonClient:
     """One-request-per-connection client for the local control protocol."""
 
     def __init__(
-        self, socket_path: Path | None = None, *, timeout: float = CONTROL_TIMEOUT
+        self,
+        socket_path: Path | None = None,
+        *,
+        timeout: float = CONTROL_TIMEOUT,
+        component: RuntimeComponent = "cli",
     ) -> None:
         self.socket_path = socket_path or runtime_socket()
         self.timeout = timeout
+        self.component = component
 
     async def request(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
         writer: asyncio.StreamWriter | None = None
@@ -113,7 +122,11 @@ class DaemonClient:
                 reader, writer = await asyncio.open_unix_connection(
                     self.socket_path, limit=_MAX_REQUEST_BYTES
                 )
-                payload: dict[str, Any] = {"protocol": PROTOCOL_VERSION, "method": method}
+                payload: dict[str, Any] = {
+                    "protocol": PROTOCOL_VERSION,
+                    "method": method,
+                    "peer": current_build_identity().peer_metadata(self.component),
+                }
                 if params is not None:
                     payload["params"] = params
                 request = json.dumps(payload, separators=(",", ":"))
@@ -154,6 +167,14 @@ class DaemonClient:
                 health=health,
                 pid=pid,
                 protocol=PROTOCOL_VERSION,
+                version=(
+                    response.get("spotter_version")
+                    if isinstance(response.get("spotter_version"), str)
+                    else None
+                ),
+                build_id=(
+                    response.get("build_id") if isinstance(response.get("build_id"), str) else None
+                ),
                 detail=(
                     response.get("detail") if isinstance(response.get("detail"), str) else None
                 ),
@@ -347,6 +368,7 @@ class DaemonServer:
                 "ok": True,
                 "health": self.health.value,
                 "pid": os.getpid(),
+                **current_build_identity().peer_metadata("daemon"),
             }
             if self.health_detail is not None:
                 response["detail"] = self.health_detail
@@ -733,6 +755,7 @@ def _secure_runtime_dir(path: Path) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run the Spotter supervision daemon")
+    parser.add_argument("--version", action="version", version=version_line("spotterd"))
     parser.parse_args(argv)
     try:
         asyncio.run(DaemonServer(app_server_endpoint=_configured_app_server_endpoint()).serve())

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -300,7 +300,9 @@ def _gate_over_ipc(
     error_detail: str | None = None
     try:
         decision, evaluation_ms, runtime_sample = asyncio.run(
-            DaemonClient(timeout=GATE_TIMEOUT).gate(event, config.gates, root)
+            DaemonClient(timeout=GATE_TIMEOUT, component="hook_bridge").gate(
+                event, config.gates, root
+            )
         )
     except DaemonTimeout as error:
         status = "timeout"

--- a/src/spotter/integration.py
+++ b/src/spotter/integration.py
@@ -15,10 +15,10 @@ from contextlib import suppress
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from fcntl import LOCK_EX, LOCK_UN, flock
-from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any, cast
 
+from spotter.build_identity import current_build_identity
 from spotter.config import ConfigurationError, SpotterConfig
 from spotter.daemon import (
     ManagedServiceManager,
@@ -45,10 +45,7 @@ def _fingerprint(content: bytes) -> str:
 
 
 def _package_version() -> str:
-    try:
-        return version("spotter-agent")
-    except PackageNotFoundError:
-        return "0+source"
+    return current_build_identity().version
 
 
 def _atomic_write(path: Path, content: bytes) -> None:

--- a/src/spotter/protocol.py
+++ b/src/spotter/protocol.py
@@ -1,0 +1,3 @@
+"""Versioned compatibility identifiers shared by runtime components."""
+
+CONTROL_PROTOCOL_VERSION = 1

--- a/tests/test_build_identity.py
+++ b/tests/test_build_identity.py
@@ -1,0 +1,40 @@
+import pytest
+
+from spotter.build_identity import current_build_identity, version_line
+from spotter.cli import main as cli_main
+from spotter.daemon import main as daemon_main
+from spotter.protocol import CONTROL_PROTOCOL_VERSION
+
+
+def test_component_identity_separates_build_from_protocol() -> None:
+    identity = current_build_identity()
+
+    peer = identity.peer_metadata("hook_bridge")
+
+    assert peer["component"] == "hook_bridge"
+    assert peer["spotter_version"] == identity.version
+    assert peer["build_id"] == identity.build_id
+    assert peer["ipc_protocol_version"] == CONTROL_PROTOCOL_VERSION
+
+
+def test_version_line_reports_packaged_identity_and_protocol() -> None:
+    identity = current_build_identity()
+
+    assert version_line("spotter") == (
+        f"spotter {identity.version} (build {identity.build_id}; ipc {CONTROL_PROTOCOL_VERSION})"
+    )
+
+
+@pytest.mark.parametrize(
+    "executable",
+    ["spotter", "spotterd"],
+)
+def test_entrypoints_expose_version(executable: str, capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as stopped:
+        if executable == "spotter":
+            cli_main(["--version"])
+        else:
+            daemon_main(["--version"])
+
+    assert stopped.value.code == 0
+    assert capsys.readouterr().out == version_line(executable) + "\n"

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from spotter.build_identity import current_build_identity
 from spotter.cli import main
 from spotter.config import GatesConfig
 from spotter.daemon import (
@@ -45,6 +46,8 @@ def test_control_socket_handles_concurrent_clients_and_health_states(socket_path
             )
             assert {status.health for status in statuses} == {RuntimeHealth.HEALTHY}
             assert len({status.pid for status in statuses}) == 1
+            assert {status.version for status in statuses} == {current_build_identity().version}
+            assert {status.build_id for status in statuses} == {current_build_identity().build_id}
             assert socket_path.stat().st_mode & 0o777 == 0o600
 
             server.set_health(RuntimeHealth.DEGRADED)

--- a/tests/test_release_build.py
+++ b/tests/test_release_build.py
@@ -1,0 +1,83 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.build_release import (
+    ReleaseBuildError,
+    _archive_tag,
+    _write_generated_identity,
+    parse_version_tag,
+    resolve_release_context,
+)
+
+
+def _git(repo: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *arguments],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _tagged_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--quiet")
+    _git(repo, "config", "user.name", "Spotter Tests")
+    _git(repo, "config", "user.email", "tests@spotter.invalid")
+    (repo / "identity.txt").write_text("tagged\n")
+    _git(repo, "add", "identity.txt")
+    _git(repo, "commit", "--quiet", "-m", "tagged source")
+    _git(repo, "tag", "v1.2.3")
+    return repo
+
+
+@pytest.mark.parametrize("tag", ["main", "1.2.3", "v1.2", "v1.2.3-rc1"])
+def test_release_tags_have_one_supported_unambiguous_shape(tag: str) -> None:
+    with pytest.raises(ReleaseBuildError, match="vMAJOR.MINOR.PATCH"):
+        parse_version_tag(tag)
+
+
+def test_release_context_is_derived_from_exact_tag(tmp_path: Path) -> None:
+    repo = _tagged_repo(tmp_path)
+    expected_commit = _git(repo, "rev-parse", "HEAD")
+
+    context = resolve_release_context(repo, "v1.2.3")
+
+    assert context.version == "1.2.3"
+    assert context.commit == expected_commit
+    assert context.build_id == f"v1.2.3@{expected_commit}"
+    assert context.source_date_epoch > 0
+
+
+def test_release_archive_ignores_moving_worktree(tmp_path: Path) -> None:
+    repo = _tagged_repo(tmp_path)
+    (repo / "identity.txt").write_text("moving branch\n")
+    context = resolve_release_context(repo, "v1.2.3")
+    destination = tmp_path / "archive"
+
+    _archive_tag(repo, context, destination)
+
+    assert (destination / "identity.txt").read_text() == "tagged\n"
+
+
+def test_release_staging_pins_version_without_build_environment(tmp_path: Path) -> None:
+    repo = _tagged_repo(tmp_path)
+    context = resolve_release_context(repo, "v1.2.3")
+    source = tmp_path / "source"
+    (source / "src/spotter").mkdir(parents=True)
+
+    generated = _write_generated_identity(source, context)
+
+    assert (source / "src/spotter/_version.py").read_text().endswith("__version__ = '1.2.3'\n")
+    assert f"BUILD_ID = {context.build_id!r}" in generated
+
+
+def test_unknown_version_tag_is_rejected(tmp_path: Path) -> None:
+    repo = _tagged_repo(tmp_path)
+
+    with pytest.raises(ReleaseBuildError, match="rev-parse"):
+        resolve_release_context(repo, "v9.9.9")


### PR DESCRIPTION
Closes #104

## Why

Downstream package managers need immutable Spotter artifacts whose version and runtime build identity come from a release tag, not a moving branch or manually synchronized files.

## What changed

- add a tag-only release builder for `vMAJOR.MINOR.PATCH` refs
- produce a source distribution, universal wheel, release manifest, and versioned SHA256 file
- embed the exact tag and commit as the packaged build identity
- expose matching identity through `spotter --version` and `spotterd --version`
- identify CLI, daemon, and Hook-bridge peers independently from IPC protocol compatibility
- validate package metadata and console entry points before publishing local artifacts
- document the artifact and runtime identity contract

The Hook bridge remains the packaged `spotter hook` command, and the artifact format contains no Homebrew prefix or Cellar assumptions.

## User and developer impact

A tagged source state can now produce the complete immutable input set needed by release automation and the Homebrew tap. Source/editable installations remain explicit `source` builds, while packaged components expose the same tag-derived identity.

## Validation

- `ruff format --check .`
- `ruff check .`
- `mypy src scripts/build_release.py tests`
- `pytest` — 455 passed
- built the same synthetic `v1.2.3` tag twice and confirmed byte-identical artifacts
- verified every emitted SHA256
- installed and exercised both the wheel and the sdist in clean Python 3.11 environments
- verified packaged daemon start/status/stop and packaged Hook-bridge invocation
- verified existing versioned artifacts are not overwritten

## Out of scope

GitHub Release publication remains #105. Stable package-manager service layout, the Homebrew tap, and lifecycle smoke automation remain #106–#108.