### PR TITLE
Add Homebrew lifecycle smoke contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Evaluation labels / metrics | ✅ | Coverage-aware evaluation and precision/FP metrics |
 | Counterfactual experiment harness | ✅ | Control/guidance same-prefix pairs |
 | Standalone `spotterd` runtime | 🟡 | Process, gate IPC, per-thread immutable state, and App Server recovery ownership implemented; setup endpoint selection remains |
-| Packaging / release | 🟡 | Tags publish verified sdist/wheel/checksum metadata; the dedicated Homebrew tap installs immutable releases and opens repeatable Formula-update PRs; stable package paths, mutable-state boundaries, Hook generation fencing, and old-daemon build detection exist; cross-environment smoke remains |
+| Packaging / release | 🟡 | Tags publish verified artifacts; the dedicated Homebrew tap installs immutable releases and opens Formula-update PRs; macOS CI covers live G1→G2 upgrade/reconcile, teardown-less fail-open uninstall, retained data, and reinstall; broader #89/#90 lifecycle work remains |
 | App Server primary observation | 🟡 | Configured endpoints route through daemon-owned epoch/reconciliation into durable Trace IR and ThreadState; setup does not select an endpoint yet |
 | Event-driven signal engine | ❌ | Current reviewer trigger is periodic |
 | Live `VERIFY / NUDGE` | ❌ | Target: `turn/steer` |

--- a/docs/homebrew-lifecycle-smoke.md
+++ b/docs/homebrew-lifecycle-smoke.md
@@ -1,0 +1,86 @@
+# Homebrew lifecycle smoke
+
+> **Status:** implemented in the official
+> [`spotter-agent/homebrew-spotter`](https://github.com/spotter-agent/homebrew-spotter) tap and
+> exercised on macOS CI. Fast ownership, path, protocol, and failure fixtures remain in this
+> repository.
+
+Issue [#108](https://github.com/spotter-agent/spotter/issues/108) varies package and Codex
+integration state independently. The real Homebrew gate builds two immutable local release
+artifacts from one Spotter source revision, publishes them through an isolated fixture tap, and
+executes:
+
+```text
+package absent / integration absent
+  ↓
+install G1 (Codex files unchanged)
+  ↓
+setup Codex + start G1 daemon + invoke packaged Hook bridge
+  ↓
+upgrade Formula to G2 while G1 remains live
+  ↓
+G2 CLI identifies the running process as G1
+cached G1 Hook fails open against the G2 package
+  ↓
+setup reconciles exactly once: G1 stops, G2 starts, generation rotates
+  ↓
+uninstall without teardown
+  ↓
+executables disappear, G2 exits, launchd does not retry, Hook fails open
+user data and dangling integration ownership remain
+  ↓
+reinstall G2 + doctor/setup repair without duplicate Hooks
+  ↓
+teardown + uninstall
+  ↓
+unrelated Codex state and durable Spotter data remain
+```
+
+The fixture removes the old keg during upgrade; no assertion relies on a versioned Cellar path
+remaining present. It checks the CLI, daemon, running PID/build, Integration Manifest generation,
+Hook command, service definition, and representative user config/journal/label/experiment/registry
+files at the relevant transitions.
+
+## Reproduce locally
+
+Clone Spotter and its tap as siblings on a macOS host with Homebrew, then run:
+
+```bash
+cd homebrew-spotter
+python3 -m venv /tmp/spotter-lifecycle-venv
+/tmp/spotter-lifecycle-venv/bin/python -m pip install 'build>=1.2,<2'
+/tmp/spotter-lifecycle-venv/bin/python scripts/lifecycle_smoke.py \
+  --spotter-source ../spotter \
+  --formula-template Formula/spotter.rb
+```
+
+The harness refuses to replace an existing Homebrew `spotter` executable or loaded
+`dev.spotter.runtime` service. Its temporary Formula, service, trust entry, and tap are cleaned on
+success and ordinary fixture failure.
+
+## Fast fixture coverage
+
+The expensive macOS transition is complemented by deterministic tests in this repository:
+
+| Lifecycle risk | Evidence |
+| --- | --- |
+| Apple Silicon, Intel, and Linuxbrew stable paths; no Cellar persistence | `tests/test_paths.py`, `tests/test_integration.py` |
+| daemon build differs after a stable link moves | `tests/test_runtime_diagnostics.py` |
+| old build is gracefully replaced exactly once | `tests/test_integration.py` managed-service restart fixtures |
+| transient upgrade relink vs sustained uninstall absence | package-boundary monitor tests in `tests/test_daemon.py` |
+| loaded-but-unavailable launchd generation after reinstall | launchd bootout/bootstrap recovery fixture in `tests/test_integration.py` |
+| missing bridge, stale integration generation, protocol mismatch | `tests/test_integration.py`, `tests/test_daemon.py`, `tests/test_hook.py` |
+| missing/duplicate/user-modified Hook ownership | `tests/test_integration.py`, `tests/test_runtime_diagnostics.py` |
+| unsupported newer manifest and schema 1–3 repair | `tests/test_integration.py` |
+| mutation before manifest commit and service teardown failure | transactional rollback fixtures in `tests/test_integration.py` |
+| foreign process or stale socket endpoint | managed-service ownership and daemon socket fixtures |
+| lifecycle mutation serialization | a competing process holds the Integration Manifest `flock` while setup proves it waits |
+
+The cached-host check executes the generated G1 command directly rather than depending on
+undocumented Codex internals. Mixed generations must be detectable and non-blocking; after a host
+reload only the reconciled G2 Hook remains.
+
+The fixture does not start or stop a shared Codex App Server. Setup currently records that endpoint
+strategy as pending, so claiming ownership in this smoke would violate the runtime boundary. Full
+configuration-generation, protocol-range, schema-migration, retention, and repository-aware purge
+behavior remains owned by #90, #47, and #89 rather than being inferred from a green packaging gate.

--- a/docs/homebrew-lifecycle-smoke.md
+++ b/docs/homebrew-lifecycle-smoke.md
@@ -39,7 +39,9 @@ unrelated Codex state and durable Spotter data remain
 The fixture removes the old keg during upgrade; no assertion relies on a versioned Cellar path
 remaining present. It checks the CLI, daemon, running PID/build, Integration Manifest generation,
 Hook command, service definition, and representative user config/journal/label/experiment/registry
-files at the relevant transitions.
+files at the relevant transitions. A long-lived fake Codex App Server sentinel must retain the same
+PID through setup, upgrade/reconcile, teardown-less uninstall, reinstall, teardown, and final
+uninstall.
 
 ## Reproduce locally
 
@@ -80,7 +82,8 @@ The cached-host check executes the generated G1 command directly rather than dep
 undocumented Codex internals. Mixed generations must be detectable and non-blocking; after a host
 reload only the reconciled G2 Hook remains.
 
-The fixture does not start or stop a shared Codex App Server. Setup currently records that endpoint
-strategy as pending, so claiming ownership in this smoke would violate the runtime boundary. Full
-configuration-generation, protocol-range, schema-migration, retention, and repository-aware purge
-behavior remains owned by #90, #47, and #89 rather than being inferred from a green packaging gate.
+The fixture starts and later cleans up its own shared App Server sentinel, but Spotter is never
+configured as that process's owner. Setup currently records the endpoint strategy as pending, so
+claiming ownership in this smoke would violate the runtime boundary. Full configuration-generation,
+protocol-range, schema-migration, retention, and repository-aware purge behavior remains owned by
+#90, #47, and #89 rather than being inferred from a green packaging gate.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -6,9 +6,9 @@
 > implementation state, see [Status](status.md). `spotter setup|teardown codex`, versioned ownership
 > manifests, managed `launchd`/`systemd --user` registration, portable startup, legacy Hook/plugin
 > migration, runtime-aware diagnostics, tag-derived release artifacts, stable packaged runtime
-> layout, official Homebrew tap, and packaged `--version` identity exist. App Server event ingestion
-> also exists, but package-vs-running-daemon upgrade policy, `spotter purge`, and transparent
-> plain-`codex` launch remain target behavior.
+> layout, official Homebrew tap, packaged `--version` identity, and a two-generation Homebrew
+> lifecycle gate exist. App Server event ingestion also exists, but broader configuration/protocol
+> migration policy, `spotter purge`, and transparent plain-`codex` launch remain target behavior.
 
 ---
 
@@ -349,8 +349,9 @@ Integration:  not configured
 - package provenance detection (`homebrew`, source, standalone, etc.);
 
 Release artifacts, the dedicated tap and Formula, shared `spotter`/`spotterd` build identity, stable
-runtime path discovery, and the package-vs-running-daemon build comparison are implemented. Full
-cross-environment install/upgrade/remove smoke coverage remains in #108.
+runtime path discovery, and the package-vs-running-daemon build comparison are implemented. The
+[Homebrew lifecycle smoke](homebrew-lifecycle-smoke.md) covers real macOS install, live upgrade,
+uninstall, and reinstall while fast fixtures cover Intel/macOS and Linuxbrew path logic.
 
 ---
 
@@ -1148,7 +1149,15 @@ Never write versioned Homebrew Cellar paths into agent Hooks/service definitions
 Schema-4 integration Hooks also carry an integration-generation fence. Re-running setup after a
 package-build or stable-prefix change rotates the fence and reconciles the exact owned Hook entries.
 A Codex process holding an older generated command invokes the current stable binary, but that binary
-rejects the retired generation and fails open rather than silently adopting the replacement build.
+rejects the retired generation or package build and fails open rather than silently adopting the
+replacement build.
+
+The running daemon also watches the stable daemon entry point. A transient unlink/relink during an
+upgrade is tolerated, so G1 remains visible until setup explicitly reconciles it. If the entry point
+stays absent for ten seconds after uninstall, the daemon exits cleanly without touching durable
+state or a shared App Server. launchd keep-alive is conditional on that executable path; systemd
+uses restart-on-failure, while package removal is a clean exit. A loaded but unavailable launchd job
+left by teardown-less uninstall is re-bootstrapped after reinstall instead of hanging in kickstart.
 
 `spotter update` should not compete with Homebrew for file ownership. It may check for updates or delegate to the package-manager-supported path.
 
@@ -1250,6 +1259,13 @@ fail-open fallback. If the package link is absent, Codex continues without launc
 removed interpreter. After reinstall, `doctor` reports the missing/old recorded package path or build
 and directs the user to rerun `spotter setup codex`; setup then reconciles the new prefix while
 preserving durable user data.
+
+If setup previously registered the managed runtime, the integration manifest, Hook, and inactive
+service registration deliberately remain repairable integration state. The daemon exits after the
+stable executable disappears, and the conditional service definition does not retry the removed
+binary. Reinstall plus `doctor`/`setup` reuses the exact ownership manifest, rotates stale build state
+when needed, and deduplicates the generated Hooks. An unrecorded or user-modified Spotter Hook is
+reported as ambiguous instead of being overwritten.
 
 It should not remove:
 
@@ -1445,16 +1461,19 @@ daemon requests. See
 [Release artifacts and build identity](releasing.md) for the authoritative artifact and identity
 contract. Homebrew-specific layout remains outside the core artifacts.
 
-Release verification should include fixtures for:
+The [Homebrew lifecycle smoke](homebrew-lifecycle-smoke.md) now verifies:
 
 - clean install;
 - setup;
 - idempotent setup;
 - upgrade with running daemon;
-- schema migration;
+- current Integration Manifest schema repair;
 - teardown;
 - uninstall without teardown;
 - reinstall with retained data.
+
+Broader schema/configuration migrations remain separate #47/#90 gates rather than being inferred
+from the packaging fixture.
 
 ---
 
@@ -1483,7 +1502,7 @@ The lifecycle implies concrete components rather than one monolithic CLI.
 
 The target lifecycle is not complete until all of these work end-to-end:
 
-- [ ] clean package install does not modify Codex;
+- [x] clean package install does not modify Codex;
 - [x] `spotter setup codex` is idempotent;
 - [x] interrupted setup can heal forward when setup is re-run (pre-manifest teardown cannot infer ownership);
 - [ ] ordinary `codex` requires no manual Spotter/App Server startup in managed mode;
@@ -1494,10 +1513,10 @@ The target lifecycle is not complete until all of these work end-to-end:
 - [ ] Codex upgrade degrades by capability rather than silently breaking;
 - [ ] Spotter upgrade handles a running old daemon and schema migration;
 - [x] `teardown codex` removes only Spotter-owned integration changes;
-- [ ] uninstall without teardown does not break Codex;
-- [ ] user data survives normal uninstall;
+- [x] uninstall without teardown does not break Codex;
+- [x] user data survives normal uninstall;
 - [ ] purge can enumerate and safely clean repository resources;
-- [ ] reinstall can reuse/migrate retained data;
+- [x] reinstall can reuse compatible retained data (migration-required state remains #47/#90);
 - [x] legacy plugin users migrate without duplicate events.
 
 For runtime component boundaries, see [Architecture](architecture.md). For implementation sequencing, see [Roadmap](roadmap.md). For current implementation state, see [Status](status.md).

--- a/docs/status.md
+++ b/docs/status.md
@@ -112,7 +112,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Event-driven detection | ❌ | Reviewer is still cadence-based | #28 after Runtime/Observe |
 | Live `VERIFY` / `NUDGE` | ❌ | Reviewer decisions stop at the journal | #22 via `turn/steer` |
 | `INTERRUPT` / `RESTART` | ❌ | No live recovery path | #26 + #30 after soft intervention is understood |
-| Packaging / long-term operations | 🟡 | Exact version tags publish verified release artifacts; the dedicated Homebrew tap installs the CLI/daemon/bridge from immutable releases and opens repeatable Formula-update PRs; stable package paths, mutable ownership roots, integration-generation fencing, and old-daemon build detection avoid Cellar assumptions | #108 cross-environment smoke, #89 retention, #90 upgrade compatibility |
+| Packaging / long-term operations | 🟡 | Exact version tags publish verified release artifacts; the dedicated Homebrew tap installs immutable releases and opens repeatable Formula-update PRs; the macOS lifecycle gate proves clean install, live G1→G2 upgrade/reconcile, teardown-less fail-open uninstall, retained data, and reinstall/teardown without Cellar assumptions | #89 retention/purge and #90 broader configuration/protocol/schema compatibility |
 
 ---
 

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -23,7 +23,7 @@ from spotter.budget import (
 from spotter.budget import (
     read as read_spend,
 )
-from spotter.build_identity import version_line
+from spotter.build_identity import current_build_identity, version_line
 from spotter.codex import CodexAdapter
 from spotter.config import ConfigurationError, MainAgentConfig, ReviewerConfig, SpotterConfig
 from spotter.core import SpotterRuntime
@@ -1072,6 +1072,14 @@ def _hook_main(
         if manifest is None or manifest.integration_generation != integration_generation:
             print(
                 "spotter: stale integration generation; failing open; "
+                "run `spotter setup codex` to reconcile",
+                file=sys.stderr,
+            )
+            return 0
+        installed_build = current_build_identity().build_id
+        if manifest.setup_build_id != installed_build:
+            print(
+                "spotter: integration package build is stale; failing open; "
                 "run `spotter setup codex` to reconcile",
                 file=sys.stderr,
             )

--- a/src/spotter/daemon.py
+++ b/src/spotter/daemon.py
@@ -38,8 +38,11 @@ CONTROL_TIMEOUT = 1.0
 GATE_TIMEOUT = 0.2
 START_TIMEOUT = 5.0
 STOP_TIMEOUT = 5.0
+SERVICE_COMMAND_TIMEOUT = 10.0
 _MAX_REQUEST_BYTES = 64 * 1024
 _RESOURCE_SAMPLE_EVERY = 64
+_PACKAGE_WATCH_INTERVAL = 0.25
+_PACKAGE_MISSING_GRACE = 10.0
 
 
 class RuntimeHealth(StrEnum):
@@ -61,6 +64,23 @@ class DaemonStatus:
     @property
     def available(self) -> bool:
         return self.health != RuntimeHealth.UNAVAILABLE
+
+
+@dataclass
+class _PackageBoundaryMonitor:
+    """Require a stable executable to stay absent before treating it as uninstall."""
+
+    missing_grace: float
+    missing_since: float | None = None
+
+    def observe(self, *, available: bool, now: float) -> bool:
+        if available:
+            self.missing_since = None
+            return False
+        if self.missing_since is None:
+            self.missing_since = now
+            return self.missing_grace <= 0
+        return now - self.missing_since >= self.missing_grace
 
 
 class DaemonError(RuntimeError):
@@ -223,6 +243,8 @@ class DaemonServer:
         app_server_endpoint: str | None = None,
         journals_dir: Path | None = None,
         layout: RuntimeLayout | None = None,
+        package_watch_interval: float = _PACKAGE_WATCH_INTERVAL,
+        package_missing_grace: float = _PACKAGE_MISSING_GRACE,
     ) -> None:
         self.layout = layout or RuntimeLayout.discover()
         self.socket_path = socket_path or runtime_socket(self.layout)
@@ -239,6 +261,9 @@ class DaemonServer:
         self._runtime_id = uuid.uuid4().hex
         self._gate_requests = 0
         self._resource_sample_seq = 0
+        self._package_watch_interval = package_watch_interval
+        self._package_monitor = _PackageBoundaryMonitor(package_missing_grace)
+        self._package_watch_task: asyncio.Task[None] | None = None
 
     def observe_trace(self, event: TraceEvent) -> ThreadState:
         """Increment daemon-owned hot state after adapter normalization and journaling."""
@@ -294,6 +319,8 @@ class DaemonServer:
                 on_state=self._on_recovery_state,
             )
             await self.recovery.start()
+        if self.layout.daemon_executable is not None:
+            self._package_watch_task = asyncio.create_task(self._watch_package_boundary())
 
     async def serve(self) -> None:
         await self.start()
@@ -306,6 +333,11 @@ class DaemonServer:
         await self._shutdown.wait()
 
     async def close(self) -> None:
+        if self._package_watch_task is not None:
+            self._package_watch_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._package_watch_task
+            self._package_watch_task = None
         if self.recovery is not None:
             await self.recovery.close()
             self.recovery = None
@@ -321,6 +353,20 @@ class DaemonServer:
                 self.socket_path.unlink()
         self._socket_inode = None
         self._release_lock()
+
+    async def _watch_package_boundary(self) -> None:
+        """Stop cleanly after uninstall without mistaking an upgrade relink for removal."""
+
+        executable = self.layout.daemon_executable
+        assert executable is not None
+        loop = asyncio.get_running_loop()
+        while True:
+            if self._package_monitor.observe(
+                available=os.access(executable, os.X_OK), now=loop.time()
+            ):
+                self._shutdown.set()
+                return
+            await asyncio.sleep(self._package_watch_interval)
 
     def set_health(self, health: RuntimeHealth, detail: str | None = None) -> None:
         if health == RuntimeHealth.UNAVAILABLE:
@@ -623,12 +669,17 @@ class ManagedServiceManager:
         logs = secure_dir(self.layout.log_dir)
         log_path = logs / "spotterd.log"
         if self.platform == "darwin":
+            program = self._program()
             return plistlib.dumps(
                 {
                     "Label": self.LABEL,
-                    "ProgramArguments": self._program(),
+                    "ProgramArguments": program,
                     "RunAtLoad": True,
-                    "KeepAlive": True,
+                    # A package-manager uninstall removes the stable entry
+                    # point without calling `spotter teardown`.  Keep the
+                    # integration registration repairable, but do not make
+                    # launchd retry a removed executable forever.
+                    "KeepAlive": {"PathState": {program[0]: True}},
                     "WorkingDirectory": str(home),
                     "EnvironmentVariables": {"SPOTTER_HOME": str(home)},
                     "StandardOutPath": str(log_path),
@@ -666,7 +717,21 @@ class ManagedServiceManager:
 
     @staticmethod
     def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(command, capture_output=True, text=True, check=False)
+        try:
+            return subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=SERVICE_COMMAND_TIMEOUT,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return subprocess.CompletedProcess(
+                command,
+                124,
+                "",
+                f"service command timed out after {SERVICE_COMMAND_TIMEOUT:.0f}s",
+            )
 
     def _service_error(self, result: subprocess.CompletedProcess[str]) -> DaemonStatus:
         detail = (result.stderr or result.stdout or "service command failed").strip()[:300]
@@ -700,8 +765,10 @@ class ManagedServiceManager:
                     detail="spotterd is running outside the managed launchd service; stop it first",
                 )
             changed = self._install_definition()
-            if loaded and changed:
-                self._run(["launchctl", "bootout", f"{domain}/{self.LABEL}"])
+            if loaded and (changed or not current.available):
+                removed = self._run(["launchctl", "bootout", f"{domain}/{self.LABEL}"])
+                if removed.returncode != 0:
+                    return self._service_error(removed)
                 loaded = False
             if not loaded:
                 result = self._run(["launchctl", "bootstrap", domain, str(self.registration_path)])

--- a/src/spotter/integration.py
+++ b/src/spotter/integration.py
@@ -87,6 +87,23 @@ def is_spotter_hook(hook: object) -> bool:
     return False
 
 
+def _is_known_legacy_hook(hook: object) -> bool:
+    """Recognize the repository/plugin bridge shape that predates manifests."""
+
+    if not isinstance(hook, dict) or not isinstance(hook.get("command"), str):
+        return False
+    try:
+        tokens = shlex.split(cast(str, hook["command"]))
+    except ValueError:
+        return False
+    if len(tokens) != 1:
+        return False
+    normalized = tokens[0].replace("\\", "/")
+    return normalized.endswith("/scripts/spotter-hook") and (
+        "PLUGIN_ROOT" in normalized or "/spotter/" in normalized
+    )
+
+
 @dataclass(frozen=True)
 class CodexInstall:
     path: str
@@ -354,22 +371,37 @@ class IntegrationManager:
                     raise IntegrationError("Codex hooks file has an unsupported hook group")
         return cast(dict[str, Any], raw), content
 
-    def _migrate_hooks(self, raw: dict[str, Any]) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    def _migrate_hooks(
+        self, raw: dict[str, Any], existing: IntegrationManifest | None
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         updated = copy.deepcopy(raw)
         events = cast(dict[str, list[dict[str, Any]]], updated.setdefault("hooks", {}))
         removed: list[dict[str, Any]] = []
         owned = self._owned_hooks()
+        previously_owned = existing.owned_hooks if existing is not None else []
         for event, groups in list(events.items()):
             kept_groups: list[dict[str, Any]] = []
             for group in groups:
                 kept_hooks = []
                 for hook in cast(list[dict[str, Any]], group["hooks"]):
                     if self._is_spotter_hook(hook):
-                        if not any(
-                            (event, group.get("matcher"), hook)
-                            == (entry["event"], entry["matcher"], entry["hook"])
+                        identity = (event, group.get("matcher"), hook)
+                        is_current = existing is not None and any(
+                            identity == (entry["event"], entry["matcher"], entry["hook"])
                             for entry in owned
-                        ):
+                        )
+                        is_recorded = any(
+                            isinstance(entry, dict)
+                            and identity
+                            == (entry.get("event"), entry.get("matcher"), entry.get("hook"))
+                            for entry in previously_owned
+                        )
+                        if not (is_current or is_recorded or _is_known_legacy_hook(hook)):
+                            raise IntegrationError(
+                                "found an unowned or user-modified Spotter Hook; "
+                                "ownership is ambiguous, so setup made no changes"
+                            )
+                        if not is_current:
                             removed.append(
                                 {"event": event, "matcher": group.get("matcher"), "hook": hook}
                             )
@@ -409,8 +441,10 @@ class IntegrationManager:
         return str(path) if isinstance(path, Path) else None
 
     def inspect(
-        self,
+        self, existing: IntegrationManifest | None = None
     ) -> tuple[IntegrationPlan, dict[str, Any], bytes | None, list[dict[str, Any]]]:
+        if existing is None and self.manifest_path.exists():
+            existing = IntegrationManifest.load(self.manifest_path)
         try:
             self.layout.validate_persistent()
         except RuntimeLayoutError as error:
@@ -424,7 +458,7 @@ class IntegrationManager:
             except (OSError, tomllib.TOMLDecodeError, ConfigurationError) as error:
                 raise IntegrationError(f"Spotter config is unusable: {error}") from error
         hooks, before = self._read_hooks()
-        migrated, removed = self._migrate_hooks(hooks)
+        migrated, removed = self._migrate_hooks(hooks, existing)
         after = (json.dumps(migrated, indent=2, sort_keys=True) + "\n").encode()
         plan = IntegrationPlan(
             hooks_file=self.hooks_path,
@@ -483,7 +517,7 @@ class IntegrationManager:
         flock(lock, LOCK_EX)
         try:
             existing = IntegrationManifest.load(self.manifest_path)
-            plan, hooks, hooks_before, removed_hooks = self.inspect()
+            plan, hooks, hooks_before, removed_hooks = self.inspect(existing)
             codex = self._codex_install()
             hooks_after = (json.dumps(hooks, indent=2, sort_keys=True) + "\n").encode()
             config_before = (

--- a/src/spotter/paths.py
+++ b/src/spotter/paths.py
@@ -91,12 +91,19 @@ class RuntimeLayout:
 
         explicit_daemon = daemon_executable or environment.get("SPOTTER_DAEMON_EXECUTABLE")
         daemon = _executable(explicit_daemon, search_path=search_path)
+        if daemon is None and invoked.name == "spotterd":
+            daemon = _executable(invoked_as, search_path=search_path)
         if daemon is None and cli is not None:
             # The active package boundary wins over PATH.  A missing sibling is
             # diagnosed later instead of silently selecting an older install.
             daemon = cli.with_name("spotterd")
         if daemon is None and not module_invocation:
             daemon = _executable("spotterd", search_path=search_path)
+        if cli is None and daemon is not None:
+            # A managed service commonly has a minimal PATH and starts through
+            # the stable daemon link directly.  Preserve that package boundary
+            # rather than falling back to a source/module identity.
+            cli = daemon.with_name("spotter")
 
         raw_system_config = environment.get("XDG_CONFIG_HOME")
         system_config = _absolute(

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import shutil
+import socket
 import time
 from collections.abc import Iterator
 from pathlib import Path
@@ -324,6 +325,25 @@ def test_second_daemon_cannot_take_the_live_socket(socket_path: Path) -> None:
         finally:
             await second.close()
             await first.close()
+
+    asyncio.run(scenario())
+
+
+def test_daemon_reclaims_a_stale_socket_without_a_live_process(
+    socket_path: Path,
+) -> None:
+    async def scenario() -> None:
+        stale = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        stale.bind(str(socket_path))
+        stale.close()
+        assert (await DaemonClient(socket_path).status()).health == RuntimeHealth.UNAVAILABLE
+
+        server = DaemonServer(socket_path)
+        await server.start()
+        try:
+            assert (await DaemonClient(socket_path).status()).health == RuntimeHealth.HEALTHY
+        finally:
+            await server.close()
 
     asyncio.run(scenario())
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -19,10 +19,12 @@ from spotter.daemon import (
     DaemonServer,
     DaemonTimeout,
     RuntimeHealth,
+    _PackageBoundaryMonitor,
     runtime_socket,
 )
 from spotter.gates import Gate
 from spotter.identity import IdentityProvenance, RuntimeIdentity, ThreadId, TurnId
+from spotter.paths import RuntimeLayout
 from spotter.snapshot import StepRecord
 from spotter.trace import TraceEvent
 
@@ -60,6 +62,57 @@ def test_control_socket_handles_concurrent_clients_and_health_states(socket_path
         finally:
             await server.close()
         assert not socket_path.exists()
+
+    asyncio.run(scenario())
+
+
+def test_package_boundary_monitor_requires_continuous_absence() -> None:
+    monitor = _PackageBoundaryMonitor(missing_grace=2.0)
+
+    assert not monitor.observe(available=False, now=10.0)
+    assert not monitor.observe(available=False, now=11.9)
+    assert not monitor.observe(available=True, now=12.0), "an upgrade relink resets the fence"
+    assert not monitor.observe(available=False, now=20.0)
+    assert monitor.observe(available=False, now=22.0)
+
+
+def test_daemon_stops_cleanly_after_the_stable_package_is_removed(
+    socket_path: Path, tmp_path: Path
+) -> None:
+    async def scenario() -> None:
+        package_bin = tmp_path / "package/bin"
+        package_bin.mkdir(parents=True)
+        cli = package_bin / "spotter"
+        daemon = package_bin / "spotterd"
+        for executable in (cli, daemon):
+            executable.write_text("#!/bin/sh\nexit 0\n")
+            executable.chmod(0o755)
+        retained = tmp_path / "state/sessions/retained.jsonl"
+        retained.parent.mkdir(parents=True)
+        retained.write_text("durable\n")
+        layout = RuntimeLayout.discover(
+            cli_executable=cli,
+            daemon_executable=daemon,
+            spotter_root=tmp_path / "state",
+            environ={},
+        )
+        server = DaemonServer(
+            socket_path,
+            layout=layout,
+            package_watch_interval=0.01,
+            package_missing_grace=0,
+        )
+        serving = asyncio.create_task(server.serve())
+        for _ in range(50):
+            if (await DaemonClient(socket_path).status()).available:
+                break
+            await asyncio.sleep(0.01)
+        daemon.unlink()
+
+        await asyncio.wait_for(serving, 1)
+
+        assert not socket_path.exists()
+        assert retained.read_text() == "durable\n"
 
     asyncio.run(scenario())
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,8 +1,11 @@
 import asyncio
+import concurrent.futures
 import io
 import json
 import plistlib
 import subprocess
+import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -147,6 +150,47 @@ def test_setup_is_idempotent_and_teardown_preserves_unowned_config(
     }
 
 
+def test_setup_waits_for_an_inflight_lifecycle_mutation(
+    homes: tuple[Path, Path],
+) -> None:
+    manager, _ = _manager(homes)
+    manager.lock_path.parent.mkdir(parents=True)
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import fcntl, pathlib, sys\n"
+                "with pathlib.Path(sys.argv[1]).open('a+') as lock:\n"
+                "    fcntl.flock(lock, fcntl.LOCK_EX)\n"
+                "    print('locked', flush=True)\n"
+                "    sys.stdin.readline()\n"
+            ),
+            str(manager.lock_path),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert holder.stdout is not None
+    assert holder.stdin is not None
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        assert holder.stdout.readline().strip() == "locked"
+        setup = executor.submit(manager.setup)
+        time.sleep(0.1)
+        waited = not setup.done()
+        holder.stdin.write("\n")
+        holder.stdin.flush()
+        assert setup.result(timeout=2).state == "ready"
+        assert waited
+    finally:
+        if holder.poll() is None:
+            holder.terminate()
+        holder.wait(timeout=2)
+        executor.shutdown(wait=True, cancel_futures=True)
+
+
 def test_setup_and_teardown_remove_a_hooks_file_created_by_spotter(
     homes: tuple[Path, Path],
 ) -> None:
@@ -215,6 +259,28 @@ def test_stale_cached_hook_generation_fails_open(
     assert "stale integration generation" in capsys.readouterr().err
     assert not (homes[0] / "sessions/stale.jsonl").exists()
     assert manifest.integration_generation != "retired-generation"
+
+
+def test_cached_hook_from_the_installed_old_build_fails_open_before_reconcile(
+    homes: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    old = BuildIdentity("1.0.0", "v1.0.0@old", "v1.0.0", "old")
+    new = BuildIdentity("1.0.1", "v1.0.1@new", "v1.0.1", "new")
+    monkeypatch.setattr("spotter.integration.current_build_identity", lambda: old)
+    manager, _ = _manager(homes)
+    manifest = manager.setup()
+    monkeypatch.setattr("spotter.cli.current_build_identity", lambda: new)
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO('{"hook_event_name":"SessionStart","session_id":"mixed"}'),
+    )
+
+    assert main(["hook", "--integration-generation", manifest.integration_generation]) == 0
+
+    assert "integration package build is stale" in capsys.readouterr().err
+    assert not (homes[0] / "sessions/mixed.jsonl").exists()
 
 
 def test_missing_packaged_bridge_command_is_bounded_and_fail_open(
@@ -371,6 +437,38 @@ def test_teardown_keeps_a_user_modified_owned_hook(homes: tuple[Path, Path]) -> 
     assert "user replacement" in manager.hooks_path.read_text()
 
 
+def test_setup_refuses_to_replace_a_user_modified_owned_hook(
+    homes: tuple[Path, Path],
+) -> None:
+    manager, service = _manager(homes)
+    manager.setup()
+    raw = json.loads(manager.hooks_path.read_text())
+    raw["hooks"]["PreToolUse"][0]["hooks"][0]["command"] += " --user-edit"
+    manager.hooks_path.write_text(json.dumps(raw))
+    before = manager.hooks_path.read_bytes()
+
+    with pytest.raises(IntegrationError, match="ownership is ambiguous"):
+        manager.setup()
+
+    assert manager.hooks_path.read_bytes() == before
+    assert service.starts == 1
+
+
+def test_setup_refuses_generated_hooks_when_the_ownership_manifest_is_missing(
+    homes: tuple[Path, Path],
+) -> None:
+    manager, service = _manager(homes)
+    manager.setup()
+    manager.manifest_path.unlink()
+    before = manager.hooks_path.read_bytes()
+
+    with pytest.raises(IntegrationError, match="ownership is ambiguous"):
+        manager.setup()
+
+    assert manager.hooks_path.read_bytes() == before
+    assert service.starts == 1
+
+
 def test_setup_preserves_unrelated_commands_that_only_mention_spotter_hook(
     homes: tuple[Path, Path],
 ) -> None:
@@ -389,6 +487,23 @@ def test_setup_preserves_unrelated_commands_that_only_mention_spotter_hook(
     manager.setup()
 
     assert "run spotter hook later" in manager.hooks_path.read_text()
+
+
+def test_setup_does_not_treat_a_composite_legacy_hook_command_as_owned(
+    homes: tuple[Path, Path],
+) -> None:
+    _, codex_home = homes
+    codex_home.mkdir()
+    command = "echo /plugins/spotter/scripts/spotter-hook"
+    hooks = {"hooks": {"SessionStart": [{"hooks": [{"type": "command", "command": command}]}]}}
+    (codex_home / "hooks.json").write_text(json.dumps(hooks))
+    manager, service = _manager(homes)
+
+    with pytest.raises(IntegrationError, match="ownership is ambiguous"):
+        manager.setup()
+
+    assert command in manager.hooks_path.read_text()
+    assert service.starts == 0
 
 
 def test_portable_setup_does_not_claim_a_preexisting_daemon(
@@ -604,6 +719,7 @@ def test_managed_service_uses_stable_package_and_user_layout(
     if platform == "darwin":
         parsed = plistlib.loads(definition)
         assert parsed["ProgramArguments"] == [str(daemon)]
+        assert parsed["KeepAlive"] == {"PathState": {str(daemon): True}}
         assert parsed["WorkingDirectory"] == str(spotter_home)
         assert parsed["StandardOutPath"] == str(spotter_home / "logs/spotterd.log")
         assert parsed["EnvironmentVariables"] == {"SPOTTER_HOME": str(spotter_home)}
@@ -668,6 +784,105 @@ def test_managed_service_start_registers_and_verifies(
 
     assert asyncio.run(service.start()).health == RuntimeHealth.HEALTHY
     assert any(command[: len(expected)] == expected for command in commands)
+
+
+def test_managed_service_reloads_an_unavailable_but_loaded_launchd_job(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spotter_home, _ = homes
+    service = ManagedServiceManager(
+        platform="darwin",
+        registration_path=spotter_home / "service.plist",
+        executable="/stable/bin/spotterd",
+    )
+    commands: list[list[str]] = []
+    statuses = iter(
+        [
+            DaemonStatus(RuntimeHealth.UNAVAILABLE),
+            DaemonStatus(
+                RuntimeHealth.HEALTHY,
+                build_id=current_build_identity().build_id,
+            ),
+        ]
+    )
+
+    def run(command: list[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    async def status() -> DaemonStatus:
+        return next(statuses, DaemonStatus(RuntimeHealth.HEALTHY))
+
+    monkeypatch.setattr(service, "_run", run)
+    monkeypatch.setattr(service, "status", status)
+
+    assert asyncio.run(service.start()).health == RuntimeHealth.HEALTHY
+    assert any(command[:2] == ["launchctl", "bootout"] for command in commands)
+    assert any(command[:2] == ["launchctl", "bootstrap"] for command in commands)
+    assert not any(command[:2] == ["launchctl", "kickstart"] for command in commands)
+
+
+def test_managed_service_reports_and_recovers_from_a_failed_rebootstrap(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spotter_home, _ = homes
+    service = ManagedServiceManager(
+        platform="darwin",
+        registration_path=spotter_home / "service.plist",
+        executable="/stable/bin/spotterd",
+    )
+    statuses = iter(
+        [
+            DaemonStatus(RuntimeHealth.UNAVAILABLE),
+            DaemonStatus(RuntimeHealth.UNAVAILABLE),
+            DaemonStatus(
+                RuntimeHealth.HEALTHY,
+                build_id=current_build_identity().build_id,
+            ),
+        ]
+    )
+    booted_out = False
+    bootstrap_attempts = 0
+
+    def run(command: list[str]) -> subprocess.CompletedProcess[str]:
+        nonlocal booted_out, bootstrap_attempts
+        if command[:2] == ["launchctl", "print"]:
+            return subprocess.CompletedProcess(command, 1 if booted_out else 0, "", "")
+        if command[:2] == ["launchctl", "bootout"]:
+            booted_out = True
+        if command[:2] == ["launchctl", "bootstrap"]:
+            bootstrap_attempts += 1
+            if bootstrap_attempts == 1:
+                return subprocess.CompletedProcess(command, 5, "", "bootstrap denied")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    async def status() -> DaemonStatus:
+        return next(statuses, DaemonStatus(RuntimeHealth.HEALTHY))
+
+    monkeypatch.setattr(service, "_run", run)
+    monkeypatch.setattr(service, "status", status)
+
+    failed = asyncio.run(service.start())
+    recovered = asyncio.run(service.start())
+
+    assert failed.health == RuntimeHealth.UNAVAILABLE
+    assert failed.detail == "bootstrap denied"
+    assert recovered.health == RuntimeHealth.HEALTHY
+    assert bootstrap_attempts == 2
+
+
+def test_managed_service_commands_have_a_bounded_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def timeout(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(["launchctl", "print"], 10)
+
+    monkeypatch.setattr(subprocess, "run", timeout)
+
+    result = ManagedServiceManager._run(["launchctl", "print"])  # noqa: SLF001
+
+    assert result.returncode == 124
+    assert "timed out" in result.stderr
 
 
 @pytest.mark.parametrize(

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -121,6 +121,19 @@ def test_explicit_invocation_wins_over_path_discovery(
     assert layout.daemon_executable == invoked.with_name("spotterd")
 
 
+def test_managed_daemon_invocation_preserves_the_stable_package_boundary(
+    tmp_path: Path,
+) -> None:
+    cli = _executable(tmp_path / "stable/opt/spotter/bin/spotter")
+    daemon = _executable(cli.with_name("spotterd"))
+
+    layout = RuntimeLayout.discover(argv0=str(daemon), environ={"PATH": ""})
+
+    assert layout.daemon_executable == daemon
+    assert layout.cli_executable == cli
+    assert layout.daemon_command == (str(daemon),)
+
+
 def test_long_state_root_uses_a_short_private_runtime_address(tmp_path: Path) -> None:
     root = tmp_path / ("long" * 40)
     layout = RuntimeLayout.discover(spotter_root=root, environ={})


### PR DESCRIPTION
Part of #108. Companion Homebrew tap PR: spotter-agent/homebrew-spotter#3.

## Why

A teardown-less Homebrew uninstall could leave the managed daemon and launchd retry policy active, and cached generated Hooks could silently cross a package-build boundary. Setup also needed a conservative ownership rule for generated Hooks whose manifest was missing or user-modified.

## What changed

- stop the daemon cleanly after the stable packaged executable remains absent, while tolerating transient upgrade relinks
- use launchd PathState keep-alive and bounded service commands, with deterministic re-bootstrap after reinstall
- fence cached Hooks by both integration generation and package build
- refuse ambiguous or modified generated Hook ownership while continuing to migrate the exact legacy bridge
- preserve the stable package boundary for direct managed `spotterd` invocation
- add cross-process lifecycle locking, stale socket, old/new daemon, uninstall, ownership, rollback, and recovery fixtures
- document the real Homebrew lifecycle gate, shared App Server isolation, and the remaining #47/#89/#90 boundaries

## Validation

- `ruff format --check .`
- `ruff check .`
- `mypy src tests`
- `pytest` — 492 passed
- CI and CodeQL passed
- real local and GitHub Actions G1→G2 Homebrew install/upgrade/uninstall/reinstall harness passed in the companion tap