### PR TITLE
ci: add tag-driven GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,160 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate tagged source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[dev]'
+      - run: ruff format --check .
+      - run: ruff check .
+      - run: mypy src tests
+      - run: pytest
+
+  build:
+    name: Build release artifacts
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[dev]'
+      - name: Build from the exact tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          event_commit="$(git rev-parse --verify "$GITHUB_SHA^{commit}")"
+          tag_commit="$(git rev-parse --verify "refs/tags/$GITHUB_REF_NAME^{commit}")"
+          if [[ "$tag_commit" != "$event_commit" ]]; then
+            echo "tag $GITHUB_REF_NAME moved after this workflow was triggered" >&2
+            exit 1
+          fi
+          python scripts/build_release.py --tag "$GITHUB_REF_NAME"
+      - name: Verify the local artifact set
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          expected_assets="$(mktemp)"
+          actual_assets="$(mktemp)"
+          trap 'rm -f "$expected_assets" "$actual_assets"' EXIT
+
+          printf '%s\n' \
+            "spotter-agent-$version-SHA256SUMS" \
+            "spotter-agent-$version-release.json" \
+            "spotter_agent-$version-py3-none-any.whl" \
+            "spotter_agent-$version.tar.gz" \
+            | sort > "$expected_assets"
+          find dist/release -maxdepth 1 -type f -printf '%f\n' | sort > "$actual_assets"
+          diff -u "$expected_assets" "$actual_assets"
+          (
+            cd dist/release
+            sha256sum --check "spotter-agent-$version-SHA256SUMS"
+          )
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ github.ref_name }}
+          path: dist/release/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-${{ github.ref_name }}
+          path: dist/release
+      - name: Stage and verify the draft release
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="$GITHUB_REF_NAME"
+          version="${tag#v}"
+          expected_assets="$(mktemp)"
+          remote_assets="$(mktemp)"
+          verification_dir="$(mktemp -d)"
+          trap 'rm -f "$expected_assets" "$remote_assets"; rm -rf "$verification_dir"' EXIT
+
+          printf '%s\n' \
+            "spotter-agent-$version-SHA256SUMS" \
+            "spotter-agent-$version-release.json" \
+            "spotter_agent-$version-py3-none-any.whl" \
+            "spotter_agent-$version.tar.gz" \
+            | sort > "$expected_assets"
+
+          manifest="dist/release/spotter-agent-$version-release.json"
+          artifact_tag="$(jq -er '.release_tag' "$manifest")"
+          artifact_commit="$(jq -er '.commit' "$manifest")"
+          remote_commit="$(gh api "repos/$GH_REPO/commits/$tag" --jq .sha)"
+          if [[ "$artifact_tag" != "$tag" || "$artifact_commit" != "$remote_commit" ]]; then
+            echo "release metadata no longer matches the remote tag" >&2
+            exit 1
+          fi
+
+          if release_is_draft="$(gh release view "$tag" --json isDraft --jq .isDraft 2>/dev/null)"; then
+            if [[ "$release_is_draft" != "true" ]]; then
+              echo "release $tag is already published; refusing to replace its assets" >&2
+              exit 1
+            fi
+          else
+            gh release create "$tag" \
+              --draft \
+              --generate-notes \
+              --title "Spotter $version" \
+              --verify-tag
+          fi
+
+          # Draft assets are staging state. Replacing them makes a failed upload retryable;
+          # the release remains private until the complete remote set passes verification.
+          gh release upload "$tag" dist/release/* --clobber
+
+          gh release view "$tag" --json assets --jq '.assets[].name' \
+            | sort > "$remote_assets"
+          diff -u "$expected_assets" "$remote_assets"
+
+          gh release download "$tag" --dir "$verification_dir"
+          while IFS= read -r asset; do
+            cmp --silent "dist/release/$asset" "$verification_dir/$asset"
+          done < "$expected_assets"
+          (
+            cd "$verification_dir"
+            sha256sum --check "spotter-agent-$version-SHA256SUMS"
+          )
+      - name: Publish the verified release
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release edit "$GITHUB_REF_NAME" --draft=false --verify-tag
+          [[ "$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft)" == "false" ]]

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1365,13 +1365,15 @@ GitHub Release
 Homebrew formula update
 ```
 
-The repository now implements the package/build portion of this pipeline. An exact
-`vMAJOR.MINOR.PATCH` tag produces a source distribution, universal wheel, machine-readable release
-manifest, and versioned SHA256 file. Both installed entry points expose the embedded tag+commit build
-identity, while the Hook bridge identifies itself independently on daemon requests. See
+The repository now implements the package/build and GitHub Release portions of this pipeline. Pushing
+an exact `vMAJOR.MINOR.PATCH` tag runs the repository validation gates, then produces a source
+distribution, universal wheel, machine-readable release manifest, and versioned SHA256 file. The
+workflow verifies the complete remote artifact set while the release is still a draft and publishes
+only after every downloaded asset matches the validated build. Both installed entry points expose
+the embedded tag+commit build identity, while the Hook bridge identifies itself independently on
+daemon requests. See
 [Release artifacts and build identity](releasing.md) for the authoritative artifact and identity
-contract. GitHub Release publication remains tracked by #105, and Homebrew-specific layout remains
-outside the core artifacts.
+contract. Homebrew-specific layout remains outside the core artifacts.
 
 Release verification should include fixtures for:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,9 +1,8 @@
 # Release artifacts and build identity
 
-Spotter's repository-owned release builder produces package-manager-neutral Python artifacts from an
-exact tag. GitHub Release publication is a separate automation step tracked by
-[#105](https://github.com/spotter-agent/spotter/issues/105); Homebrew Formula layout remains owned by
-the dedicated tap.
+Spotter's repository-owned release workflow produces package-manager-neutral Python artifacts from
+an exact tag and publishes them to a GitHub Release. Homebrew Formula layout remains owned by the
+dedicated tap.
 
 ## Artifact contract
 
@@ -49,6 +48,23 @@ The builder deliberately does not build the working tree or a branch name. It:
 
 An unknown tag, branch name, malformed tag, failed package build, identity mismatch, or incomplete
 entry-point set aborts before artifacts are published to the requested output directory.
+
+## Publish a GitHub Release
+
+Push an exact `vMAJOR.MINOR.PATCH` tag to the canonical repository. The tag-triggered
+[`release.yml`](../.github/workflows/release.yml) workflow checks out that tag and runs the same
+format, lint, typecheck, and test gates as CI before it builds anything. It then builds the four-file
+artifact contract above and verifies the local filenames and SHA256 manifest.
+
+Publication uses a draft GitHub Release as staging state. The workflow uploads the complete artifact
+set, downloads it again, compares every remote file byte-for-byte with the validated build, and
+checks the downloaded SHA256 manifest before publishing the draft. A failed validation, build,
+upload, or verification therefore cannot create a public partial release. A retry may refresh assets
+on an existing draft, but the workflow refuses to alter an already-published release for the tag.
+
+The published release exposes both the versioned source-distribution URL and its SHA256 in
+`spotter-agent-X.Y.Z-SHA256SUMS` and `spotter-agent-X.Y.Z-release.json`. The tap update flow can use
+those values directly; it does not need to rebuild or inspect a moving branch.
 
 ## Runtime identity contract
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -112,7 +112,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Event-driven detection | ❌ | Reviewer is still cadence-based | #28 after Runtime/Observe |
 | Live `VERIFY` / `NUDGE` | ❌ | Reviewer decisions stop at the journal | #22 via `turn/steer` |
 | `INTERRUPT` / `RESTART` | ❌ | No live recovery path | #26 + #30 after soft intervention is understood |
-| Packaging / long-term operations | 🟡 | Exact version tags build validated sdist/wheel artifacts, release metadata, SHA256 sums, and shared CLI/daemon/bridge build identity; Homebrew publication is not yet implemented | #105 release automation, #106–#108 packaged layout/tap/smoke, #89 retention, #90 upgrade compatibility |
+| Packaging / long-term operations | 🟡 | Exact version tags run validation and publish a verified GitHub Release containing the sdist, wheel, release metadata, and SHA256 sums; CLI/daemon/bridge share embedded build identity; Homebrew publication is not yet implemented | #106–#108 packaged layout/tap/smoke, #89 retention, #90 upgrade compatibility |
 
 ---
 


### PR DESCRIPTION
## Purpose

Add the repository-owned release automation needed for an exact version tag to produce a validated GitHub Release for downstream distribution.

Closes #105

## Changes

- trigger release automation only for exact-looking `vMAJOR.MINOR.PATCH` tags, with the existing builder enforcing the final tag grammar
- run formatting, lint, typecheck, and test gates before building or granting release write access
- build and locally verify the four-artifact contract introduced by #104
- stage uploads in a draft, verify the remote tag identity, exact asset set, bytes, and SHA256 manifest, then publish
- keep failed uploads retryable while refusing to alter an already-published release
- update release, lifecycle, and status documentation for the implemented contract

## Impact

The dedicated Homebrew tap can consume a versioned sdist URL and published SHA256 metadata directly from the GitHub Release without rebuilding from `main`. Homebrew Formula changes and signing/notarization remain out of scope.

## Validation

- `ruff format --check .`
- `ruff check .`
- `mypy src tests`
- `pytest` — 455 passed
- parsed the workflow YAML and ran `bash -n` against every Bash step
- built an isolated `v0.0.0` tag in a temporary clone and verified the generated SHA256 manifest
