### PR TITLE
fix(replay): prioritize missing resource drift

### DIFF
--- a/src/spotter/replay.py
+++ b/src/spotter/replay.py
@@ -576,7 +576,11 @@ def _declared_resource_drift(
         return (EnvironmentDrift.UNKNOWN_ENVIRONMENT_DRIFT,)
     drift: list[EnvironmentDrift] = []
     for source, restored in zip(left, right, strict=True):
-        if source.worktree_path_reference != restored.worktree_path_reference:
+        if source.state == "ignored" and restored.state == "missing":
+            category = EnvironmentDrift.MISSING_IGNORED_FILE
+        elif source.state == "untracked" and restored.state == "missing":
+            category = EnvironmentDrift.MISSING_UNTRACKED_FILE
+        elif source.worktree_path_reference != restored.worktree_path_reference:
             category = EnvironmentDrift.ABSOLUTE_PATH_MISMATCH
         elif (
             source.sha256 is not None
@@ -584,10 +588,6 @@ def _declared_resource_drift(
             and source.sha256 == restored.sha256
         ):
             continue
-        elif source.state == "ignored" and restored.state == "missing":
-            category = EnvironmentDrift.MISSING_IGNORED_FILE
-        elif source.state == "untracked" and restored.state == "missing":
-            category = EnvironmentDrift.MISSING_UNTRACKED_FILE
         elif source.state == "tracked":
             category = EnvironmentDrift.TRACKED_STATE_MISMATCH
         else:

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -715,9 +715,11 @@ def test_environment_comparison_classifies_submodule_drift_separately(repo: Path
 def test_declared_ignored_resource_is_not_hidden_by_matching_forks(
     repo: Path, codex_home: Path
 ) -> None:
+    _commit_baseline(repo)
     (repo / ".gitignore").write_text(".env\n")
-    (repo / ".env").write_text("fixture-secret")
+    (repo / ".env").write_text(str(repo.resolve()))
     (repo / "fixture.json").write_text('{"version": 1}')
+    source = fingerprint_environment(repo, (".env",)).declared_resources[0]
     sha = snapshot_worktree(repo)
     _journal(
         OLD_ID,
@@ -744,6 +746,7 @@ def test_declared_ignored_resource_is_not_hidden_by_matching_forks(
     )
     manifest = load_fork_manifest(Path(plan.manifest or ""))
 
+    assert source.worktree_path_reference is True
     assert plan.source_environment_preflight == ("SOURCE_ENVIRONMENT_MISMATCH:MISSING_IGNORED_FILE")
     assert manifest.source_environment_preflight == plan.source_environment_preflight
     assert manifest.environment is not None


### PR DESCRIPTION
## Why

PR #196 added absolute-worktree-path drift detection. Its review noted that a declared ignored or untracked resource containing such a path would be labeled `ABSOLUTE_PATH_MISMATCH` when the resource was entirely missing after restore, hiding the more diagnostic missing-resource category.

## What changed

- classify missing ignored/untracked resources before comparing worktree-path references
- keep `ABSOLUTE_PATH_MISMATCH` for resources that exist on both sides but retain the wrong worktree reference
- extend the source-to-fork regression case with an ignored file that contains the source worktree path

## Validation

- `.venv/bin/pytest tests/test_replay.py -q`
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src tests`
- `.venv/bin/pytest` (572 passed)

Follow-up to #196. Related to #42.