### PR TITLE
Document the official Homebrew distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Evaluation labels / metrics | ✅ | Coverage-aware evaluation and precision/FP metrics |
 | Counterfactual experiment harness | ✅ | Control/guidance same-prefix pairs |
 | Standalone `spotterd` runtime | 🟡 | Process, gate IPC, per-thread immutable state, and App Server recovery ownership implemented; setup endpoint selection remains |
-| Packaging / release | 🟡 | Tags publish verified sdist/wheel/checksum metadata; stable package entry points, mutable-state boundaries, Hook generation fencing, and old-daemon build detection exist; Homebrew tap publication remains |
+| Packaging / release | 🟡 | Tags publish verified sdist/wheel/checksum metadata; the dedicated Homebrew tap installs immutable releases and opens repeatable Formula-update PRs; stable package paths, mutable-state boundaries, Hook generation fencing, and old-daemon build detection exist; cross-environment smoke remains |
 | App Server primary observation | 🟡 | Configured endpoints route through daemon-owned epoch/reconciliation into durable Trace IR and ThreadState; setup does not select an endpoint yet |
 | Event-driven signal engine | ❌ | Current reviewer trigger is periodic |
 | Live `VERIFY / NUDGE` | ❌ | Target: `turn/steer` |
@@ -387,12 +387,14 @@ Task-set validation freezes task and fixture hashes and checks the versioned sco
 
 ---
 
-## Target installation and operations UX
+## Homebrew installation and operations UX
 
-The target first-run experience is intentionally small:
+Install the standalone runtime from the official
+[`spotter-agent/homebrew-spotter`](https://github.com/spotter-agent/homebrew-spotter) tap. The
+qualified form is intentional: it taps only the Formula needed for this install.
 
 ```bash
-brew install spotter
+brew install spotter-agent/spotter/spotter
 spotter setup codex
 spotter doctor
 
@@ -400,7 +402,10 @@ spotter doctor
 codex
 ```
 
-The user should not need to manually run `spotter daemon start` or `codex app-server daemon start` before each session.
+The Formula exposes both `spotter` and `spotterd`. Package installation itself does not edit Codex
+configuration or register the integration; `spotter setup codex` remains the explicit integration
+transaction. The user should not need to manually run `spotter daemon start` or
+`codex app-server daemon start` before each session.
 
 Detailed ownership, rollback, upgrades, uninstall, purge, and reinstall behavior are specified in [Lifecycle](docs/lifecycle.md).
 

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -509,7 +509,7 @@ A runtime supervisor is not complete if the user must manually orchestrate sever
 Target experience:
 
 ```bash
-brew install spotter
+brew install spotter-agent/spotter/spotter
 spotter setup codex
 spotter doctor
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -6,21 +6,20 @@
 > implementation state, see [Status](status.md). `spotter setup|teardown codex`, versioned ownership
 > manifests, managed `launchd`/`systemd --user` registration, portable startup, legacy Hook/plugin
 > migration, runtime-aware diagnostics, tag-derived release artifacts, stable packaged runtime
-> layout, and packaged `--version` identity exist. App Server event ingestion also exists, but Homebrew publication,
-> package-vs-running-daemon upgrade policy, `spotter purge`, and transparent plain-`codex` launch
-> remain target behavior.
+> layout, official Homebrew tap, and packaged `--version` identity exist. App Server event ingestion
+> also exists, but package-vs-running-daemon upgrade policy, `spotter purge`, and transparent
+> plain-`codex` launch remain target behavior.
 
 ---
 
 ## 30-second target lifecycle
 
-The intended packaged lifecycle should be understandable as four operations. Homebrew distribution
-is not available yet; source installation and the currently implemented commands are documented in
-the [README](../README.md#use-the-current-prototype):
+The packaged lifecycle is four operations. The qualified install command selects the official
+`spotter-agent/homebrew-spotter` tap without trusting unrelated third-party Formulae:
 
 ```bash
 # 1. Install the product
-brew install spotter
+brew install spotter-agent/spotter/spotter
 
 # 2. Integrate an agent once
 spotter setup codex
@@ -75,7 +74,7 @@ Spotter-managed external path, and #79 provides the daemon/control and `ServiceM
 
 | Task | Command / section |
 | --- | --- |
-| Target package installation | `brew install spotter` → [3. Install](#3-install-package-only) |
+| Package installation | `brew install spotter-agent/spotter/spotter` → [3. Install](#3-install-package-only) |
 | Connect Codex | `spotter setup codex` → [4. Setup](#4-spotter-setup-codex) |
 | Understand App Server ownership | [5. App Server lifecycle](#5-app-server-lifecycle) |
 | Understand background service startup | [6. Managed runtime startup](#6-managed-runtime-startup) |
@@ -101,7 +100,7 @@ Spotter-managed external path, and #79 provides the daemon/control and `ServiceM
 ```text
 UNINSTALLED
     │
-    │ brew install spotter
+    │ brew install spotter-agent/spotter/spotter
     ▼
 INSTALLED
     │ package exists
@@ -291,11 +290,17 @@ That is why a true `purge --all` needs a repository registry and Git-aware clean
 
 # 3. Install: package only
 
-Target command:
+Qualified command:
 
 ```bash
-brew install spotter
+brew install spotter-agent/spotter/spotter
 ```
+
+The `homebrew-spotter` repository name surfaces as the Homebrew tap `spotter-agent/spotter`; the
+final `/spotter` names its Formula. Installation consumes the immutable sdist and SHA-256 from a
+published Spotter tag, installs the declared Python runtime plus pinned Python resources, and exposes
+both `spotter` and `spotterd`. Its `brew services` metadata runs `opt_bin/spotterd`, so the service
+reference remains stable when Homebrew moves the active keg during an upgrade.
 
 ### Preconditions
 
@@ -341,12 +346,11 @@ Integration:  not configured
 
 ### Remaining implementation
 
-- Homebrew Formula/tap publication;
 - package provenance detection (`homebrew`, source, standalone, etc.);
 
-Release artifacts, shared `spotter`/`spotterd` build identity, stable runtime path discovery, and the
-package-vs-running-daemon build comparison are implemented. Full Formula install/remove smoke
-coverage remains in #107/#108.
+Release artifacts, the dedicated tap and Formula, shared `spotter`/`spotterd` build identity, stable
+runtime path discovery, and the package-vs-running-daemon build comparison are implemented. Full
+cross-environment install/upgrade/remove smoke coverage remains in #108.
 
 ---
 
@@ -1303,7 +1307,7 @@ Never remove non-Spotter refs/worktrees based on path guessing.
 A normal reinstall may encounter durable data from an earlier Spotter version.
 
 ```text
-brew install spotter
+brew install spotter-agent/spotter/spotter
       ↓
 existing Spotter data found
       ↓

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,8 +1,8 @@
 # Release artifacts and build identity
 
 Spotter's repository-owned release workflow produces package-manager-neutral Python artifacts from
-an exact tag and publishes them to a GitHub Release. Homebrew Formula layout remains owned by the
-dedicated tap.
+an exact tag and publishes them to a GitHub Release. Homebrew Formula layout is owned by the
+dedicated [`spotter-agent/homebrew-spotter`](https://github.com/spotter-agent/homebrew-spotter) tap.
 
 ## Artifact contract
 
@@ -65,6 +65,28 @@ on an existing draft, but the workflow refuses to alter an already-published rel
 The published release exposes both the versioned source-distribution URL and its SHA256 in
 `spotter-agent-X.Y.Z-SHA256SUMS` and `spotter-agent-X.Y.Z-release.json`. The tap update flow can use
 those values directly; it does not need to rebuild or inspect a moving branch.
+
+## Publish through Homebrew
+
+The tap's hourly and manually dispatchable `Update Spotter Formula` workflow reads the latest
+published release and validates its tag, manifest identity, sdist filename, size, and SHA-256 against
+the GitHub Release assets. If the release is newer than the Formula, it opens a version-specific tap
+pull request updating the immutable source URL and checksum. It refuses drafts, prereleases,
+downgrades, malformed manifests, and same-version artifact changes.
+
+The Formula separately pins the supported Homebrew Python and every Python runtime dependency as an
+immutable resource. A release that changes runtime dependencies therefore requires those resource
+changes to be reviewed in the same tap PR rather than allowing package installation to resolve new
+dependencies from the network implicitly.
+
+After the Formula PR passes macOS and Linux `brew test-bot`, users install it with:
+
+```bash
+brew install spotter-agent/spotter/spotter
+```
+
+The Formula install exposes `spotter`, `spotterd`, and the `spotter hook` bridge but never invokes
+`spotter setup codex`; package installation and Codex integration remain separate transactions.
 
 ## Runtime identity contract
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -112,7 +112,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Event-driven detection | ❌ | Reviewer is still cadence-based | #28 after Runtime/Observe |
 | Live `VERIFY` / `NUDGE` | ❌ | Reviewer decisions stop at the journal | #22 via `turn/steer` |
 | `INTERRUPT` / `RESTART` | ❌ | No live recovery path | #26 + #30 after soft intervention is understood |
-| Packaging / long-term operations | 🟡 | Exact version tags publish verified release artifacts; a central runtime layout gives CLI/daemon/bridge stable package entry points, explicit mutable ownership roots, integration-generation fencing, and old-daemon build detection without Cellar assumptions; Homebrew publication is not yet implemented | #107–#108 tap/smoke, #89 retention, #90 upgrade compatibility |
+| Packaging / long-term operations | 🟡 | Exact version tags publish verified release artifacts; the dedicated Homebrew tap installs the CLI/daemon/bridge from immutable releases and opens repeatable Formula-update PRs; stable package paths, mutable ownership roots, integration-generation fencing, and old-daemon build detection avoid Cellar assumptions | #108 cross-environment smoke, #89 retention, #90 upgrade compatibility |
 
 ---
 


### PR DESCRIPTION
Closes #107.

Companion tap PR: spotter-agent/homebrew-spotter#1

## Why

The dedicated Homebrew tap now provides the package-only installation path defined by the release and runtime-layout contracts. The main repository needs to name the authoritative tap, document the qualified command, and explain how verified releases flow into Formula update PRs.

## What changed

- document `brew install spotter-agent/spotter/spotter` as the official initial install command
- make the package-install versus `spotter setup codex` ownership boundary explicit
- document the immutable release-manifest-to-Formula updater and pinned Python resource policy
- record stable `opt_bin/spotterd` service behavior
- update current packaging status while leaving cross-environment upgrade/remove smoke to #108

## Validation

- `ruff format --check .`
- `ruff check .`
- `mypy src tests`
- `pytest` — 480 passed
- documentation references checked for stale unqualified initial-install commands
