### PR TITLE
docs(experiment): report recovery-prefix noise

### DIFF
--- a/docs/experiments/fork-neutral-recovery-prefix.json
+++ b/docs/experiments/fork-neutral-recovery-prefix.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": 1,
+  "measured_at": "2026-08-14",
+  "experiment_id": "4a0ae646-68f7-489d-a5d0-d998b405bce2",
+  "source_session": "019ffc08-9b3d-7f83-bfeb-6cf3f833671a",
+  "branch_step": 14,
+  "prefix_id": "20a086ad71aff70f39a174f5600baeaff2982c6b0d24a7b33e0ae2ab73bc3928",
+  "source_snapshot": "96c6509e1265225210fc16ee1c823663c1e2f848",
+  "model": "gpt-5.6-sol",
+  "reasoning_effort": "low",
+  "scorer": "python3 check.py",
+  "raw_result_sha256": "3a863f28a6cc1460d456e2d6b62034bdf3915bf528cfbd8afe75bc955ab1b2dd",
+  "source_failure": {
+    "failure_step": 20,
+    "exception": "TypeError",
+    "recovered": true
+  },
+  "coverage": {
+    "candidates": 9,
+    "forkable_exact": 5,
+    "pre_mutation_candidates": 3,
+    "pre_mutation_forkable": 3,
+    "earliest_forkable_step": 2
+  },
+  "outcomes": {
+    "pairs": 3,
+    "judgeable_pairs": 3,
+    "mechanical_disagreements": 0,
+    "environment_mismatches": 0,
+    "infrastructure_failures": 0,
+    "passing_arms": 6
+  },
+  "continuations": [
+    {
+      "pair": 0,
+      "arm": "neutral_a",
+      "session_id": "beb53e8f-4595-4f7e-936e-688b4bdbfc53",
+      "elapsed_seconds": 1986.775,
+      "tool_calls": 6,
+      "reported_tokens": 240427
+    },
+    {
+      "pair": 0,
+      "arm": "neutral_b",
+      "session_id": "43162207-1b6f-4c07-8d52-6904d1e05411",
+      "elapsed_seconds": 5169.514,
+      "tool_calls": 6,
+      "reported_tokens": 243591
+    },
+    {
+      "pair": 1,
+      "arm": "neutral_b",
+      "session_id": "8de09595-fed1-4f02-afbf-503fe5ad5f5c",
+      "elapsed_seconds": 942.917,
+      "tool_calls": 6,
+      "reported_tokens": 240543
+    },
+    {
+      "pair": 1,
+      "arm": "neutral_a",
+      "session_id": "e0b2e3c5-483c-4093-a5cc-ac562edc9ae2",
+      "elapsed_seconds": 3431.854,
+      "tool_calls": 5,
+      "reported_tokens": 217601
+    },
+    {
+      "pair": 2,
+      "arm": "neutral_a",
+      "session_id": "0afbf36c-f4a6-4392-95b4-2096efc83cf7",
+      "elapsed_seconds": 23.537,
+      "tool_calls": 3,
+      "reported_tokens": 190134
+    },
+    {
+      "pair": 2,
+      "arm": "neutral_b",
+      "session_id": "94a5d4d6-9990-4372-80b0-31cb3fe730fb",
+      "elapsed_seconds": 616.355,
+      "tool_calls": 7,
+      "reported_tokens": 265549
+    }
+  ]
+}

--- a/docs/experiments/fork-neutral-recovery-prefix.md
+++ b/docs/experiments/fork-neutral-recovery-prefix.md
@@ -1,0 +1,57 @@
+# Recovery-prefix identical-arm fork run
+
+**Measured:** 2026-08-14
+
+**Source:** frozen `settings-validation` fixture at pinned low reasoning effort
+
+**Decision:** **recovery-path replay was stable in this low-effort cohort; do not pool it with default-effort noise**
+
+## Design
+
+The fixture requires endpoint trimming and positive-integer retry validation. A fresh source session
+running `gpt-5.6-sol` at `low` reasoning effort made an incomplete first patch, then observed the
+mechanical scorer fail because `None` leaked `TypeError`. It recovered with a second patch and
+passed `python3 check.py`.
+
+The experiment selected step 14, after the incomplete patch but before the failing scorer run, with
+prefix ID `20a086ad71aff70f39a174f5600baeaff2982c6b0d24a7b33e0ae2ab73bc3928`.
+Three pairs (six independent continuations) resumed with the identical `Continue the task.` prompt.
+Both model and reasoning effort were pinned to match the source session.
+
+## Result
+
+| Measure | Result |
+| --- | ---: |
+| Judgeable neutral pairs | 3/3 |
+| Passing arms | 6/6 |
+| Mechanical outcome disagreements | 0/3 (0%) |
+| Environment mismatches | 0/3 |
+| Infrastructure failures | 0/6 |
+| Continuation tool calls | 3–7 |
+| Continuation elapsed time | 23.537–5,169.514 seconds |
+| Continuation reported tokens | 190,134–265,549 |
+
+All six continuations found the same `None` conversion failure and repaired it. This removes the
+previous reports' source-success ceiling: the source itself made a mechanically failing attempt,
+and the chosen prefix contains that incomplete implementation. Outcome variance still did not
+appear in three repeated pairs.
+
+The derived machine-readable result is
+[`fork-neutral-recovery-prefix.json`](fork-neutral-recovery-prefix.json). The scoped experiment ID
+is `4a0ae646-68f7-489d-a5d0-d998b405bce2`. The append-only raw local JSONL remains at
+`~/.spotter/experiments/019ffc08-9b3d-7f83-bfeb-6cf3f833671a-step14.jsonl` with SHA-256
+`3a863f28a6cc1460d456e2d6b62034bdf3915bf528cfbd8afe75bc955ab1b2dd`; other incomplete and
+prepare-only attempts in that file are excluded by experiment ID.
+
+## Coverage and limitations
+
+The source exposed nine proposals: five exact and four excluded after Class C effects. All three
+pre-mutation candidates were exact. The experiment deliberately uses `low` reasoning effort to
+produce a recoverable source failure, so its 0/3 disagreement rate describes only that pinned
+configuration. It must not be pooled with the preceding default-effort cohort or used as its noise
+bound.
+
+Across four fresh tasks, Spotter has now observed 0/14 mechanical disagreements, 0/14 environment
+mismatches, and 0/28 infrastructure failures when listed descriptively. The defensible strata are
+still 0/11 at the prior default effort and 0/3 at low effort. #42 remains open for failures that
+survive to final mechanical outcomes and for explicit environment-drift qualification.

--- a/docs/research.md
+++ b/docs/research.md
@@ -282,7 +282,12 @@ to establish the representative noise bound. A third
 implementation decision and repeated five pairs, but all ten arms still passed. The cumulative
 result is 0/11 disagreements, 0/11 environment mismatches, and 0/22 infrastructure failures across
 three tasks. Further ceiling-task repetition is low-value; the next sample needs observed mechanical
-failures near an intervention opportunity.
+failures near an intervention opportunity. A fourth
+[recovery-prefix run](experiments/fork-neutral-recovery-prefix.md) pinned `low` reasoning effort and
+branched after the source session made an incomplete patch that subsequently failed the scorer and
+required recovery. Its three pairs again produced no disagreement, environment mismatch, or
+infrastructure failure. Because effort changes the continuation distribution, this 0/3 result is a
+separate low-effort cohort and is not pooled into the prior default-effort 0/11 noise estimate.
 
 Intervention deltas smaller than the instrument noise floor should not be overinterpreted.
 


### PR DESCRIPTION
Part of #42.

Summary:
- report three identical-arm pairs from a source session that made and recovered from a mechanically failing patch
- pin and persist `gpt-5.6-sol` at `low` reasoning effort for source and continuations
- publish exact coverage, outcome, timing, tool, and token measurements
- keep the low-effort 0/3 result separate from the prior default-effort 0/11 cohort

Result:
- 3/3 judgeable pairs, 6/6 passing arms
- 0/3 mechanical disagreements and environment mismatches
- 0/6 infrastructure failures

Verification:
- jq report validation and raw-result SHA-256 verification
- ruff format --check .
- ruff check .
- mypy src tests
- pytest: 443 passed