### PR TITLE
feat(reviewer): merge related signal jobs

### DIFF
--- a/src/spotter/review_scheduler.py
+++ b/src/spotter/review_scheduler.py
@@ -24,6 +24,9 @@ class ReviewerJob:
     created_at: float | None
     snapshot: ThreadState
     reviewer_input: ReviewerInput
+    signal_ids: tuple[str, ...]
+    signal_types: tuple[str, ...]
+    candidate_event_ids: tuple[str, ...]
 
     def queued_event(self, trigger: TraceEvent) -> TraceEvent:
         return TraceEvent(
@@ -32,11 +35,14 @@ class ReviewerJob:
                 "review_job_id": self.job_id,
                 "signal_id": self.signal_id,
                 "signal_type": self.signal_type,
+                "signal_ids": list(self.signal_ids),
+                "signal_types": list(self.signal_types),
                 "thread_id": self.thread_id.value,
                 "target_turn_id": self.target_turn_id.value,
                 "target_connection_epoch": self.target_connection_epoch,
                 "state_version": self.state_version,
                 "candidate_event_id": self.candidate_event_id,
+                "candidate_event_ids": list(self.candidate_event_ids),
                 "input_coverage": self.reviewer_input.coverage(),
             },
             event_id=f"spotter:review-job:{self.job_id}:queued",
@@ -52,6 +58,7 @@ class ReviewerJob:
             {
                 "review_job_id": self.job_id,
                 "signal_id": self.signal_id,
+                "signal_ids": list(self.signal_ids),
                 "reason": reason,
                 "target_turn_id": self.target_turn_id.value,
                 "target_connection_epoch": self.target_connection_epoch,
@@ -70,6 +77,7 @@ class ReviewerJob:
             {
                 "review_job_id": self.job_id,
                 "signal_id": self.signal_id,
+                "signal_ids": list(self.signal_ids),
                 "reason": reason,
                 "target_turn_id": self.target_turn_id.value,
                 "target_connection_epoch": self.target_connection_epoch,
@@ -136,26 +144,55 @@ class ReviewScheduler:
 
         if event.kind != "signal_candidate":
             return tuple(transitions)
-        status = event.payload.get("status")
-        signal_id = _required_string(event.payload, "signal_id")
-        if status in {"resolved", "stale"}:
-            job_id = self._job_by_signal.get(signal_id)
-            resolved_job = self._jobs.get(job_id) if job_id is not None else None
-            if resolved_job is not None:
-                transitions.append(self._discard(resolved_job, event, f"signal_{status}"))
-            return tuple(transitions)
-        if status != "active" or signal_id in self._seen_signal_ids:
-            return tuple(transitions)
-        if state_before is None:
+        if state_before is None and event.payload.get("status") == "active":
             raise ReviewSchedulingError("active signal has no source ThreadState snapshot")
-        job = _job(event, state_before, signal_id)
-        self._seen_signal_ids.add(signal_id)
-        if state_before.active_turn_id != job.target_turn_id:
-            transitions.append(job.discarded_event(event, "target_not_active"))
+        transitions.extend(
+            self.update_candidates((event,), state_before or state_after, state_after)
+        )
+        return tuple(transitions)
+
+    def update_candidates(
+        self,
+        events: Iterable[TraceEvent],
+        source_snapshot: ThreadState,
+        state_after: ThreadState,
+    ) -> tuple[TraceEvent, ...]:
+        """Schedule one immutable job for related candidates from one source state."""
+
+        transitions: list[TraceEvent] = []
+        active: list[TraceEvent] = []
+        for event in events:
+            if event.kind != "signal_candidate":
+                continue
+            signal_id = _required_string(event.payload, "signal_id")
+            status = event.payload.get("status")
+            if status in {"resolved", "stale"}:
+                job_id = self._job_by_signal.get(signal_id)
+                job = self._jobs.get(job_id) if job_id is not None else None
+                if job is not None:
+                    transitions.append(self._discard(job, event, f"signal_{status}"))
+            elif status == "active" and signal_id not in self._seen_signal_ids:
+                active.append(event)
+        if not active:
+            return tuple(transitions)
+
+        job = _job(tuple(active), source_snapshot)
+        self._seen_signal_ids.update(job.signal_ids)
+        trigger = active[-1]
+        if source_snapshot.active_turn_id != job.target_turn_id:
+            transitions.append(job.discarded_event(trigger, "target_not_active"))
+            return tuple(transitions)
+        if (
+            state_after.thread_id != job.thread_id
+            or state_after.active_turn_id != job.target_turn_id
+            or state_after.connection_epoch != job.target_connection_epoch
+        ):
+            transitions.append(job.discarded_event(trigger, "target_changed"))
             return tuple(transitions)
         self._jobs[job.job_id] = job
-        self._job_by_signal[signal_id] = job.job_id
-        transitions.append(job.queued_event(event))
+        for signal_id in job.signal_ids:
+            self._job_by_signal[signal_id] = job.job_id
+        transitions.append(job.queued_event(trigger))
         return tuple(transitions)
 
     def hydrate(self, records: Iterable[StepRecord]) -> tuple[TraceEvent, ...]:
@@ -168,12 +205,41 @@ class ReviewScheduler:
         replay = ThreadStateStore()
         snapshots: dict[tuple[ThreadId, int], ThreadState] = {}
         missing: dict[str, TraceEvent] = {}
+        candidate_group: list[TraceEvent] = []
+        candidate_key: tuple[ThreadId, int] | None = None
+
+        def flush_candidates() -> None:
+            nonlocal candidate_key
+            if not candidate_group or candidate_key is None:
+                return
+            thread_id, version = candidate_key
+            snapshot = snapshots.get(candidate_key)
+            if snapshot is None:
+                raise ReviewSchedulingError("candidate source ThreadState snapshot is missing")
+            state_after = replay.snapshot(thread_id)
+            for transition in self.update_candidates(candidate_group, snapshot, state_after):
+                assert transition.event_id is not None
+                missing[transition.event_id] = transition
+            candidate_group.clear()
+            candidate_key = None
+
         for record in records:
             event = record.event
             identity = event.identity
             if identity is None or identity.thread_id is None:
                 continue
             thread_id = identity.thread_id
+            next_key: tuple[ThreadId, int] | None = None
+            if event.kind == "signal_candidate":
+                version = event.payload.get("state_version")
+                if isinstance(version, int) and not isinstance(version, bool):
+                    next_key = (thread_id, version)
+            if (
+                candidate_group
+                and next_key != candidate_key
+                and event.kind != "signal_candidate_suppressed"
+            ):
+                flush_candidates()
             try:
                 state_before = replay.snapshot(thread_id)
             except ThreadStateError:
@@ -182,14 +248,18 @@ class ReviewScheduler:
             snapshots[(thread_id, state_after.version)] = state_after
             if event.event_id is not None:
                 missing.pop(event.event_id, None)
-            candidate_state = state_before
             if event.kind == "signal_candidate":
-                version = event.payload.get("state_version")
-                if isinstance(version, int) and not isinstance(version, bool):
-                    candidate_state = snapshots.get((thread_id, version))
-            for transition in self.update(event, candidate_state, state_after):
+                if next_key is None:
+                    raise ReviewSchedulingError("signal candidate has no integer state_version")
+                candidate_key = next_key
+                candidate_group.append(event)
+                continue
+            if event.kind == "signal_candidate_suppressed":
+                continue
+            for transition in self.update(event, state_before, state_after):
                 assert transition.event_id is not None
                 missing[transition.event_id] = transition
+        flush_candidates()
         return tuple(missing.values())
 
     def _discard(self, job: ReviewerJob, trigger: TraceEvent, reason: str) -> TraceEvent:
@@ -201,19 +271,24 @@ class ReviewScheduler:
         job = self._jobs.pop(job_id, None)
         self._started_job_ids.discard(job_id)
         if job is not None:
-            self._job_by_signal.pop(job.signal_id, None)
+            for signal_id in job.signal_ids:
+                self._job_by_signal.pop(signal_id, None)
 
 
-def _job(event: TraceEvent, snapshot: ThreadState, signal_id: str) -> ReviewerJob:
+def _job(events: tuple[TraceEvent, ...], snapshot: ThreadState) -> ReviewerJob:
+    if not events:
+        raise ReviewSchedulingError("review job has no candidates")
+    signal_ids = tuple(_required_string(event.payload, "signal_id") for event in events)
+    signal_types = tuple(_required_string(event.payload, "signal_type") for event in events)
+    candidate_event_ids = tuple(event.event_id for event in events if event.event_id is not None)
+    if len(candidate_event_ids) != len(events):
+        raise ReviewSchedulingError("active signal has no durable event identity")
+    event = events[-1]
     identity = event.identity
     if identity is None or identity.thread_id is None or identity.turn_id is None:
         raise ReviewSchedulingError("active signal has no exact thread/turn identity")
     thread_id = identity.thread_id
     turn_id = identity.turn_id
-    signal_type = _required_string(event.payload, "signal_type")
-    candidate_event_id = event.event_id
-    if candidate_event_id is None:
-        raise ReviewSchedulingError("active signal has no durable event identity")
     state_version = event.payload.get("state_version")
     target_epoch = event.payload.get("target_connection_epoch")
     if not isinstance(state_version, int) or isinstance(state_version, bool):
@@ -222,29 +297,88 @@ def _job(event: TraceEvent, snapshot: ThreadState, signal_id: str) -> ReviewerJo
         not isinstance(target_epoch, int) or isinstance(target_epoch, bool)
     ):
         raise ReviewSchedulingError("active signal has an invalid connection epoch")
+    for candidate in events:
+        if (
+            candidate.identity != identity
+            or candidate.payload.get("thread_id") != thread_id.value
+            or candidate.payload.get("turn_id") != turn_id.value
+            or candidate.payload.get("state_version") != state_version
+            or candidate.payload.get("target_connection_epoch") != target_epoch
+        ):
+            raise ReviewSchedulingError("merged signals do not share one immutable target")
     if (
-        event.payload.get("thread_id") != thread_id.value
-        or event.payload.get("turn_id") != turn_id.value
-        or snapshot.thread_id != thread_id
+        snapshot.thread_id != thread_id
         or snapshot.version != state_version
         or snapshot.identity.turn_id != turn_id
         or snapshot.connection_epoch != target_epoch
     ):
         raise ReviewSchedulingError("active signal target does not match its ThreadState snapshot")
-    job_id = hashlib.sha256(f"{signal_id}:{candidate_event_id}".encode()).hexdigest()
+    merged_payload = _merge_candidate_payload(events, signal_ids, signal_types)
+    reviewer_input = build_reviewer_input(merged_payload, snapshot)
+    job_key = (
+        f"{signal_ids[0]}:{candidate_event_ids[0]}"
+        if len(events) == 1
+        else ":".join(candidate_event_ids)
+    )
+    job_id = hashlib.sha256(job_key.encode()).hexdigest()
     return ReviewerJob(
         job_id,
-        signal_id,
-        signal_type,
+        signal_ids[0],
+        signal_types[0],
         thread_id,
         turn_id,
         target_epoch,
         state_version,
-        candidate_event_id,
+        candidate_event_ids[0],
         event.occurred_at,
         snapshot,
-        build_reviewer_input(event.payload, snapshot),
+        reviewer_input,
+        signal_ids,
+        signal_types,
+        candidate_event_ids,
     )
+
+
+def _merge_candidate_payload(
+    events: tuple[TraceEvent, ...],
+    signal_ids: tuple[str, ...],
+    signal_types: tuple[str, ...],
+) -> dict[str, object]:
+    if len(events) == 1:
+        return dict(events[0].payload)
+
+    evidence: list[str] = []
+    resources: list[str] = []
+    features: dict[str, object] = {}
+    severities: list[int | float] = []
+    for event, signal_type in zip(events, signal_types, strict=True):
+        evidence.extend(_strings(event.payload.get("evidence_event_ids")))
+        resources.extend(_strings(event.payload.get("involved_resources")))
+        severity = event.payload.get("severity_hint")
+        if isinstance(severity, int | float) and not isinstance(severity, bool):
+            severities.append(severity)
+        raw_features = event.payload.get("features")
+        if isinstance(raw_features, Mapping):
+            features.update(
+                {
+                    f"{signal_type}.{key}": value
+                    for key, value in raw_features.items()
+                    if isinstance(key, str)
+                }
+            )
+    digest = hashlib.sha256(":".join(signal_ids).encode()).hexdigest()
+    return {
+        "signal_id": f"merged:{digest}",
+        "signal_type": "+".join(dict.fromkeys(signal_types)),
+        "severity_hint": max(severities) if severities else None,
+        "evidence_event_ids": list(dict.fromkeys(evidence)),
+        "involved_resources": list(dict.fromkeys(resources)),
+        "features": features,
+    }
+
+
+def _strings(value: object) -> tuple[str, ...]:
+    return tuple(item for item in value if isinstance(item, str)) if isinstance(value, list) else ()
 
 
 def _required_string(payload: Mapping[str, object], key: str) -> str:

--- a/src/spotter/runtime_connection.py
+++ b/src/spotter/runtime_connection.py
@@ -405,7 +405,23 @@ class AppServerRecoveryLoop:
         except ThreadStateError:
             state_before = None
         state = self.thread_states.observe(record.event)
-        for transition in self.review_scheduler.update(record.event, state_before, state):
+        self._record_review_transitions(
+            self.review_scheduler.update(record.event, state_before, state)
+        )
+        candidate_events: list[TraceEvent] = []
+        for candidate in self.signals.update(record.event, state.version):
+            candidate_record = self._append_derived(candidate.to_trace_event(record.event))
+            if candidate_record is not None:
+                candidate_events.append(candidate_record.event)
+        if candidate_events:
+            current = self.thread_states.snapshot(event.identity.thread_id)
+            self._record_review_transitions(
+                self.review_scheduler.update_candidates(candidate_events, state, current)
+            )
+        return record
+
+    def _record_review_transitions(self, transitions: tuple[TraceEvent, ...]) -> None:
+        for transition in transitions:
             self._record(transition)
             job_id = transition.payload.get("review_job_id")
             if (
@@ -415,9 +431,6 @@ class AppServerRecoveryLoop:
                 and (job := self.review_scheduler.get(job_id)) is not None
             ):
                 self.on_review_job(job)
-        for candidate in self.signals.update(record.event, state.version):
-            self._record(candidate.to_trace_event(record.event))
-        return record
 
     def _append_derived(self, event: TraceEvent) -> StepRecord | None:
         """Recover one already-derived event without running producers out of order."""

--- a/tests/test_review_scheduler.py
+++ b/tests/test_review_scheduler.py
@@ -42,6 +42,34 @@ def _active_candidate() -> tuple[list[TraceEvent], TraceEvent]:
     return [turn, first, second], candidate
 
 
+def _signal_candidate(
+    event_id: str,
+    signal_id: str,
+    signal_type: str,
+    evidence_id: str,
+    feature: str,
+    *,
+    state_version: int = 1,
+) -> TraceEvent:
+    return _event(
+        event_id,
+        "signal_candidate",
+        {
+            "signal_id": signal_id,
+            "signal_type": signal_type,
+            "thread_id": "thread-1",
+            "turn_id": "turn-1",
+            "target_connection_epoch": 1,
+            "state_version": state_version,
+            "severity_hint": 3,
+            "evidence_event_ids": [evidence_id],
+            "involved_resources": [f"resource:{signal_id}"],
+            "features": {feature: 3},
+            "status": "active",
+        },
+    )
+
+
 def test_active_candidate_queues_one_immutable_snapshot() -> None:
     source_events, candidate = _active_candidate()
     states = ThreadStateStore()
@@ -59,6 +87,45 @@ def test_active_candidate_queues_one_immutable_snapshot() -> None:
     assert len(scheduler.pending()) == 1
     assert scheduler.pending()[0].snapshot is snapshot
     assert scheduler.pending()[0].state_version == 3
+
+
+def test_related_candidates_merge_into_one_bounded_reviewer_job() -> None:
+    turn = _event("turn-start", "turn_started", {})
+    first = _signal_candidate(
+        "candidate-1", "signal-1", "failure_streak", "failure-2", "consecutive_failures"
+    )
+    second = _signal_candidate(
+        "candidate-2",
+        "signal-2",
+        "repeated_equivalent_tool_call",
+        "read-4",
+        "consecutive_equivalent_calls",
+    )
+    states = ThreadStateStore()
+    snapshot = states.observe(turn)
+    states.observe(first)
+    state_after = states.observe(second)
+    scheduler = ReviewScheduler()
+
+    queued = scheduler.update_candidates((first, second), snapshot, state_after)
+    job = scheduler.pending()[0]
+
+    assert len(queued) == 1
+    assert len(scheduler.pending()) == 1
+    assert job.signal_ids == ("signal-1", "signal-2")
+    assert job.signal_types == ("failure_streak", "repeated_equivalent_tool_call")
+    assert job.candidate_event_ids == ("candidate-1", "candidate-2")
+    assert job.reviewer_input.evidence_event_ids == ("failure-2", "read-4")
+    assert job.reviewer_input.involved_resources == (
+        "resource:signal-1",
+        "resource:signal-2",
+    )
+    assert job.reviewer_input.features == (
+        ("failure_streak.consecutive_failures", 3),
+        ("repeated_equivalent_tool_call.consecutive_equivalent_calls", 3),
+    )
+    assert queued[0].payload["signal_ids"] == ["signal-1", "signal-2"]
+    assert queued[0].payload["candidate_event_ids"] == ["candidate-1", "candidate-2"]
 
 
 def test_target_change_discards_pending_job() -> None:
@@ -119,6 +186,36 @@ def test_hydration_backfills_only_missing_queue_transition() -> None:
     assert len(recovered.pending()) == 1
     assert recovered.pending()[0].snapshot.version == 3
     assert recovered.pending()[0].reviewer_input == scheduler.pending()[0].reviewer_input
+
+
+def test_hydration_preserves_merged_candidate_evidence() -> None:
+    turn = _event("turn-start", "turn_started", {})
+    first = _signal_candidate(
+        "candidate-1", "signal-1", "failure_streak", "failure-2", "consecutive_failures"
+    )
+    second = _signal_candidate(
+        "candidate-2",
+        "signal-2",
+        "repeated_equivalent_tool_call",
+        "read-4",
+        "consecutive_equivalent_calls",
+    )
+    records = [
+        StepRecord(0, turn, None),
+        StepRecord(1, first, None),
+        StepRecord(2, second, None),
+    ]
+    scheduler = ReviewScheduler()
+    queued = scheduler.hydrate(records)[0]
+    recovered = ReviewScheduler()
+
+    assert recovered.hydrate([*records, StepRecord(3, queued, None)]) == ()
+    assert len(recovered.pending()) == 1
+    assert recovered.pending()[0].signal_ids == ("signal-1", "signal-2")
+    assert recovered.pending()[0].reviewer_input.evidence_event_ids == (
+        "failure-2",
+        "read-4",
+    )
 
 
 def test_hydration_recovers_running_job_as_stale_not_discarded() -> None:

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 
 from spotter.identity import IdentityProvenance, RuntimeIdentity, ThreadId, TurnId
+from spotter.review_scheduler import ReviewerJob
 from spotter.runtime_connection import AppServerRecoveryLoop
-from spotter.signals import SignalEngine, SignalStatus, SignalType
+from spotter.signals import SignalCandidate, SignalEngine, SignalStatus, SignalType
 from spotter.snapshot import StepRecord
 from spotter.thread_state import ThreadStateStore
 from spotter.trace import TraceEvent, TraceProvenance
@@ -261,6 +262,69 @@ def test_runtime_journals_signal_candidates_and_recovers_cooldown(tmp_path: Path
     ]
     assert len(suppressed) == 1
     assert suppressed[0].payload["status"] == "cooled_down"
+
+
+def test_runtime_batches_same_source_candidates_before_submitting_review(tmp_path: Path) -> None:
+    class TwoSignalEngine(SignalEngine):
+        def update(self, event: TraceEvent, state_version: int) -> tuple[SignalCandidate, ...]:
+            if event.event_id != "event-1" or event.identity is None:
+                return ()
+            assert event.identity.thread_id is not None
+            return tuple(
+                SignalCandidate(
+                    f"signal-{index}",
+                    signal_type,
+                    event.identity.thread_id,
+                    event.identity.turn_id.value if event.identity.turn_id else None,
+                    event.connection_epoch,
+                    state_version,
+                    event.occurred_at,
+                    event.occurred_at,
+                    index,
+                    (f"evidence-{index}",),
+                    (f"resource:{index}",),
+                    SignalStatus.ACTIVE,
+                    event.event_id,
+                    ((feature, index),),
+                )
+                for index, signal_type, feature in (
+                    (2, SignalType.FAILURE_STREAK, "consecutive_failures"),
+                    (
+                        3,
+                        SignalType.REPEATED_EQUIVALENT_TOOL_CALL,
+                        "consecutive_equivalent_calls",
+                    ),
+                )
+            )
+
+    submitted: list[ReviewerJob] = []
+    runtime = AppServerRecoveryLoop(
+        "ws://unused",
+        tmp_path / "sessions",
+        ThreadStateStore(),
+        signals=TwoSignalEngine(),
+        on_review_job=submitted.append,
+    )
+    runtime._record(
+        TraceEvent(
+            "turn_started",
+            {},
+            event_id="turn-start",
+            identity=_event("event-1", "completed").identity,
+            connection_epoch=1,
+        )
+    )
+    runtime._record(_event("event-1", "completed"))
+
+    records = runtime.ingestor.records()
+    candidates = [record.event for record in records if record.event.kind == "signal_candidate"]
+    queued = [record.event for record in records if record.event.kind == "review_job_queued"]
+
+    assert len(candidates) == 2
+    assert len(queued) == 1
+    assert queued[0].payload["signal_ids"] == ["signal-2", "signal-3"]
+    assert len(submitted) == 1
+    assert submitted[0].reviewer_input.evidence_event_ids == ("evidence-2", "evidence-3")
 
 
 def test_runtime_backfills_candidate_after_interrupted_derived_append(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- batch signal candidates derived from the same source state before review scheduling
- merge their signal IDs, types, evidence, resources, and namespaced features into one bounded immutable reviewer job
- preserve single-candidate job IDs for journal compatibility and rebuild identical merged jobs during hydration

Advances #28.

## Verification
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (540 passed)