### PR TITLE
fix(replay): enable hooks in captured task workspaces

### DIFF
--- a/src/spotter/task_corpus.py
+++ b/src/spotter/task_corpus.py
@@ -480,7 +480,7 @@ def _run_task_agent(
         args += ["--model", model]
     args += ["--skip-git-repo-check", "--sandbox", sandbox]
     if capture_replay_source:
-        args.append("--json")
+        args += ["--dangerously-bypass-hook-trust", "--json"]
     args.append(prompt)
     env = {**os.environ}
     if capture_replay_source:

--- a/tests/test_task_corpus.py
+++ b/tests/test_task_corpus.py
@@ -406,10 +406,12 @@ def test_task_agent_capture_mode_enables_json_hooks_without_supervision(
 
     capture_args, capture_env = calls[0]
     assert "--json" in capture_args
+    assert "--dangerously-bypass-hook-trust" in capture_args
     assert capture_env["SPOTTER_CAPTURE_ONLY"] == "1"
     assert "SPOTTER_DISABLE" not in capture_env
     normal_args, normal_env = calls[1]
     assert "--json" not in normal_args
+    assert "--dangerously-bypass-hook-trust" not in normal_args
     assert normal_env["SPOTTER_DISABLE"] == "1"
     assert "SPOTTER_CAPTURE_ONLY" not in normal_env
 


### PR DESCRIPTION
## Bug

`tasks run --capture-replay-sources` initialized each fixture as a fresh scratch repository, but Codex did not trust configured Hooks in that repository. Agent arms and scorers completed while Spotter journals were never created, so every arm reported a missing replay source.

## Root cause and fix

The capture child used `--skip-git-repo-check` but did not opt into the Codex automation flag that permits already-vetted configured Hooks. Capture mode now adds `--dangerously-bypass-hook-trust`; normal task arms remain unchanged and continue with Spotter disabled.

This path is already gated by frozen task validation, preflight, explicit `--capture-replay-sources`, and explicit paid-run consent.

## Verification

- focused task-corpus tests
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (570 passed)
- real `validation-v1` batch: control `PASS`, guidance `TASK_FAIL`, replay sources `2/2 captured`

Related to #42.