### PR TITLE
feat(replay): capture agent config provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,9 +370,10 @@ snapshots. `spotter fork` writes a durable manifest under `~/.spotter/fork-manif
 source event, snapshot, rollout-prefix digest, external-effect warnings, and captured environment
 fingerprint. Counterfactual pairs are fully prepared and must pass shared-prefix and captured-
 environment parity checks before either agent arm runs, then rechecks each arm against its immutable
-manifest immediately before model continuation. Ignored files, environment variables, and
-agent configuration are explicitly marked as not captured rather than assumed equal. Experiments
-can pin both the Codex model and reasoning effort, and persist both values in result provenance.
+manifest immediately before model continuation. Ignored files and environment variables are
+explicitly marked as not captured rather than assumed equal. Prefixes preserve the rollout model,
+runtime, and a secret-free subset of turn configuration; experiments can pin both the Codex model
+and reasoning effort and persist both values in result provenance.
 Neutral mode gives both arms the exact control prompt and reports mechanically judgeable outcome
 disagreement, environment-preflight mismatch, and infrastructure-failure rates separately. The
 command provides the measurement path; a representative executed corpus is still required before

--- a/src/spotter/replay.py
+++ b/src/spotter/replay.py
@@ -568,7 +568,7 @@ def _build_prefix_manifest(
         common_dir = repo / common_dir
     repository_id = _digest(str(common_dir.resolve()).encode())
     rollout_digest = _rollout_prefix_digest(rollout, call_id)
-    model, runtime_version = _rollout_provenance(rollout, call_id)
+    model, runtime_version, agent_config = _rollout_provenance(rollout, call_id)
     identity = target.event.identity
     turn_id = identity.turn_id.value if identity and identity.turn_id else None
     effects = tuple(external_effects(records, through_step=step))
@@ -600,7 +600,7 @@ def _build_prefix_manifest(
         agent="codex",
         model=model,
         runtime_version=runtime_version,
-        agent_config="not_captured",
+        agent_config=agent_config,
         context_source="truncated_codex_rollout",
         context_limitations=(
             "spotter_private_reviewer_state_not_injected",
@@ -620,9 +620,10 @@ def _rollout_prefix_digest(rollout: Path, call_id: str) -> str:
     raise ReplayError(f"call_id {call_id} not found in rollout {rollout.name}")
 
 
-def _rollout_provenance(rollout: Path, call_id: str) -> tuple[str | None, str | None]:
+def _rollout_provenance(rollout: Path, call_id: str) -> tuple[str | None, str | None, str]:
     model = None
     runtime_version = None
+    agent_config = "not_captured"
     for index, line in enumerate(rollout.read_text(encoding="utf-8").splitlines()):
         record = _rollout_record(line, index + 1)
         if call_id in _record_ids(record):
@@ -634,7 +635,22 @@ def _rollout_provenance(rollout: Path, call_id: str) -> tuple[str | None, str | 
             model = payload["model"]
         if isinstance(payload.get("cli_version"), str):
             runtime_version = payload["cli_version"]
-    return model, runtime_version
+        if record.get("type") == "turn_context":
+            config = {
+                key: payload[key]
+                for key in ("approval_policy", "effort", "personality")
+                if isinstance(payload.get(key), str)
+            }
+            for key, nested_key in (
+                ("collaboration_mode", "mode"),
+                ("sandbox_policy", "type"),
+            ):
+                nested = payload.get(key)
+                if isinstance(nested, dict) and isinstance(nested.get(nested_key), str):
+                    config[key] = nested[nested_key]
+            if config:
+                agent_config = _canonical_json(config).decode()
+    return model, runtime_version, agent_config
 
 
 def _write_fork_manifest(path: Path, manifest: ForkManifest) -> None:

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -60,7 +60,19 @@ def codex_home(tmp_path: Path) -> Path:
             "payload": {"call_id": "call_A", "name": "exec", "model": "gpt-test"},
         },
         {"ordinal": 2, "type": "response_item", "payload": {"call_id": "call_A", "output": "ok"}},
-        {"ordinal": 3, "type": "response_item", "payload": {"call_id": "call_B", "name": "exec"}},
+        {
+            "ordinal": 3,
+            "type": "turn_context",
+            "payload": {
+                "model": "gpt-test",
+                "effort": "low",
+                "approval_policy": "never",
+                "personality": "pragmatic",
+                "sandbox_policy": {"type": "workspace-write", "writable_roots": ["secret"]},
+                "collaboration_mode": {"mode": "default", "developer_instructions": "secret"},
+            },
+        },
+        {"ordinal": 4, "type": "response_item", "payload": {"call_id": "call_B", "name": "exec"}},
     ]
     rollout = day / f"rollout-2026-08-11T10-00-00-{OLD_ID}.jsonl"
     rollout.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
@@ -77,7 +89,7 @@ def test_fork_rollout_truncates_and_renames(codex_home: Path) -> None:
     rollout = next((codex_home / "sessions").rglob("*.jsonl"))
     forked = fork_rollout(rollout, "call_B", "new-id-1234")
     lines = forked.read_text().splitlines()
-    assert len(lines) == 3  # cut strictly before call_B
+    assert len(lines) == 4  # cut strictly before call_B
     assert OLD_ID not in forked.name and "new-id-1234" in forked.name
     assert all(OLD_ID not in line for line in lines)
     assert rollout.read_text().count("call_B") == 1  # original untouched
@@ -263,7 +275,14 @@ def test_fork_end_to_end(repo: Path, codex_home: Path) -> None:
     assert manifest.prefix.agent == "codex"
     assert manifest.prefix.model == "gpt-test"
     assert manifest.prefix.runtime_version == "test-1"
-    assert manifest.prefix.agent_config == "not_captured"
+    assert json.loads(manifest.prefix.agent_config) == {
+        "approval_policy": "never",
+        "collaboration_mode": "default",
+        "effort": "low",
+        "personality": "pragmatic",
+        "sandbox_policy": "workspace-write",
+    }
+    assert "secret" not in manifest.prefix.agent_config
     assert manifest.environment is not None
     assert manifest.environment.snapshot_sha == sha
     assert manifest.environment.fingerprint_sha256 == plan.environment_fingerprint
@@ -369,7 +388,7 @@ def test_fork_rollout_matches_event_msg_item_ids(codex_home: Path) -> None:
     )
     rollout.write_text("\n".join(lines) + "\n")
     forked = fork_rollout(rollout, "exec-1234", "new-id")
-    assert len(forked.read_text().splitlines()) == 4  # cut before the event_msg
+    assert len(forked.read_text().splitlines()) == 5  # cut before the event_msg
 
 
 def test_code_mode_correlates_hook_ids_to_exact_pre_call_cut(repo: Path, codex_home: Path) -> None:


### PR DESCRIPTION
Part of #42.

Summary:
- derive replay-prefix agent configuration from the latest pre-branch Codex `turn_context`
- persist effort, approval policy, personality, sandbox mode, and collaboration mode as canonical JSON
- exclude nested instructions, writable roots, and other potentially sensitive configuration values
- retain the explicit `not_captured` sentinel for legacy rollouts without turn context

Verification:
- ruff format --check .
- ruff check .
- mypy src tests
- pytest: 494 passed