### PR TITLE
feat(reviewer): prioritize pending signal jobs

### DIFF
--- a/src/spotter/review_executor.py
+++ b/src/spotter/review_executor.py
@@ -1,6 +1,7 @@
 """Asynchronous shadow execution for durable signal-driven reviewer jobs."""
 
 import asyncio
+import math
 import time
 from collections.abc import Awaitable, Callable
 
@@ -31,132 +32,155 @@ class ReviewExecutor:
         self.record = record
         self.is_fresh = is_fresh
         self.reviewer = reviewer
-        self._lock = asyncio.Lock()
-        self._tasks: set[asyncio.Task[None]] = set()
+        self._queue: asyncio.PriorityQueue[tuple[float, int, int, ReviewerJob]] = (
+            asyncio.PriorityQueue()
+        )
+        self._runner: asyncio.Task[None] | None = None
+        self._sequence = 0
         self._submitted: set[str] = set()
 
     def submit(self, job: ReviewerJob) -> None:
         if not self.config.on_signals or job.job_id in self._submitted:
             return
         self._submitted.add(job.job_id)
-        task = asyncio.create_task(
-            self._run(job, time.perf_counter_ns()), name=f"review-{job.job_id[:12]}"
-        )
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
+        self._sequence += 1
+        self._queue.put_nowait((-_priority(job), self._sequence, time.perf_counter_ns(), job))
+        if self._runner is None or self._runner.done():
+            self._runner = asyncio.create_task(self._work(), name="review-queue")
 
     async def drain(self) -> None:
-        if self._tasks:
-            await asyncio.gather(*tuple(self._tasks))
+        await self._queue.join()
 
     async def close(self) -> None:
-        for task in tuple(self._tasks):
-            task.cancel()
-        if self._tasks:
-            await asyncio.gather(*tuple(self._tasks), return_exceptions=True)
+        if self._runner is not None:
+            self._runner.cancel()
+            await asyncio.gather(self._runner, return_exceptions=True)
+            self._runner = None
+
+    async def _work(self) -> None:
+        while True:
+            _, _, queued_ns, job = await self._queue.get()
+            try:
+                await self._run(job, queued_ns)
+            finally:
+                self._queue.task_done()
 
     async def _run(self, job: ReviewerJob, queued_ns: int) -> None:
-        async with self._lock:
-            if not self.is_fresh(job):
-                return
-            session = job.thread_id.value
-            try:
-                token, refusal = reserve(
-                    session,
-                    self.config.max_per_session,
-                    self.config.max_per_day,
-                )
-            except Exception as error:  # noqa: BLE001 — spending failure must stay visible
-                self.record(
-                    self._event(
-                        job,
-                        "reviewer_error",
-                        {
-                            "review_job_id": job.job_id,
-                            "error": f"review budget unavailable: {error}"[:300],
-                        },
-                    )
-                )
-                return
-            if token is None:
-                kind = "reviewer_error" if "unreadable" in refusal else "reviewer_capped"
-                key = "error" if kind == "reviewer_error" else "reason"
-                self.record(self._event(job, kind, {key: refusal, "review_job_id": job.job_id}))
-                return
-            started_at = time.time()
-            queue_ms = _elapsed_ms(queued_ns)
-            self.record(
-                self._event(
-                    job,
-                    "review_inference_started",
-                    {"review_job_id": job.job_id, "queue_ms": queue_ms},
-                    occurred_at=started_at,
-                )
+        if not self.is_fresh(job):
+            return
+        session = job.thread_id.value
+        try:
+            token, refusal = reserve(
+                session,
+                self.config.max_per_session,
+                self.config.max_per_day,
             )
-            inference_started_ns = time.perf_counter_ns()
-            try:
-                decision, tokens = await self.reviewer(job.reviewer_input, self.config.model)
-            except asyncio.CancelledError:
-                inference_ms = _elapsed_ms(inference_started_ns)
-                spend = settle(session, token, 0) or charge(session, 0)
-                self.record(
-                    self._event(
-                        job,
-                        "reviewer_error",
-                        {
-                            "review_job_id": job.job_id,
-                            "error": "review cancelled during daemon shutdown",
-                            "spend": _spend(spend),
-                            "timing": {"queue_ms": queue_ms, "inference_ms": inference_ms},
-                        },
-                    )
-                )
-                raise
-            except Exception as error:  # noqa: BLE001 — paid failure must remain observable
-                inference_ms = _elapsed_ms(inference_started_ns)
-                spend = settle(session, token, 0) or charge(session, 0)
-                self.record(
-                    self._event(
-                        job,
-                        "reviewer_error",
-                        {
-                            "review_job_id": job.job_id,
-                            "error": str(error)[:300],
-                            "spend": _spend(spend),
-                            "timing": {"queue_ms": queue_ms, "inference_ms": inference_ms},
-                        },
-                    )
-                )
-                return
-            inference_ms = _elapsed_ms(inference_started_ns)
-            spend = settle(session, token, tokens) or charge(session, tokens)
-            stale = not self.is_fresh(job)
+        except Exception as error:  # noqa: BLE001 — spending failure must stay visible
             self.record(
                 self._event(
                     job,
-                    "reviewer_decision",
+                    "reviewer_error",
                     {
                         "review_job_id": job.job_id,
-                        "decision": decision.decision,
-                        "failure_class": decision.failure_class,
-                        "reason": decision.reason,
-                        "hypothesis": decision.hypothesis,
-                        "confidence": decision.confidence,
-                        "model": self.config.model,
-                        "reviewed_state_version": job.state_version,
-                        "target_turn_id": job.target_turn_id.value,
-                        "target_connection_epoch": job.target_connection_epoch,
-                        "stale": stale,
-                        "shadow": True,
-                        "inputs": job.reviewer_input.coverage(),
-                        "timing": {
-                            "queue_ms": queue_ms,
-                            "inference_ms": inference_ms,
-                        },
-                        "spend": _spend(spend),
+                        "error": f"review budget unavailable: {error}"[:300],
+                        "priority": _priority(job),
                     },
                 )
             )
+            return
+        if token is None:
+            kind = "reviewer_error" if "unreadable" in refusal else "reviewer_capped"
+            key = "error" if kind == "reviewer_error" else "reason"
+            self.record(
+                self._event(
+                    job,
+                    kind,
+                    {
+                        key: refusal,
+                        "review_job_id": job.job_id,
+                        "priority": _priority(job),
+                    },
+                )
+            )
+            return
+        started_at = time.time()
+        queue_ms = _elapsed_ms(queued_ns)
+        self.record(
+            self._event(
+                job,
+                "review_inference_started",
+                {
+                    "review_job_id": job.job_id,
+                    "queue_ms": queue_ms,
+                    "priority": _priority(job),
+                },
+                occurred_at=started_at,
+            )
+        )
+        inference_started_ns = time.perf_counter_ns()
+        try:
+            decision, tokens = await self.reviewer(job.reviewer_input, self.config.model)
+        except asyncio.CancelledError:
+            inference_ms = _elapsed_ms(inference_started_ns)
+            spend = settle(session, token, 0) or charge(session, 0)
+            self.record(
+                self._event(
+                    job,
+                    "reviewer_error",
+                    {
+                        "review_job_id": job.job_id,
+                        "error": "review cancelled during daemon shutdown",
+                        "spend": _spend(spend),
+                        "timing": {"queue_ms": queue_ms, "inference_ms": inference_ms},
+                    },
+                )
+            )
+            raise
+        except Exception as error:  # noqa: BLE001 — paid failure must remain observable
+            inference_ms = _elapsed_ms(inference_started_ns)
+            spend = settle(session, token, 0) or charge(session, 0)
+            self.record(
+                self._event(
+                    job,
+                    "reviewer_error",
+                    {
+                        "review_job_id": job.job_id,
+                        "error": str(error)[:300],
+                        "spend": _spend(spend),
+                        "timing": {"queue_ms": queue_ms, "inference_ms": inference_ms},
+                    },
+                )
+            )
+            return
+        inference_ms = _elapsed_ms(inference_started_ns)
+        spend = settle(session, token, tokens) or charge(session, tokens)
+        stale = not self.is_fresh(job)
+        self.record(
+            self._event(
+                job,
+                "reviewer_decision",
+                {
+                    "review_job_id": job.job_id,
+                    "decision": decision.decision,
+                    "failure_class": decision.failure_class,
+                    "reason": decision.reason,
+                    "hypothesis": decision.hypothesis,
+                    "confidence": decision.confidence,
+                    "model": self.config.model,
+                    "reviewed_state_version": job.state_version,
+                    "target_turn_id": job.target_turn_id.value,
+                    "target_connection_epoch": job.target_connection_epoch,
+                    "stale": stale,
+                    "shadow": True,
+                    "inputs": job.reviewer_input.coverage(),
+                    "timing": {
+                        "queue_ms": queue_ms,
+                        "inference_ms": inference_ms,
+                    },
+                    "spend": _spend(spend),
+                },
+            )
+        )
 
     @staticmethod
     def _event(
@@ -186,3 +210,11 @@ def _spend(spend: Spend) -> dict[str, int]:
 
 def _elapsed_ms(started_ns: int) -> float:
     return max(0.0, (time.perf_counter_ns() - started_ns) / 1_000_000)
+
+
+def _priority(job: ReviewerJob) -> float:
+    value = job.reviewer_input.severity_hint
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        priority = float(value)
+        return priority if math.isfinite(priority) else 0.0
+    return 0.0

--- a/tests/test_review_executor.py
+++ b/tests/test_review_executor.py
@@ -1,4 +1,5 @@
 import asyncio
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -6,7 +7,9 @@ import pytest
 from spotter.config import ReviewerConfig
 from spotter.identity import IdentityProvenance, RuntimeIdentity, ThreadId, TurnId
 from spotter.review_executor import ReviewExecutor
+from spotter.review_scheduler import ReviewerJob
 from spotter.reviewer import ReviewerDecision
+from spotter.reviewer_input import ReviewerInput
 from spotter.runtime_connection import AppServerRecoveryLoop
 from spotter.thread_state import ThreadStateStore
 from spotter.trace import TraceEvent
@@ -159,5 +162,74 @@ def test_failed_review_records_monotonic_queue_and_inference_timing(
         assert float(timing["queue_ms"]) >= 0
         assert float(timing["inference_ms"]) >= 0
         assert runtime.review_scheduler.pending() == ()
+
+    asyncio.run(scenario())
+
+
+def test_pending_reviews_use_severity_before_limited_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path / "home"))
+
+    async def scenario() -> None:
+        runtime = AppServerRecoveryLoop("ws://unused", tmp_path / "sessions", ThreadStateStore())
+        captured: list[ReviewerJob] = []
+        runtime.set_review_job_callback(captured.append)
+        _trigger(runtime)
+        base = captured[0]
+
+        def queued_job(name: str, severity: int) -> ReviewerJob:
+            return replace(
+                base,
+                job_id=name,
+                signal_id=name,
+                candidate_event_id=f"candidate-{name}",
+                reviewer_input=replace(
+                    base.reviewer_input,
+                    signal_id=name,
+                    severity_hint=severity,
+                ),
+                signal_ids=(name,),
+                candidate_event_ids=(f"candidate-{name}",),
+            )
+
+        low = queued_job("low", 1)
+        medium = queued_job("medium", 5)
+        high = queued_job("high", 9)
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        order: list[str] = []
+        recorded: list[TraceEvent] = []
+
+        async def reviewer(input_: ReviewerInput, model: str) -> tuple[ReviewerDecision, int]:
+            signal_id = input_.signal_id
+            order.append(signal_id)
+            if signal_id == "low":
+                entered.set()
+                await release.wait()
+            return ReviewerDecision("continue", "none", "prioritized", 0.8), 1
+
+        executor = ReviewExecutor(
+            ReviewerConfig(on_signals=True, max_per_session=2, max_per_day=2),
+            recorded.append,
+            lambda job: True,
+            reviewer=reviewer,
+        )
+        executor.submit(low)
+        await entered.wait()
+        executor.submit(medium)
+        executor.submit(high)
+        release.set()
+        await executor.drain()
+        await executor.close()
+
+        assert order == ["low", "high"]
+        started = [event for event in recorded if event.kind == "review_inference_started"]
+        assert [event.payload["review_job_id"] for event in started] == ["low", "high"]
+        assert [event.payload["priority"] for event in started] == [1.0, 9.0]
+        capped = [event for event in recorded if event.kind == "reviewer_capped"]
+        assert len(capped) == 1
+        assert capped[0].payload["review_job_id"] == "medium"
+        assert capped[0].payload["priority"] == 5.0
 
     asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- replace submission-order lock contention with one severity-prioritized pending review queue
- preserve FIFO ordering for equal severity and never preempt an in-flight paid review
- recheck freshness before budget reservation and journal the chosen priority on started/capped outcomes

Advances #28.

## Verification
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (541 passed)