### PR TITLE
fix(experiment): reject shared arm worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,8 +369,9 @@ before the first mutation has a fork anchor; mutation boundaries continue to add
 snapshots. `spotter fork` writes a durable manifest under `~/.spotter/fork-manifests/`. The manifest links the
 source event, snapshot, rollout-prefix digest, external-effect warnings, and captured environment
 fingerprint. Counterfactual pairs are fully prepared and must pass shared-prefix and captured-
-environment parity checks before either agent arm runs, then rechecks each arm against its immutable
-manifest immediately before model continuation. Ignored files and environment variables are
+environment parity checks before either agent arm runs. The arms must use distinct worktrees, and
+each is rechecked against its immutable manifest immediately before model continuation. Ignored
+files and environment variables are
 explicitly marked as not captured rather than assumed equal. Prefixes preserve the rollout model,
 runtime, and a secret-free subset of turn configuration; experiments can pin both the Codex model
 and reasoning effort and persist both values in result provenance. When those values are pinned and

--- a/src/spotter/experiment.py
+++ b/src/spotter/experiment.py
@@ -124,6 +124,8 @@ def _pair_environment_preflight(prepared: list[tuple[str, str, ForkPlan]]) -> st
         plan.prefix_id is None or plan.environment_fingerprint is None for plan in plans
     ):
         return "FORK_PROVENANCE_UNAVAILABLE"
+    if Path(plans[0].worktree).resolve() == Path(plans[1].worktree).resolve():
+        return "SHARED_ARM_WORKTREE"
     if plans[0].prefix_id != plans[1].prefix_id:
         return "PREFIX_MISMATCH"
     if plans[0].environment_fingerprint == plans[1].environment_fingerprint:

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -211,6 +211,36 @@ def test_environment_mismatch_prevents_both_agent_arms(
     assert "infrastructure failures=2/2" in summarize(results)
 
 
+def test_shared_arm_worktree_prevents_both_agent_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    counter = 0
+
+    def shared_fork(*args: object, **kwargs: object) -> ForkPlan:
+        nonlocal counter
+        counter += 1
+        return ForkPlan(
+            f"fork-{counter}",
+            5,
+            "/same/worktree",
+            f"/rollout/{counter}",
+            "codex ...",
+            prefix_id="same-prefix",
+            environment_fingerprint="same-environment",
+        )
+
+    ran: list[str] = []
+    monkeypatch.setattr(experiment, "fork", shared_fork)
+    monkeypatch.setattr(experiment, "_run_arm", lambda *args, **kwargs: ran.append("run"))
+    monkeypatch.setattr(experiment, "_cleanup", lambda worktree: None)
+
+    results = run_experiment("s1", 5, None, run=True, neutral=True)
+
+    assert ran == []
+    assert all(result.classification == ArmClassification.INFRA_FAIL for result in results)
+    assert all(result.environment_preflight == "SHARED_ARM_WORKTREE" for result in results)
+
+
 def test_arm_rechecks_environment_immediately_before_agent_run(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Part of #42.

Summary:
- require the two counterfactual arms to use distinct resolved worktree paths
- refuse both arms before model execution when fork planning aliases the same mutable workspace
- persist `SHARED_ARM_WORKTREE` in the established preflight diagnostic field

Verification:
- ruff format --check .
- ruff check .
- mypy src tests
- pytest: 496 passed