### PR TITLE
fix(experiment): enforce source config parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,8 @@ environment parity checks before either agent arm runs, then rechecks each arm a
 manifest immediately before model continuation. Ignored files and environment variables are
 explicitly marked as not captured rather than assumed equal. Prefixes preserve the rollout model,
 runtime, and a secret-free subset of turn configuration; experiments can pin both the Codex model
-and reasoning effort and persist both values in result provenance.
+and reasoning effort and persist both values in result provenance. When those values are pinned and
+source provenance is available, a mismatch is rejected before either arm starts.
 Neutral mode gives both arms the exact control prompt and reports mechanically judgeable outcome
 disagreement, environment-preflight mismatch, and infrastructure-failure rates separately. The
 command provides the measurement path; a representative executed corpus is still required before

--- a/src/spotter/experiment.py
+++ b/src/spotter/experiment.py
@@ -139,6 +139,34 @@ def _pair_environment_preflight(prepared: list[tuple[str, str, ForkPlan]]) -> st
     return f"ENVIRONMENT_MISMATCH:{detail}"
 
 
+def _source_config_preflight(
+    prepared: list[tuple[str, str, ForkPlan]],
+    model: str | None,
+    reasoning_effort: str | None,
+) -> str:
+    if model is None and reasoning_effort is None:
+        return "MATCHED"
+    manifest_path = next((plan.manifest for _, _, plan in prepared if plan.manifest), None)
+    if manifest_path is None:
+        return "SOURCE_CONFIG_UNAVAILABLE"
+    try:
+        prefix = load_fork_manifest(Path(manifest_path)).prefix
+        if model is not None and prefix.model != model:
+            return "SOURCE_MODEL_MISMATCH" if prefix.model else "SOURCE_MODEL_UNAVAILABLE"
+        if reasoning_effort is not None:
+            if prefix.agent_config == "not_captured":
+                return "SOURCE_REASONING_EFFORT_UNAVAILABLE"
+            config = json.loads(prefix.agent_config)
+            source_effort = config.get("effort") if isinstance(config, dict) else None
+            if not isinstance(source_effort, str):
+                return "SOURCE_REASONING_EFFORT_UNAVAILABLE"
+            if source_effort != reasoning_effort:
+                return "SOURCE_REASONING_EFFORT_MISMATCH"
+    except (OSError, ReplayError, ValueError) as error:
+        return f"SOURCE_CONFIG_ERROR:{error}"
+    return "MATCHED"
+
+
 def _arm_environment_preflight(plan: ForkPlan) -> str:
     try:
         current = fingerprint_environment(Path(plan.worktree))
@@ -291,19 +319,31 @@ def run_experiment(
             (arm, prompt, fork(session_id, step, codex_home=codex_home)) for arm, prompt in arms
         ]
         environment_preflight = _pair_environment_preflight(prepared)
+        source_config_preflight = _source_config_preflight(prepared, model, reasoning_effort)
         for arm, prompt, plan in prepared:
+            execution: tuple[int | None, int | None, ArmClassification, str, str, str | None]
             if run:
-                execution = _execute_arm(
-                    plan,
-                    prompt,
-                    environment_preflight,
-                    check=check,
-                    sandbox=sandbox,
-                    timeout=timeout,
-                    model=model,
-                    reasoning_effort=reasoning_effort,
-                    codex_home=codex_home,
-                )
+                if source_config_preflight != "MATCHED":
+                    execution = (
+                        None,
+                        None,
+                        ArmClassification.SETUP_FAIL,
+                        "",
+                        "",
+                        source_config_preflight,
+                    )
+                else:
+                    execution = _execute_arm(
+                        plan,
+                        prompt,
+                        environment_preflight,
+                        check=check,
+                        sandbox=sandbox,
+                        timeout=timeout,
+                        model=model,
+                        reasoning_effort=reasoning_effort,
+                        codex_home=codex_home,
+                    )
             else:
                 execution = (None, None, ArmClassification.UNJUDGEABLE, "", "", None)
             agent_exit, check_exit, classification, check_stdout, check_stderr, diagnostic = (

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -296,6 +296,51 @@ def test_arm_environment_drift_is_persisted_and_summarized(
     assert "environment mismatches=1/1" in summarize(results)
 
 
+def test_explicit_source_config_mismatch_prevents_agent_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    counter: dict[str, int] = {}
+
+    def manifested_fork(session_id: str, step: int, *, codex_home: object = None) -> ForkPlan:
+        plan = _fake_fork(counter)(session_id, step, codex_home=codex_home)
+        return ForkPlan(
+            plan.session_id,
+            plan.branch_step,
+            plan.worktree,
+            plan.rollout,
+            plan.command,
+            manifest=f"/manifest-{plan.session_id}.json",
+            prefix_id=plan.prefix_id,
+            environment_fingerprint=plan.environment_fingerprint,
+        )
+
+    monkeypatch.setattr(experiment, "fork", manifested_fork)
+    monkeypatch.setattr(
+        experiment,
+        "load_fork_manifest",
+        lambda path: SimpleNamespace(
+            prefix=SimpleNamespace(model="gpt-test", agent_config='{"effort":"high"}')
+        ),
+    )
+    monkeypatch.setattr(experiment, "_cleanup", lambda worktree: None)
+    ran: list[str] = []
+    monkeypatch.setattr(experiment, "_run_arm", lambda *args, **kwargs: ran.append("run"))
+
+    results = run_experiment(
+        "s1",
+        5,
+        None,
+        run=True,
+        neutral=True,
+        model="gpt-test",
+        reasoning_effort="low",
+    )
+
+    assert ran == []
+    assert all(result.classification == ArmClassification.SETUP_FAIL for result in results)
+    assert all(result.infra_diagnostic == "SOURCE_REASONING_EFFORT_MISMATCH" for result in results)
+
+
 def test_empty_experiment_is_an_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """PR #15 review P2: --pairs 0 must not succeed with zero data."""
     with pytest.raises(ValueError, match="pairs must be >= 1"):


### PR DESCRIPTION
Part of #42.

Summary:
- compare explicit continuation model and reasoning-effort pins with source-prefix provenance
- refuse both arms before model execution when source and continuation config differ
- fail visibly when a requested pin cannot be proven from legacy source provenance
- persist the mismatch as a setup diagnostic without misclassifying it as environment drift

Verification:
- ruff format --check .
- ruff check .
- mypy src tests
- pytest: 495 passed