### PR TITLE
docs: add multilingual README and user guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 build/
 dist/
 
+.grepai/

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,242 @@
+<div align="center">
+
+<p>
+  <a href="README.md">English</a> ·
+  <strong>한국어</strong> ·
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<h1>Spotter</h1>
+
+<picture>
+  <img alt="Spotter" src="docs/assets/main-ts.png" width="250" />
+</picture>
+
+<h3>잘못된 코딩 에이전트의 작업 궤적을 비용이 커지기 전에 포착하세요.</h3>
+
+<p>
+  Spotter는 코딩 에이전트를 위한 로컬 런타임 감독 도구입니다.<br />
+  최종 diff뿐 아니라 작업 과정을 관찰하여 비용이 큰 이탈을 일찍 발견합니다.
+</p>
+
+<p>
+  <code>로컬 우선</code> · <code>제한된 게이트</code> · <code>작업 궤적 중심</code>
+</p>
+
+<p>
+  <a href="#설치"><strong>설치</strong></a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="#빠른-시작"><strong>빠른 시작</strong></a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="docs/user-guide.ko.md"><strong>상세 가이드</strong></a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="docs/status.md">현재 상태(영문)</a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="docs/README.md">전체 문서</a>
+</p>
+
+</div>
+
+---
+
+## Spotter가 필요한 이유
+
+코딩 에이전트는 대개 한 번의 명백한 실수로 실패하지 않습니다. 약한 가정 하나가 다음 검색과
+수정, 테스트의 방향을 결정하고, 반복되는 작은 판단이 복구 가능한 실수를 시간과 토큰, 저장소
+변경 낭비로 키웁니다.
+
+<table>
+  <tr>
+    <td width="33%" valign="top">
+      <strong>🔭 작업 궤적 중심</strong><br />
+      <sub>최종 diff뿐 아니라 판단, 증거, 수정, 검증의 흐름을 관찰합니다.</sub>
+    </td>
+    <td width="33%" valign="top">
+      <strong>⚡ 제한된 안전 검사</strong><br />
+      <sub>위험한 도구 사용 전 결정론적 검사를 로컬에서 빠르게 수행합니다.</sub>
+    </td>
+    <td width="33%" valign="top">
+      <strong>🩺 명확한 저하 상태</strong><br />
+      <sub>Codex를 막지 않으면서 관찰·제어 문제를 진단할 수 있게 표시합니다.</sub>
+    </td>
+  </tr>
+</table>
+
+Spotter는 진행 중인 작업 궤적을 독립적으로 바라보며 다음 질문에 답할 수 있도록 돕습니다.
+
+- 에이전트가 새로운 정보 없이 같은 실패나 사실상 동일한 작업을 반복하고 있는가?
+- 변경 범위가 요청한 범위를 벗어나 커지고 있는가?
+- 의미 있는 변경 후 관련 검증이 수행되었는가?
+- 새 증거로 약해진 가정을 계속 근거로 삼고 있는가?
+- 결정론적 안전 규칙을 위반하려 하고 있는가?
+
+목표는 알림을 늘리는 것이 아니라, 첫 번째 의미 있는 이탈 이후 낭비되는 작업을 줄이는 것입니다.
+
+## 현재 Spotter가 하는 일
+
+현재 런타임은 다음을 수행할 수 있습니다.
+
+- Codex Hook 및 설정된 App Server 이벤트를 내구성 있는 작업 궤적 저널에 수집합니다.
+- 스레드, 턴, 증거, 진행 상황, 감지 신호에 대한 데몬 소유의 실시간 상태를 유지합니다.
+- 위험한 도구 사용 전에 제한 시간 내에서 결정론적 게이트를 적용합니다.
+- 반복 루프, 정체된 탐색, 범위 확대, 검증 누락, 오래된 가정의 후보를 감지합니다.
+- 선택적으로 시맨틱 리뷰를 섀도 모드로 실행합니다.
+- `spotter status`와 `spotter doctor`로 상태 및 통합 진단을 제공합니다.
+- 복구와 분석을 위한 Git 기반 스냅샷 및 리플레이 자료를 보존합니다.
+
+> [!IMPORTANT]
+> Spotter는 활발히 개발 중입니다. 결정론적 게이트는 실제로 동작하지만 시맨틱 `VERIFY`와
+> `NUDGE` 결정은 현재 실시간 턴에 전달되지 않고 기록만 됩니다. 일부 App Server 관찰 및 제어
+> 기능은 명시적인 설정이 필요합니다. 정확한 현재 경계는
+> [현재 상태(영문)](docs/status.md)에서 확인하세요.
+
+현재 독립 실행형 통합의 주 대상은 Codex입니다.
+
+## 동작 방식
+
+```text
+Codex
+  ├─ Hooks ────────────────► 제한된 결정론적 게이트
+  └─ App Server 이벤트 ────► 설정된 경우 관찰 및 제어
+                                   │
+                                   ▼
+                                spotterd
+                                   │
+                 저널 · 실시간 상태 · 신호 · 섀도 리뷰
+```
+
+결정론적 게이트는 제한된 시간 안에 처리되고, 더 느린 시맨틱 리뷰는 동기식 도구 실행 경로 밖에서
+동작합니다. 관찰이나 제어 기능이 저하되면 진단에 명확히 표시되며, 생성된 Hook은 Codex의 정상
+사용을 막지 않도록 fail-open으로 동작합니다.
+
+## 설치
+
+공식 Homebrew tap을 사용하는 패키지 설치가 지원됩니다.
+
+```bash
+brew install spotter-agent/spotter/spotter
+```
+
+두 실행 파일이 모두 설치되었는지 확인합니다.
+
+```bash
+spotter --version
+spotterd --version
+```
+
+패키지 설치는 CLI와 데몬, Hook 브리지만 설치합니다. Codex 설정을 수정하거나 통합을 등록하지는
+않습니다.
+
+소스 또는 개발 체크아웃으로 설치하려면
+[CONTRIBUTING.md](CONTRIBUTING.md#local-setup)를 참고하세요.
+
+## 빠른 시작
+
+`codex` CLI가 설치되어 있고 `PATH`에서 실행 가능한지 확인한 다음, 관리형 통합이 적용할 내용을
+검토하고 설정합니다.
+
+```bash
+spotter setup codex --dry-run
+spotter setup codex
+spotter doctor
+```
+
+설정은 트랜잭션 방식으로 처리되며 여러 번 실행해도 같은 결과를 보장합니다. Spotter가 소유한
+Hook과 서비스 상태를 정확히 기록하므로, 이후 복구나 연결 해제 시 사용자 소유 설정을 추측하지
+않습니다.
+
+설정이 끝나면 평소처럼 Codex를 사용합니다.
+
+```bash
+codex
+```
+
+## 자주 쓰는 명령
+
+| 명령 | 용도 |
+| --- | --- |
+| `spotter status` | 통합, 데몬, 기능, 저장소 상태 표시 |
+| `spotter doctor` | 합성 상태 검사를 실행하고 조치 가능한 진단 출력 |
+| `spotter daemon status` | 패키지로 설치된 `spotterd` 프로세스와 빌드 식별자 확인 |
+| `spotter metrics` | 수집된 런타임 및 평가 지표 요약 |
+| `spotter observability` | 사용 가능한 작업 궤적 소스와 정규화 이벤트 확인 |
+| `spotter --help` | 전체 명령 목록 표시 |
+
+설정 파일은 선택 사항입니다. 게이트, 저장소, 스냅샷, 리뷰어 예산을 조정해야 할 때는
+[spotter.example.toml](spotter.example.toml)을 참고하세요. 신호 기반 시맨틱 리뷰는 모델 토큰을
+소비하며 기본적으로 비활성화되어 있습니다. 필요한 경우에만 활성화하고 제공되는 세션별·일별
+한도를 유지하세요.
+
+## 업그레이드
+
+Formula를 업그레이드한 뒤 설정을 다시 실행하여 설치된 빌드, 실행 중인 데몬, 통합 세대를
+Spotter가 조정하도록 합니다.
+
+```bash
+brew upgrade spotter-agent/spotter/spotter
+spotter setup codex
+spotter doctor
+```
+
+지속적으로 사용되는 Hook과 서비스 참조는 버전별 Homebrew Cellar 경로가 아니라 안정적인 패키지
+진입점을 사용합니다. Spotter는 실행 중인 이전 버전 데몬을 새로 설치된 CLI와 같다고 가정하지
+않고 이를 감지합니다.
+
+## 연결 해제 또는 제거
+
+Spotter는 유지하고 Codex 통합만 제거하려면 다음을 실행합니다.
+
+```bash
+spotter teardown codex
+```
+
+완전히 제거하려면 다음을 실행합니다.
+
+```bash
+spotter teardown codex
+brew uninstall spotter-agent/spotter/spotter
+```
+
+Homebrew 제거는 패키지가 소유한 실행 파일을 제거하고 패키지 런타임을 중지합니다. 별도로 관리되는
+`~/.spotter` 아래 사용자 데이터는 의도적으로 삭제하지 않습니다. 연결 해제 없이 패키지만 제거해
+통합 설정이 남더라도 fail-open으로 동작하며, 재설치 후 복구할 수 있습니다.
+
+일반적인 절차를 넘어서는 업그레이드, 복구, 마이그레이션, 연결 해제, 데이터 제거를 수행하기
+전에는 [Lifecycle](docs/lifecycle.md)을 참고하세요.
+
+## 운영 보장
+
+<details>
+<summary><strong>안전 및 소유권 보장 보기</strong></summary>
+
+- `brew install`과 `brew upgrade`는 Codex 설정을 암묵적으로 변경하지 않습니다.
+- `spotter setup codex`와 `spotter teardown codex`는 정확히 소유한 통합 상태만 변경합니다.
+- 생성된 Hook은 안정적인 실행 파일 경로를 사용하며 Spotter를 사용할 수 없을 때 fail-open으로
+  동작합니다.
+- Spotter는 소유권을 증명할 수 없는 공유 Codex App Server를 중지하지 않습니다.
+- 제거와 사용자 데이터 삭제는 별도 작업입니다.
+- `status`와 `doctor`는 관찰 또는 제어 기능의 저하를 명확히 보여 줍니다.
+
+이 계약은 빠른 픽스처 테스트와 실제 macOS Homebrew 설치 → 실행 중 업그레이드 → 제거 → 재설치
+수명주기 스모크 테스트로 검증됩니다. 증거와 재현 방법은
+[Homebrew lifecycle smoke](docs/homebrew-lifecycle-smoke.md)를 참고하세요.
+
+</details>
+
+## 문서
+
+| 알고 싶은 내용 | 문서 |
+| --- | --- |
+| 현재 동작하는 기능과 아직 실험적인 기능 | [현재 상태(영문)](docs/status.md) |
+| 설치, 설정, 운영, 문제 해결 또는 제거 | [설치 및 사용 상세 가이드](docs/user-guide.ko.md) |
+| 패키지와 통합의 전체 계약 | [Lifecycle](docs/lifecycle.md) |
+| 제품 아이디어와 개입 모델 | [Concept](docs/concept.md) |
+| 런타임 경계와 내구성 상태 | [Architecture](docs/architecture.md) |
+| 향후 작업과 증거 게이트 | [Roadmap](docs/roadmap.md) |
+| 실험, 가설, 증거 | [Research](docs/research.md) |
+| Spotter 개발 또는 기여 | [Contributing](CONTRIBUTING.md) |
+| 모든 프로젝트 문서 | [문서 인덱스](docs/README.md) |
+
+---
+
+<p align="center">
+  <a href="https://github.com/Bogyie">@bogyie / 김보경</a>과
+  <a href="https://github.com/YoungJinJung">@zerone / 정영진</a>이 관리합니다.<br />
+  <a href="LICENSE">MIT 라이선스</a>로 배포됩니다.
+</p>

--- a/README.md
+++ b/README.md
@@ -1,19 +1,35 @@
 <div align="center">
 
-# Spotter
+<p>
+  <strong>English</strong> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<h1>Spotter</h1>
 
 <picture>
   <img alt="Spotter" src="docs/assets/main-ts.png" width="250" />
 </picture>
 
-### Catch bad coding-agent trajectories before they become expensive.
+<h3>Catch bad coding-agent trajectories before they become expensive.</h3>
 
-Spotter is a local runtime supervisor for coding agents. It watches how work unfolds—not only the
-final diff—so loops, scope drift, weak assumptions, and missing validation can be noticed while
-they are still cheap to correct.
+<p>
+  Spotter is a local runtime supervisor for coding agents.<br />
+  It watches how work unfolds—not only the final diff—so costly deviations can be caught early.
+</p>
 
-[Install](#install) · [Quick start](#connect-spotter-to-codex) ·
-[Current status](docs/status.md) · [Documentation](docs/README.md)
+<p>
+  <code>local-first</code> · <code>bounded gates</code> · <code>trajectory-aware</code>
+</p>
+
+<p>
+  <a href="#install"><strong>Install</strong></a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="#connect-spotter-to-codex"><strong>Quick start</strong></a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="docs/user-guide.md"><strong>Detailed guide</strong></a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="docs/status.md">Current status</a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="docs/README.md">Documentation</a>
+</p>
 
 </div>
 
@@ -24,6 +40,23 @@ they are still cheap to correct.
 Coding agents rarely fail in one obvious step. A weak assumption can shape the next search, edit,
 and test; repeated local decisions then turn a recoverable mistake into wasted time, tokens, and
 repository churn.
+
+<table>
+  <tr>
+    <td width="33%" valign="top">
+      <strong>🔭 Trajectory-aware</strong><br />
+      <sub>Observe decisions, evidence, edits, and validation—not only the final diff.</sub>
+    </td>
+    <td width="33%" valign="top">
+      <strong>⚡ Bounded safety</strong><br />
+      <sub>Keep deterministic checks local and fast before risky tool use.</sub>
+    </td>
+    <td width="33%" valign="top">
+      <strong>🩺 Visible degradation</strong><br />
+      <sub>Make unavailable observation or control diagnosable without blocking Codex.</sub>
+    </td>
+  </tr>
+</table>
 
 Spotter maintains an independent view of the running trajectory and helps answer:
 
@@ -169,6 +202,9 @@ that needs more than the common path above.
 
 ## Operational guarantees
 
+<details>
+<summary><strong>Show the safety and ownership guarantees</strong></summary>
+
 - `brew install` and `brew upgrade` do not silently modify Codex configuration.
 - `spotter setup codex` and `spotter teardown codex` change only exact owned integration state.
 - Generated Hooks use stable executable paths and fail open when Spotter is unavailable.
@@ -180,12 +216,15 @@ These contracts are covered by fast fixtures and a real macOS Homebrew install �
 uninstall → reinstall lifecycle smoke. See
 [Homebrew lifecycle smoke](docs/homebrew-lifecycle-smoke.md) for the evidence and reproduction path.
 
+</details>
+
 ## Documentation
 
 | If you want to… | Read |
 | --- | --- |
 | See what works today and what is still experimental | [Status](docs/status.md) |
-| Install, configure, upgrade, recover, or uninstall | [Lifecycle](docs/lifecycle.md) |
+| Install, configure, operate, troubleshoot, or uninstall | [Detailed user guide](docs/user-guide.md) |
+| Understand the complete package and integration contract | [Lifecycle](docs/lifecycle.md) |
 | Understand the product idea and intervention model | [Concept](docs/concept.md) |
 | Understand runtime boundaries and durable state | [Architecture](docs/architecture.md) |
 | Follow upcoming work and evidence gates | [Roadmap](docs/roadmap.md) |
@@ -193,11 +232,10 @@ uninstall → reinstall lifecycle smoke. See
 | Build or contribute to Spotter | [Contributing](CONTRIBUTING.md) |
 | Browse every project document | [Documentation index](docs/README.md) |
 
-## Maintainers
+---
 
-Maintained by [@bogyie / Bogyoeng Kim](https://github.com/Bogyie) and
-[@zerone / Youngjin Jung](https://github.com/YoungJinJung).
-
-## License
-
-[MIT](LICENSE)
+<p align="center">
+  Maintained by <a href="https://github.com/Bogyie">@bogyie / Bogyoeng Kim</a> and
+  <a href="https://github.com/YoungJinJung">@zerone / Youngjin Jung</a>.<br />
+  Released under the <a href="LICENSE">MIT License</a>.
+</p>

--- a/README.md
+++ b/README.md
@@ -1,465 +1,203 @@
-Maintained by [@bogyie / Bogyoeng Kim](https://github.com/Bogyie) and [@zerone / Youngjin Jung](https://github.com/YoungJinJung)
-
 <div align="center">
 
 # Spotter
 
 <picture>
-  <img alt="Spotter" src="docs/assets/main-ts.png" width="40%" style="max-width: 250;"/>
+  <img alt="Spotter" src="docs/assets/main-ts.png" width="250" />
 </picture>
 
-> **A runtime spotter for coding agents.**  
-> Your coding agent drives. Spotter watches the trajectory, challenges bad assumptions, and steps in before wasted work compounds.
+### Catch bad coding-agent trajectories before they become expensive.
 
-Spotter is an experimental **runtime supervision system for coding agents**, starting with Codex.
+Spotter is a local runtime supervisor for coding agents. It watches how work unfolds—not only the
+final diff—so loops, scope drift, weak assumptions, and missing validation can be noticed while
+they are still cheap to correct.
+
+[Install](#install) · [Quick start](#connect-spotter-to-codex) ·
+[Current status](docs/status.md) · [Documentation](docs/README.md)
 
 </div>
 
 ---
 
-## 30-second summary
+## Why Spotter
 
-Spotter asks a more specific question than “is the agent wrong?”
+Coding agents rarely fail in one obvious step. A weak assumption can shape the next search, edit,
+and test; repeated local decisions then turn a recoverable mistake into wasted time, tokens, and
+repository churn.
 
-> **Can we detect a bad assumption, loop, scope drift, or missing validation while the agent is still working, and intervene before the mistake becomes expensive?**
+Spotter maintains an independent view of the running trajectory and helps answer:
 
-The repository is already beyond a scaffold. The current prototype implements Hook-based trajectory collection, daemon-backed deterministic gates, crash-safe journals, Git snapshots, fork/replay, a shadow reviewer, claim/evidence state, evaluation labels/metrics, counterfactual experiment machinery, and a standalone daemon/control foundation.
+- Is the agent repeating failures or equivalent actions without learning anything new?
+- Is the change growing beyond the requested scope?
+- Did meaningful edits happen without relevant validation?
+- Is the agent still acting on a hypothesis that newer evidence has weakened?
+- Is a deterministic safety rule about to be violated?
 
-The current prototype and target product architecture are different:
+The goal is not more alerts. It is less wasted work after the first meaningful deviation.
 
-```text
-CURRENT PROTOTYPE
+## What Spotter does today
 
-Codex / Claude Code
-       │ hooks
-       ▼
- spotter-hook process
-       │
-       ├─ journal
-       ├─ deterministic gate
-       ├─ snapshot
-       └─ periodic shadow review
+The current runtime can:
 
+- collect Codex Hook and configured App Server events into durable trajectory journals;
+- maintain daemon-owned live state for threads, turns, evidence, progress, and detected signals;
+- enforce bounded deterministic gates before risky tool use;
+- detect candidate loops, stalled exploration, scope growth, missing validation, and stale
+  hypotheses;
+- run optional semantic reviews in shadow mode;
+- expose health and integration diagnostics through `spotter status` and `spotter doctor`;
+- preserve Git-backed snapshots and replay material for recovery and analysis.
 
-TARGET ARCHITECTURE
+> [!IMPORTANT]
+> Spotter is under active development. Deterministic gates are active, but semantic `VERIFY` and
+> `NUDGE` decisions are currently recorded rather than delivered into live turns. Some App Server
+> observation and control capabilities still require explicit configuration. Check
+> [Status](docs/status.md) for the exact current boundary.
 
-Codex TUI
-    │
-    ▼
-External Codex App Server
-    ↕ events / steer / interrupt
- spotterd
-    │
-    └─ PreToolUse Hook
-       (deterministic synchronous enforcement only)
-```
+Codex is the primary standalone integration.
 
-[#78](https://github.com/spotter-agent/spotter/issues/78) proved shared observation and steering for a
-Spotter-managed external App Server. The daemon now owns connection epochs, reconnect/reconciliation,
-and conservative control freshness; endpoint selection in setup remains the last ordinary-use gap.
-
-For the fastest project snapshot, read [Status](docs/status.md). For sequence and evidence gates, read [Roadmap](docs/roadmap.md).
-
----
-
-## Current status
-
-[Status](docs/status.md) is the authoritative implementation dashboard, including capability
-state, current blockers, evidence gaps, and linked work. The README keeps only the stable project
-overview so fast-moving implementation detail is not maintained in two places.
-
----
-
-## Roadmap
-
-The roadmap uses named outcomes instead of `P0–P9` / `E0–E5` codes:
+## How it works
 
 ```text
-Runtime
-  ↓
-Observe
-  ↓
-Detect
-  ↓
-Intervene
-  ↓
-Recover
-  ↓
-Harden
+Codex
+  ├─ Hooks ────────────────► bounded deterministic gates
+  └─ App Server events ────► observation and control when configured
+                                   │
+                                   ▼
+                                spotterd
+                                   │
+                 journal · live state · signals · shadow review
 ```
 
-| Stage | What becomes trustworthy |
-| --- | --- |
-| **Runtime** | standalone App Server/`spotterd` boundary and lifecycle |
-| **Observe** | primary event ingestion, live state, and observability |
-| **Detect** | cheap candidate signals + semantic reviewer quality |
-| **Intervene** | live `VERIFY/NUDGE`, provenance, benefit vs harm |
-| **Recover** | interrupt/restart with reversibility and side-effect awareness |
-| **Harden** | upgrades, migrations, retention, cleanup, diagnostics, long-term operation |
+Deterministic gates stay bounded, while slower semantic review remains off synchronous
+tool-execution paths. If observation or control degrades, diagnostics remain explicit and
+generated Hooks fail open rather than blocking normal Codex use.
 
-Experiments are not a separate parallel roadmap. Each stage has an evidence gate. Implementing a mechanism does not prove the mechanism helps.
+## Install
 
-GitHub Milestones carry stage assignment for issues. See [Roadmap](docs/roadmap.md) for stage meaning, linked issues, dependencies, and exit criteria.
-
----
-
-## Core idea
-
-Coding agents work through long trajectories:
-
-```text
-understand
-   ↓
-inspect
-   ↓
-hypothesize
-   ↓
-edit
-   ↓
-run
-   ↓
-observe
-   ↓
-revise
-   ↓
-validate
-```
-
-Many failures are not one bad output. They are **trajectory failures**.
-
-```text
-Weak assumption
-"the timeout must come from the Redis pool"
-        │
-        ▼
-Search only Redis-related code
-        │
-        ▼
-Edit Redis configuration
-        │
-        ▼
-Tests fail for unrelated reasons
-        │
-        ▼
-Add compensating changes
-        │
-        ▼
-Scope grows; time/tokens are already spent
-```
-
-A post-hoc diff reviewer may eventually catch the mistake, but most of the cost has already been paid.
-
-Spotter tries to intervene earlier:
-
-```text
-Weak assumption
-      │
-      ├─ insufficient evidence detected
-      │       ↓
-      │     VERIFY
-      │       ↓
-      │ inspect the stack trace / run focused probe
-      │
-      └─ avoid compounding the wrong branch
-```
-
-The goal is not to maximize alarms. It is to reduce **wasted progress after the first meaningful deviation**.
-
----
-
-## Intervention ladder
-
-Spotter prefers the weakest intervention likely to help.
-
-| Action | Meaning | Current state | Target runtime primitive |
-| --- | --- | --- | --- |
-| `CONTINUE` | No useful intervention | ✅ shadow reviewer | no-op |
-| `VERIFY` | A consequential assumption needs evidence | ✅ decision only | async `turn/steer` |
-| `NUDGE` | The trajectory is drifting or wasting effort | ✅ decision only | async `turn/steer` |
-| `BLOCK` | A deterministic policy violation is about to execute | ✅ gate | synchronous `PreToolUse` deny |
-| `INTERRUPT` | Continuing the active turn is likely to compound failure | ❌ | `turn/interrupt` |
-| `RESTART` | The reasoning context itself is no longer trustworthy | ❌ | fresh continuation from verified state |
-
-A semantic reviewer disagreement should **not** casually become a synchronous `BLOCK`. Stronger interventions require stronger evidence.
-
----
-
-## Target architecture
-
-Spotter separates four responsibilities:
-
-```text
-Observation plane
-  What is happening?
-  → Codex App Server event stream
-
-Control plane
-  How can Spotter influence the active trajectory?
-  → turn/steer, turn/interrupt
-
-Enforcement plane
-  What must be decided before execution?
-  → PreToolUse deterministic gate
-
-Supervision runtime
-  Who owns state, signals, reviewers, budgets, recovery?
-  → spotterd
-```
-
-Target data flow:
-
-```text
-                     ┌─────────────┐
-                     │  Codex TUI  │
-                     └──────┬──────┘
-                            │
-                            ▼
-                 ┌──────────────────────┐
-                 │ External App Server  │
-                 └──────┬────────▲──────┘
-                        │        │
-                events  │        │ steer / interrupt
-                        ▼        │
-                 ┌──────────────────┐
-                 │     spotterd     │
-                 │                  │
-                 │ Thread Manager   │
-                 │ Live State       │
-                 │ Trace IR         │
-                 │ Audit State      │
-                 │ Signal Engine    │
-                 │ Reviewer         │
-                 │ Intervention     │
-                 │ Journal          │
-                 └────────┬─────────┘
-                          │
-                 deterministic gate
-                          │
-                          ▼
-                   PreToolUse Hook
-```
-
-State ownership is explicit:
-
-```text
-memory   = live supervision state for active/dormant threads
-journal  = durable event history + recovery/analysis source
-snapshot = filesystem/Git state at a branch/recovery point
-```
-
----
-
-## Use the current prototype
-
-Python 3.11+:
+The supported packaged installation uses the official Homebrew tap:
 
 ```bash
-git clone https://github.com/spotter-agent/spotter.git
-cd spotter
-python -m venv .venv
-source .venv/bin/activate
-python -m pip install -e '.[dev]'
+brew install spotter-agent/spotter/spotter
 ```
 
-The package has one runtime dependency, `websockets`, which pip installs automatically. The `dev`
-extra adds the repository's test, type-checking, formatting, and release-build tools; use
-`pip install -e .` when those tools are not needed. Tagged artifact production is documented in
-[Release artifacts and build identity](docs/releasing.md).
-
-Configuration:
+Verify both installed entry points:
 
 ```bash
-cp spotter.example.toml spotter.toml
-spotter --config spotter.toml
+spotter --version
+spotterd --version
 ```
 
-Signal-driven reviews spend model tokens and are off by default. Enable them deliberately with
-`reviewer.on_signals = true`; the existing `max_per_session` and `max_per_day` ceilings apply.
+Package installation only installs the CLI, daemon, and Hook bridge. It does **not** edit Codex
+configuration or register an integration.
 
-Current plugin compatibility path:
+For a source/development checkout, follow [CONTRIBUTING.md](CONTRIBUTING.md#local-setup).
 
-```bash
-# Codex
-codex plugin marketplace add spotter-agent/spotter
-codex plugin add spotter@spotter
+## Connect Spotter to Codex
 
-# Claude Code
-claude plugin marketplace add spotter-agent/spotter
-claude plugin install spotter@spotter
-```
-
-Plugin installation remains a compatibility path. New standalone integration can use:
+Make sure the `codex` CLI is installed and available on `PATH`, then inspect and apply the managed
+integration:
 
 ```bash
 spotter setup codex --dry-run
 spotter setup codex
-spotter teardown codex
-```
-
-App Server endpoint selection remains pending; when a verified endpoint is present in the integration
-manifest, `spotterd` owns its connection and recovery loop. Setup does not print or claim an endpoint
-that it has not verified.
-
-Useful commands:
-
-```bash
-spotter observe
-spotter hook  # hook bridge; JSON payload on stdin
-spotter setup codex [--dry-run|--portable]
-spotter teardown codex
-spotter daemon start|stop|restart|status
-spotter analyze
-spotter review --session <id>
-spotter label --session <id> --step <n> --verdict fp
-spotter metrics
-spotter observability [--session <id>]
-spotter fork --session <id> --step <n>
-# require an ignored/non-secret fixture file to survive into the fork:
-spotter fork --session <id> --step <n> --environment-resource .fixture-config
-# classify loss of an explicitly required virtualenv/cache separately:
-spotter fork --session <id> --step <n> --environment-venv-or-cache .venv
-spotter fork-coverage --session <id>
-spotter prune --repo /path/to/repo  # dry-run unless --apply is supplied
-spotter tasks validate path/to/task-set.toml
-spotter tasks preflight path/to/task-set.toml
-spotter tasks run path/to/task-set.toml --guidance "..." --run
-# retain each arm's journal/snapshots so failed outcomes can seed fork experiments:
-spotter tasks run path/to/task-set.toml --guidance "..." \
-  --capture-replay-sources --model gpt-5.6 --reasoning-effort low --run
-# after an interrupted batch, repeat the same conditions and add:
-# --resume ~/.spotter/experiments/task-batches/<batch>.jsonl
-spotter experiment --session <id> --step <n> --guidance "..." --check "..."
-# repeat the same neutral continuation to measure replay/model outcome noise:
-spotter experiment --session <id> --step <n> --neutral --pairs 3 --check "..." \
-  --model gpt-5.6 --reasoning-effort low --run
-```
-
-When snapshotting is enabled, `SessionStart` pins one baseline Git snapshot so read-only exploration
-before the first mutation has a fork anchor; mutation boundaries continue to add deduplicated
-snapshots. `spotter fork` writes a durable manifest under `~/.spotter/fork-manifests/`. The manifest links the
-source event, snapshot, rollout-prefix digest, external-effect warnings, and captured environment
-fingerprint. Counterfactual pairs are fully prepared and must pass shared-prefix and captured-
-environment parity checks before either agent arm runs. The arms must use distinct worktrees, and
-each is rechecked against its immutable manifest immediately before model continuation. Explicitly
-declared relative non-secret files, directories, virtualenv/cache paths, and non-secret environment
-variables are hashed and checked from source to fork and again immediately before continuation;
-missing ignored or untracked resources, missing declared virtualenv/caches, changed variables, and
-copied values that still reference the source worktree's absolute path block both arms. Directory
-trees containing symbolic links are rejected. Undeclared
-ignored resources and environment variables are explicitly marked as not captured rather than
-assumed equal. Prefixes preserve the rollout model,
-runtime, and a secret-free subset of turn configuration; experiments can pin both the Codex model
-and reasoning effort and persist both values in result provenance. When those values are pinned and
-source provenance is available, a mismatch is rejected before either arm starts.
-Submodule status divergence is reported separately from ordinary tracked-state drift; declared
-resource trees containing symbolic links remain rejected before continuation.
-Neutral mode gives both arms the exact control prompt and reports mechanically judgeable outcome
-disagreement, environment-preflight mismatch, and infrastructure-failure rates separately. The
-command provides the measurement path; a representative executed corpus is still required before
-claiming a replay noise bound.
-
-`fork-coverage` is read-only. It classifies every journaled proposal against the currently available
-rollout and Git snapshot objects, reports the earliest exact fork, and separates pre-mutation
-coverage from missing state/context, external-effect contamination, and observation gaps. Because
-the command checks object availability now, pruned or moved historical repositories remain visible
-as `NOT_FORKABLE_STATE` rather than being counted as covered. Active signal triggers are linked to
-their first subsequent proposal while the signal remains active, so the report separately counts
-triggers with no follow-up action and follow-ups that are exactly forkable.
-
-Task-set validation freezes task and fixture hashes and checks the versioned scorer/budget contract without executing commands. Preflight runs setup, the broken-state scorer, a declared known-good transform, and the positive scorer in a temporary fixture copy; it never runs agent arms. Because preflight and batch execution run corpus-declared shell commands, use `validate` only for untrusted task sets. `tasks run` requires an explicit paid-run opt-in, starts each control/guidance arm from a clean fixture copy, journals bounded mechanical results with `fsync`, and resumes only when the frozen set, environment, and run conditions still match. By default, child arms disable Spotter to avoid recursive supervision. `--capture-replay-sources` instead initializes each fixture as a local Git baseline, runs Hooks in capture-only mode, and retains the source workspace under `SPOTTER_HOME/task-sources`; journals and snapshots remain enabled while daemon gating and shadow review are bypassed, and each arm records either its replay-source session ID or an explicit capture error. Task batches can pin both model and reasoning effort so later fork continuations can prove source parity. The Codex backend enforces the wall-time budget; it records the declared max-turn budget for parity/provenance because `codex exec` does not expose a hard turn-limit flag. The existence of the experiment harness does **not** mean positive intervention advantage has been established. Enough executed multi-task runs remain an evidence gap.
-
----
-
-## Homebrew installation and operations UX
-
-Install the standalone runtime from the official
-[`spotter-agent/homebrew-spotter`](https://github.com/spotter-agent/homebrew-spotter) tap. The
-qualified form is intentional: it taps only the Formula needed for this install.
-
-```bash
-brew install spotter-agent/spotter/spotter
-spotter setup codex
 spotter doctor
+```
 
-# normal use afterwards
+Setup is transactional and idempotent. It records the exact Spotter-owned Hooks and service state so
+later repair or teardown does not guess at user-owned configuration.
+
+After setup, use Codex normally:
+
+```bash
 codex
 ```
 
-The Formula exposes both `spotter` and `spotterd`. Package installation itself does not edit Codex
-configuration or register the integration; `spotter setup codex` remains the explicit integration
-transaction. The user should not need to manually run `spotter daemon start` or
-`codex app-server daemon start` before each session.
+## Everyday commands
 
-Detailed ownership, rollback, upgrades, uninstall, purge, and reinstall behavior are specified in [Lifecycle](docs/lifecycle.md).
+| Command | Purpose |
+| --- | --- |
+| `spotter status` | Show integration, daemon, capability, and storage health |
+| `spotter doctor` | Run synthetic health checks and print actionable diagnostics |
+| `spotter daemon status` | Inspect the packaged `spotterd` process and build identity |
+| `spotter metrics` | Summarize collected runtime and evaluation metrics |
+| `spotter observability` | Inspect which trajectory sources and normalized events are available |
+| `spotter --help` | Show the complete command surface |
 
----
+Configuration is optional. Use [spotter.example.toml](spotter.example.toml) as the reference when
+you need to customize gates, storage, snapshots, or reviewer budgets. Signal-driven semantic
+reviews spend model tokens and are disabled by default; enable them deliberately and keep the
+provided per-session and per-day limits.
 
-## Issues and metadata
+## Upgrade
 
-Repository issues use GitHub's native structured metadata rather than prefixed label taxonomies:
+Upgrade the Formula, then rerun setup so Spotter can reconcile the installed build, running daemon,
+and integration generation:
 
-- **Type** — `Task`, `Bug`, `Feature`, `Architecture`, or `Experiment`;
-- **Priority** — `Urgent`, `High`, `Medium`, or `Low`;
-- **Effort** — `XS` through `XL`, representing change surface, validation burden, and uncertainty;
-- **Area** — the primary product/problem domain;
-- **Milestone** — `Runtime`, `Observe`, `Detect`, `Intervene`, `Recover`, or `Harden` when the issue belongs to the product roadmap;
-- **Dependencies** — native `blocked by` / `blocking` relationships for actual blockers.
+```bash
+brew upgrade spotter-agent/spotter/spotter
+spotter setup codex
+spotter doctor
+```
 
-Labels are exceptional contributor signals only; currently `good first issue` and `help wanted` remain. Detailed semantics live in [Repository Conventions](docs/conventions.md#13-issue-metadata-and-triage).
+Persistent Hook and service references use stable package entry points rather than versioned
+Homebrew Cellar paths. Spotter detects a still-running older daemon instead of assuming it matches
+the newly installed CLI.
 
----
+## Disconnect or uninstall
+
+To remove the Codex integration but keep Spotter installed:
+
+```bash
+spotter teardown codex
+```
+
+For a clean uninstall:
+
+```bash
+spotter teardown codex
+brew uninstall spotter-agent/spotter/spotter
+```
+
+Homebrew uninstall removes package-owned executables and stops the packaged runtime. It
+intentionally does not purge separately managed user data under `~/.spotter`. An integration left
+behind by an uninstall without teardown is designed to fail open and can be repaired after
+reinstalling.
+
+See [Lifecycle](docs/lifecycle.md) before upgrades, recovery, migration, teardown, or data removal
+that needs more than the common path above.
+
+## Operational guarantees
+
+- `brew install` and `brew upgrade` do not silently modify Codex configuration.
+- `spotter setup codex` and `spotter teardown codex` change only exact owned integration state.
+- Generated Hooks use stable executable paths and fail open when Spotter is unavailable.
+- Spotter does not stop a shared Codex App Server that it cannot prove it owns.
+- Uninstall and user-data purge are separate operations.
+- `status` and `doctor` make degraded observation or control visible.
+
+These contracts are covered by fast fixtures and a real macOS Homebrew install → live upgrade →
+uninstall → reinstall lifecycle smoke. See
+[Homebrew lifecycle smoke](docs/homebrew-lifecycle-smoke.md) for the evidence and reproduction path.
 
 ## Documentation
 
-- **[Docs index](docs/README.md)** — choose a document by question/reading path
-- **[Status](docs/status.md)** — current implementation, blocker, and next steps
-- **[Concept](docs/concept.md)** — problem definition, principles, and intervention semantics
-- **[Architecture](docs/architecture.md)** — process, state, event, control, and failure contracts
-- **[Lifecycle](docs/lifecycle.md)** — install → setup → run → recover → upgrade → teardown → purge
-- **[Roadmap](docs/roadmap.md)** — named stages, dependencies, and evidence gates
-- **[Research](docs/research.md)** — prior work, borrowed ideas, open hypotheses, and evidence gaps
-- **[Conventions](docs/conventions.md)** — code, issue metadata, branch, PR, and documentation conventions
+| If you want to… | Read |
+| --- | --- |
+| See what works today and what is still experimental | [Status](docs/status.md) |
+| Install, configure, upgrade, recover, or uninstall | [Lifecycle](docs/lifecycle.md) |
+| Understand the product idea and intervention model | [Concept](docs/concept.md) |
+| Understand runtime boundaries and durable state | [Architecture](docs/architecture.md) |
+| Follow upcoming work and evidence gates | [Roadmap](docs/roadmap.md) |
+| Review experiments, hypotheses, and evidence | [Research](docs/research.md) |
+| Build or contribute to Spotter | [Contributing](CONTRIBUTING.md) |
+| Browse every project document | [Documentation index](docs/README.md) |
 
----
+## Maintainers
 
-## Development
-
-```bash
-ruff format --check .
-ruff check .
-mypy src tests
-pytest
-```
-
-The migration should preserve a transport-independent boundary:
-
-```text
-agent-specific runtime events
-        ↓
-normalized Trace IR
-        ↓
-Spotter state / policy / evaluation
-```
-
-Codex App Server event shapes should not leak throughout Spotter core.
-
----
-
-## Trajectory Engineering
-
-Spotter is also an experiment in **Trajectory Engineering**:
-
-- Prompt engineering — what the model is instructed to do
-- Context engineering — what the model can see
-- Harness engineering — what tools and constraints surround execution
-- **Trajectory engineering — how an already-running path is observed, verified, steered, stopped, and recovered**
-
-The working hypothesis is:
-
-> **A better agent system is not only one that makes fewer mistakes. It is also one that detects mistakes early enough that they remain cheap to correct.**
-
-That hypothesis is not yet proven for Spotter. Null and negative intervention results are first-class outcomes.
+Maintained by [@bogyie / Bogyoeng Kim](https://github.com/Bogyie) and
+[@zerone / Youngjin Jung](https://github.com/YoungJinJung).
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,232 @@
+<div align="center">
+
+<p>
+  <a href="README.md">English</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <strong>简体中文</strong>
+</p>
+
+<h1>Spotter</h1>
+
+<picture>
+  <img alt="Spotter" src="docs/assets/main-ts.png" width="250" />
+</picture>
+
+<h3>在错误的编码智能体轨迹造成高昂代价之前发现它们。</h3>
+
+<p>
+  Spotter 是一款面向编码智能体的本地运行时监督工具。<br />
+  它不仅查看最终 diff，还观察工作过程，从而尽早发现代价高昂的偏离。
+</p>
+
+<p>
+  <code>本地优先</code> · <code>有界门控</code> · <code>轨迹感知</code>
+</p>
+
+<p>
+  <a href="#安装"><strong>安装</strong></a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="#快速开始"><strong>快速开始</strong></a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="docs/user-guide.zh-CN.md"><strong>详细指南</strong></a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="docs/status.md">当前状态（英文）</a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="docs/README.md">完整文档</a>
+</p>
+
+</div>
+
+---
+
+## 为什么需要 Spotter
+
+编码智能体很少因为一个明显的步骤而失败。一个薄弱的假设可能影响后续的搜索、编辑和测试；
+反复出现的局部判断，最终会把原本可以恢复的错误变成时间、令牌和仓库改动的浪费。
+
+<table>
+  <tr>
+    <td width="33%" valign="top">
+      <strong>🔭 轨迹感知</strong><br />
+      <sub>不仅查看最终 diff，还观察决策、证据、编辑和验证的过程。</sub>
+    </td>
+    <td width="33%" valign="top">
+      <strong>⚡ 有界安全检查</strong><br />
+      <sub>在高风险工具调用前，通过本地快速执行确定性检查。</sub>
+    </td>
+    <td width="33%" valign="top">
+      <strong>🩺 明确的降级状态</strong><br />
+      <sub>在不阻塞 Codex 的前提下，让观察或控制问题可被诊断。</sub>
+    </td>
+  </tr>
+</table>
+
+Spotter 独立观察正在进行的工作轨迹，帮助回答：
+
+- 智能体是否在没有获得新信息的情况下重复失败或执行等价操作？
+- 修改是否正在超出请求的范围？
+- 发生重要修改后，是否缺少相应验证？
+- 智能体是否仍依据已被新证据削弱的假设行动？
+- 是否即将违反确定性的安全规则？
+
+目标不是产生更多警报，而是减少第一次实质性偏离之后的无效工作。
+
+## Spotter 目前能做什么
+
+当前运行时可以：
+
+- 将 Codex Hook 和已配置的 App Server 事件收集到持久的轨迹日志中；
+- 维护由守护进程持有的线程、轮次、证据、进度和检测信号实时状态；
+- 在高风险工具调用前执行有严格时限的确定性门控；
+- 检测循环、停滞的探索、范围扩张、缺失验证和过时假设的候选信号；
+- 以影子模式运行可选的语义审查；
+- 通过 `spotter status` 和 `spotter doctor` 提供健康状态与集成诊断；
+- 保留基于 Git 的快照和回放材料，用于恢复与分析。
+
+> [!IMPORTANT]
+> Spotter 正在积极开发中。确定性门控已经生效，但语义 `VERIFY` 和 `NUDGE` 决策目前只会
+> 被记录，尚不会传递到实时轮次。部分 App Server 观察与控制能力仍需要显式配置。准确的当前
+> 边界请参阅[当前状态（英文）](docs/status.md)。
+
+Codex 是目前主要的独立集成目标。
+
+## 工作原理
+
+```text
+Codex
+  ├─ Hooks ────────────────► 有严格时限的确定性门控
+  └─ App Server 事件 ──────► 配置后提供观察与控制
+                                   │
+                                   ▼
+                                spotterd
+                                   │
+                 日志 · 实时状态 · 信号 · 影子审查
+```
+
+确定性门控始终在限定时间内执行，而较慢的语义审查位于同步工具执行路径之外。如果观察或控制
+能力降级，诊断会明确显示；生成的 Hook 会采用 fail-open 行为，不阻碍 Codex 的正常使用。
+
+## 安装
+
+支持通过官方 Homebrew tap 安装：
+
+```bash
+brew install spotter-agent/spotter/spotter
+```
+
+验证两个入口点均已安装：
+
+```bash
+spotter --version
+spotterd --version
+```
+
+安装软件包只会安装 CLI、守护进程和 Hook 桥接器，**不会**修改 Codex 配置或注册集成。
+
+如需从源码或开发检出进行安装，请参阅
+[CONTRIBUTING.md](CONTRIBUTING.md#local-setup)。
+
+## 快速开始
+
+确认 `codex` CLI 已安装并可通过 `PATH` 调用，然后预览并应用托管集成：
+
+```bash
+spotter setup codex --dry-run
+spotter setup codex
+spotter doctor
+```
+
+设置过程具备事务性和幂等性。它会准确记录 Spotter 所有的 Hook 和服务状态，因此后续修复或
+解除集成时无需猜测用户所有的配置。
+
+完成后，照常使用 Codex：
+
+```bash
+codex
+```
+
+## 常用命令
+
+| 命令 | 用途 |
+| --- | --- |
+| `spotter status` | 显示集成、守护进程、能力和存储健康状态 |
+| `spotter doctor` | 运行合成健康检查并输出可执行的诊断建议 |
+| `spotter daemon status` | 检查软件包安装的 `spotterd` 进程及构建标识 |
+| `spotter metrics` | 汇总已收集的运行时和评估指标 |
+| `spotter observability` | 检查可用的轨迹来源和规范化事件 |
+| `spotter --help` | 显示完整命令列表 |
+
+配置文件是可选的。如需自定义门控、存储、快照或审查预算，请参考
+[spotter.example.toml](spotter.example.toml)。信号驱动的语义审查会消耗模型令牌，并且默认
+关闭；请仅在确有需要时启用，并保留已有的每会话和每日限额。
+
+## 升级
+
+升级 Formula 后再次运行设置，让 Spotter 协调已安装构建、正在运行的守护进程和集成版本：
+
+```bash
+brew upgrade spotter-agent/spotter/spotter
+spotter setup codex
+spotter doctor
+```
+
+持久 Hook 和服务引用使用稳定的软件包入口点，而不是带版本号的 Homebrew Cellar 路径。
+Spotter 会检测仍在运行的旧版守护进程，不会假设它与新安装的 CLI 相同。
+
+## 解除集成或卸载
+
+如需保留 Spotter，只移除 Codex 集成：
+
+```bash
+spotter teardown codex
+```
+
+如需完整卸载：
+
+```bash
+spotter teardown codex
+brew uninstall spotter-agent/spotter/spotter
+```
+
+Homebrew 卸载会移除软件包所有的可执行文件，并停止软件包运行时。它有意保留单独管理的
+`~/.spotter` 用户数据。如果未先解除集成就卸载，残留集成会按设计采用 fail-open 行为，并可
+在重新安装后修复。
+
+如果升级、恢复、迁移、解除集成或数据删除超出上述常规路径，请先参阅
+[Lifecycle](docs/lifecycle.md)。
+
+## 运行保障
+
+<details>
+<summary><strong>查看安全与所有权保障</strong></summary>
+
+- `brew install` 和 `brew upgrade` 不会静默修改 Codex 配置。
+- `spotter setup codex` 和 `spotter teardown codex` 只修改其明确所有的集成状态。
+- 生成的 Hook 使用稳定的可执行文件路径，并在 Spotter 不可用时采用 fail-open 行为。
+- Spotter 不会停止其无法证明拥有的共享 Codex App Server。
+- 卸载与用户数据清除是两个独立操作。
+- `status` 和 `doctor` 会明确显示观察或控制能力的降级。
+
+这些约定由快速夹具测试和真实的 macOS Homebrew 安装 → 在线升级 → 卸载 → 重装生命周期
+冒烟测试覆盖。证据和复现方法请参阅
+[Homebrew lifecycle smoke](docs/homebrew-lifecycle-smoke.md)。
+
+</details>
+
+## 文档
+
+| 如果你想了解…… | 请阅读 |
+| --- | --- |
+| 当前可用功能与仍处于实验阶段的功能 | [当前状态（英文）](docs/status.md) |
+| 安装、配置、运行、故障排查或卸载 | [安装与使用详细指南](docs/user-guide.zh-CN.md) |
+| 软件包与集成的完整约定 | [Lifecycle](docs/lifecycle.md) |
+| 产品理念与干预模型 | [Concept](docs/concept.md) |
+| 运行时边界与持久状态 | [Architecture](docs/architecture.md) |
+| 后续工作与证据门槛 | [Roadmap](docs/roadmap.md) |
+| 实验、假设和证据 | [Research](docs/research.md) |
+| 构建 Spotter 或参与贡献 | [Contributing](CONTRIBUTING.md) |
+| 浏览所有项目文档 | [文档索引](docs/README.md) |
+
+---
+
+<p align="center">
+  由 <a href="https://github.com/Bogyie">@bogyie / Bogyoeng Kim</a> 和
+  <a href="https://github.com/YoungJinJung">@zerone / Youngjin Jung</a> 维护。<br />
+  采用 <a href="LICENSE">MIT 许可证</a>发布。
+</p>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,25 @@
-# Spotter Documentation
+<div align="center">
 
-Start here if you are reading the repository for the first time.
+<h1>Spotter Documentation</h1>
+
+<p>Find the shortest path from product overview to operations, architecture, or research.</p>
+
+<p>
+  <a href="../README.md">← Product overview</a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="user-guide.md"><strong>Detailed user guide</strong></a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="status.md">Current status</a>
+</p>
+
+</div>
+
+---
 
 ## Which document should I read?
 
 | Question | Document | What you get |
 | --- | --- | --- |
 | What works today, what is blocked, what happens next? | **[Status](status.md)** | implementation dashboard + immediate blocker |
+| How do I install, configure, operate, troubleshoot, or remove Spotter? | [Detailed user guide](user-guide.md) ([한국어](user-guide.ko.md) · [简体中文](user-guide.zh-CN.md)) | advanced user operations + issue reporting |
 | What problem is Spotter trying to solve? | [Concept](concept.md) | mental model, principles, intervention semantics |
 | What processes/components/state should exist? | [Architecture](architecture.md) | component, state, IPC, and failure contracts |
 | What happens from install through uninstall/reinstall? | [Lifecycle](lifecycle.md) | command-by-command operational lifecycle |
@@ -96,6 +109,7 @@ To avoid maintaining duplicate specifications:
 - **Status** owns “where are we now?”
 - **Concept** owns “what problem and principles define Spotter?”
 - **Architecture** owns runtime components, process/data flow, state ownership, IPC, and failure contracts.
+- **Detailed user guide** owns user-facing installation, operation, troubleshooting, and issue reporting.
 - **Lifecycle** owns package/service/integration/session/update/removal behavior.
 - **Roadmap** owns named stages, dependencies, and evidence gates.
 - **Reference** owns prior papers/systems, what they demonstrate, implementation precedents, and what Spotter should or should not borrow.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,9 +1,9 @@
 # Lifecycle and Operations
 
 > **Status:** primarily a target contract with an implemented transactional Codex setup slice. For
-> commands that work today, see [Use the current prototype](../README.md#use-the-current-prototype);
-> for current
-> implementation state, see [Status](status.md). `spotter setup|teardown codex`, versioned ownership
+> commands that work today, see [Connect Spotter to Codex](../README.md#connect-spotter-to-codex);
+> for current implementation state, see [Status](status.md). `spotter setup|teardown codex`,
+> versioned ownership
 > manifests, managed `launchd`/`systemd --user` registration, portable startup, legacy Hook/plugin
 > migration, runtime-aware diagnostics, tag-derived release artifacts, stable packaged runtime
 > layout, official Homebrew tap, packaged `--version` identity, and a two-generation Homebrew

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,9 +1,40 @@
-# Spotter Status
+<div align="center">
+
+<h1>Spotter Status</h1>
+
+<p><strong>What works today, what remains partial, and what is not live yet.</strong></p>
+
+<p>
+  <a href="../README.md">← README</a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="#30-second-summary">30-second summary</a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="#quick-capability-status">Capabilities</a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="#evidence-status">Evidence</a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="roadmap.md">Roadmap</a>
+</p>
+
+</div>
 
 > **Purpose:** the fastest way to answer three questions: **What works today? What blocks the project now? What comes next?**  
 > Runtime details: [Architecture](architecture.md) · Sequence and evidence gates: [Roadmap](roadmap.md)
 
 ---
+
+<table>
+  <tr>
+    <td width="33%" valign="top">
+      <strong>✅ Active today</strong><br />
+      <sub>Hook ingestion, deterministic gates, journals, snapshots, replay, and diagnostics.</sub>
+    </td>
+    <td width="33%" valign="top">
+      <strong>🟡 Partial or shadow</strong><br />
+      <sub>App Server observation, live state, event-driven detection, and semantic review.</sub>
+    </td>
+    <td width="33%" valign="top">
+      <strong>❌ Not live yet</strong><br />
+      <sub>Delivered <code>VERIFY</code>/<code>NUDGE</code> and live recovery interventions.</sub>
+    </td>
+  </tr>
+</table>
 
 ## 30-second summary
 

--- a/docs/user-guide.ko.md
+++ b/docs/user-guide.ko.md
@@ -1,0 +1,498 @@
+<div align="center">
+
+<h1>Spotter 설치 및 사용 상세 가이드</h1>
+
+<p>
+  <a href="user-guide.md">English</a> ·
+  <strong>한국어</strong> ·
+  <a href="user-guide.zh-CN.md">简体中文</a>
+</p>
+
+<p>
+  고급 사용자를 위한 설치, 런타임 운영, 설정, 업그레이드, 안전한 제거,<br />
+  문제 해결 및 이슈 리포팅 가이드입니다.
+</p>
+
+<p><a href="../README.ko.md">← README로 돌아가기</a></p>
+
+</div>
+
+---
+
+> [!IMPORTANT]
+> Spotter는 활발히 개발 중입니다. 결정론적 Hook 게이트는 현재 동작하지만 시맨틱 `VERIFY`와
+> `NUDGE` 결정은 실시간 턴에 전달되지 않고 섀도 모드로 기록만 됩니다. App Server 관찰 및
+> 제어에는 명시적인 설정이 필요합니다. 정확한 현재 경계는
+> [Status(영문)](status.md)를 참고하세요.
+
+<table>
+  <tr>
+    <td width="50%" valign="top">
+      <a href="#3-homebrew로-설치"><strong>📦 Homebrew로 설치</strong></a><br />
+      <sub>지원되는 공식 패키지 설치 경로를 사용합니다.</sub>
+    </td>
+    <td width="50%" valign="top">
+      <a href="#4-소스에서-수동-설치"><strong>🛠️ 수동 설치</strong></a><br />
+      <sub>안정적인 Python 환경에서 Spotter를 실행합니다.</sub>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <a href="#5-spotter를-codex에-연결"><strong>🔌 Codex 연결</strong></a><br />
+      <sub>관리형 통합을 미리 보고 적용한 뒤 검증합니다.</sub>
+    </td>
+    <td width="50%" valign="top">
+      <a href="#9-연결-해제-및-제거"><strong>🧹 안전하게 제거</strong></a><br />
+      <sub>통합 해제, 패키지 제거, 사용자 데이터를 구분합니다.</sub>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <a href="#10-문제-해결"><strong>🩺 문제 해결</strong></a><br />
+      <sub>PATH, 데몬, 설정, 관찰 문제를 진단합니다.</sub>
+    </td>
+    <td width="50%" valign="top">
+      <a href="#11-이슈-리포팅"><strong>📝 이슈 리포팅</strong></a><br />
+      <sub>민감정보 없이 유용한 진단 정보를 수집합니다.</sub>
+    </td>
+  </tr>
+</table>
+
+## 1. 설치 방법 선택
+
+| 방법 | 적합한 용도 | 유지관리 방식 |
+| --- | --- | --- |
+| Homebrew(권장) | 일반적인 macOS 및 Linux 사용 | Homebrew가 패키지를 소유하고 Spotter는 Codex 통합만 소유 |
+| 전용 Python 환경 | 소스 평가 및 고급/수동 설치 | 사용자가 Python, 가상환경, 소스 업데이트, 실행 파일 안정성을 관리 |
+| 편집 가능한 개발 설치 | Spotter 자체를 수정하는 기여자 | 수동 설치 관리에 개발 의존성과 저장소 검사 추가 |
+
+활성화할 `spotter`와 `spotterd` 조합을 의도적으로 관리하는 경우가 아니라면 Homebrew 설치와
+수동 설치를 같은 `PATH`에 두지 마세요. 설정은 안정적인 실행 파일 경로를 기록하며, 서로 다른
+설치를 섞으면 CLI와 데몬의 빌드가 불일치하기 쉽습니다.
+
+## 2. 사전 요구사항
+
+모든 설치에는 다음이 필요합니다.
+
+- 통합 설정 전에 설치되어 있고 `PATH`에서 실행 가능한 `codex` CLI
+- 홈 디렉터리 아래에 파일을 생성할 수 있는 사용자 계정
+- 스냅샷, 포크, 리플레이 또는 소스 설치를 사용할 때 Git
+
+수동 설치에는 Python 3.11 이상도 필요합니다. 계속하기 전에 관련 도구를 확인하세요.
+
+```bash
+codex --version
+git --version
+python3 --version
+```
+
+Spotter 설정을 `sudo`로 실행하지 마세요. 통합, 백그라운드 서비스, 런타임 소켓, 데이터는 현재
+로그인한 사용자 계정의 소유여야 합니다.
+
+## 3. Homebrew로 설치
+
+공식 tap에서 설치합니다.
+
+```bash
+brew install spotter-agent/spotter/spotter
+```
+
+CLI와 데몬이 같은 패키지 경계에서 제공되는지 확인합니다.
+
+```bash
+command -v spotter
+command -v spotterd
+spotter --version
+spotterd --version
+```
+
+패키지 설치는 Codex 설정을 수정하거나 Hook을 등록하거나 서비스를 시작하지 않습니다. 이러한
+변경은 명시적인 설정 단계에서만 수행됩니다.
+
+## 4. 소스에서 수동 설치
+
+경로가 바뀌지 않을 전용 가상환경을 사용하세요. 다음 예시는 소스와 설치된 실행 파일을 분리합니다.
+
+```bash
+mkdir -p ~/.local/src ~/.local/share/spotter
+git clone https://github.com/spotter-agent/spotter.git ~/.local/src/spotter
+python3 -m venv ~/.local/share/spotter/venv
+~/.local/share/spotter/venv/bin/python -m pip install --upgrade pip
+~/.local/share/spotter/venv/bin/python -m pip install ~/.local/src/spotter
+```
+
+가상환경의 `bin` 디렉터리를 셸 `PATH`에 추가하거나 실행 파일을 절대 경로로 호출하세요. 설정 전에
+두 명령이 같은 위치에 나란히 설치되었는지 확인합니다.
+
+```bash
+~/.local/share/spotter/venv/bin/spotter --version
+~/.local/share/spotter/venv/bin/spotterd --version
+```
+
+가상환경이 아직 `PATH`에 없다면 이후 예제를 실행하기 전에 활성화합니다.
+
+```bash
+source ~/.local/share/spotter/venv/bin/activate
+```
+
+Spotter는 발견한 CLI와 데몬 경로를 통합 설정에 영구 기록합니다. 설정 후에는 가상환경을 이동하거나
+삭제하지 마세요. 먼저 통합을 해제하거나 같은 안정적인 경로에 환경을 다시 만든 뒤 설정을 다시
+실행해야 합니다.
+
+기여자를 위한 편집 가능한 설치는 저장소 로컬 워크플로를 사용합니다.
+
+```bash
+cd ~/.local/src/spotter
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -e '.[dev]'
+```
+
+프로젝트를 수정하기 전에 [Contributing](../CONTRIBUTING.md#local-setup)을 참고하세요.
+
+## 5. Spotter를 Codex에 연결
+
+항상 먼저 변경 계획을 확인합니다.
+
+```bash
+spotter setup codex --dry-run
+```
+
+그다음 관리형 통합을 적용하고 전체 경로를 검증합니다.
+
+```bash
+spotter setup codex
+spotter doctor
+```
+
+관리형 설정은 트랜잭션 방식이며 여러 번 실행해도 같은 결과를 보장합니다. Spotter가 소유한 Codex
+Hook/플러그인 상태만 변경하고, fingerprint가 있는 백업을 보관하며, `spotterd`를 로그인 범위의
+사용자 서비스로 등록합니다. 또한 합성 Hook 왕복을 검증하고 기본적으로
+`~/.spotter/integrations/codex.json`에 소유권 매니페스트를 커밋합니다.
+
+영구 사용자 서비스 등록을 사용할 수 없거나 원하지 않는다면 portable 모드를 사용합니다.
+
+```bash
+spotter setup codex --portable
+spotter doctor
+```
+
+Portable 모드는 로그인 시 자동으로 시작되는 서비스를 등록하지 않고 `spotterd`를 시작합니다.
+로그아웃, 재부팅 또는 프로세스 종료 후에는 직접 다시 시작해야 합니다.
+
+```bash
+spotter daemon start
+```
+
+설정이 끝나면 평소처럼 Codex를 사용합니다.
+
+```bash
+codex
+```
+
+## 6. 설정
+
+설정 파일은 선택 사항입니다. Spotter는 기본적으로 `~/.spotter/spotter.toml`을 찾습니다.
+`SPOTTER_HOME`을 설정하면 Spotter의 설정, 데이터, 통합, 런타임, 로그 루트가 함께 이동합니다.
+설정과 진단 시 `--config`로 파일을 명시할 수도 있습니다.
+
+보수적인 시작 설정은 다음과 같습니다.
+
+```toml
+observation_only = true
+snapshot_on_patch = true
+
+[main_agent]
+adapter = "codex"
+
+[reviewer]
+model = "default"
+# on_signals = true
+# every_steps = 25
+max_per_session = 20
+max_per_day = 100
+
+[gates]
+forbidden_paths = []
+block_dependency_changes = false
+```
+
+명시적인 설정 파일을 검증하고 등록하려면 다음을 실행합니다.
+
+```bash
+spotter doctor --config /absolute/path/to/spotter.toml
+spotter setup codex --config /absolute/path/to/spotter.toml
+```
+
+신호 기반 및 주기적 시맨틱 리뷰는 모델 토큰을 사용하며 기본적으로 비활성화되어 있습니다. 필요한
+경우에만 활성화하고 세션별·일별 한도를 유지하세요. 현재 리뷰 결정은 기록만 된다는 점도 기억해야
+합니다.
+
+## 7. Spotter 운영 및 점검
+
+### 상태와 런타임
+
+```bash
+spotter status
+spotter doctor
+spotter daemon status
+```
+
+`spotter status`는 빠르고 비침습적인 요약을 제공하고, `spotter doctor`는 더 깊은 합성 검사를
+수행합니다. 종료 코드는 다음과 같습니다.
+
+| 종료 코드 | 의미 |
+| --- | --- |
+| `0` | 정상 |
+| `1` | 경고가 있지만 감독이 동작하거나, 설정된 기능 일부가 저하됨 |
+| `2` | 필수 통합, 데몬, 저장소 또는 원장 계약이 깨짐 |
+
+설정 후 App Server가 구성되지 않았다는 관찰/실시간 제어 경고가 표시될 수 있습니다. 이는 현재
+알려진 경계입니다. 결정론적 PreToolUse Hook 적용은 독립적으로 유지되지만, 완전한 App Server
+관찰과 실시간 제어는 사용할 수 없습니다.
+
+수동 데몬 명령은 `spotterd`만 제어하며 공유 Codex App Server를 중지하거나 초기화하지 않습니다.
+
+```bash
+spotter daemon start
+spotter daemon restart
+spotter daemon stop
+```
+
+### 수집 데이터와 커버리지
+
+```bash
+spotter metrics
+spotter observability
+spotter analyze
+```
+
+`analyze`, `metrics`, `observability`에 `--session <id>`를 사용하면 하나의 기록된 세션으로 출력을
+제한할 수 있습니다. 저널과 진단에는 저장소 경로, 프롬프트, 도구 payload 등 작업 맥락이 포함될
+수 있으므로 민감한 데이터로 취급하세요.
+
+### 저장소 관리
+
+스냅샷 정리는 기본적으로 dry-run입니다. 관련 저장소 안에서 실행하거나 저장소 경로를 지정합니다.
+
+```bash
+spotter prune --repo /path/to/repository --forks
+spotter prune --repo /path/to/repository --forks --apply
+```
+
+저널 만료에는 기간을 명시해야 하며, 오래된 세션을 포크하는 데 필요한 스냅샷도 제거될 수 있습니다.
+
+```bash
+spotter prune --repo /path/to/repository --journals --max-age-days 30
+spotter prune --repo /path/to/repository --journals --max-age-days 30 --apply
+```
+
+`--apply`를 추가하기 전에 dry-run 출력을 읽으세요. Spotter는 소유한 ref와 worktree를 Git을
+인식하는 방식으로 정리하므로, 이를 원시 재귀 삭제로 대체하지 마세요.
+
+## 8. 업그레이드 및 재설치
+
+Homebrew 설치는 다음과 같이 업그레이드합니다.
+
+```bash
+brew upgrade spotter-agent/spotter/spotter
+spotter setup codex
+spotter doctor
+```
+
+설정을 다시 실행하면 설치된 CLI, 실행 중인 데몬, 생성된 Hook 경로, 빌드 식별자, 통합 세대가
+조정됩니다.
+
+전용 소스 환경은 다음과 같이 업그레이드합니다.
+
+```bash
+git -C ~/.local/src/spotter pull --ff-only
+~/.local/share/spotter/venv/bin/python -m pip install --upgrade ~/.local/src/spotter
+source ~/.local/share/spotter/venv/bin/activate
+spotter setup codex
+spotter doctor
+```
+
+업그레이드가 중단되었다면 생성된 Hook을 먼저 직접 수정하지 마세요. `spotter status`를 실행한 뒤
+setup과 doctor를 다시 실행하세요. 설정은 보존된 소유권 상태를 사용해 Hook 중복 없이 조정하도록
+설계되어 있습니다.
+
+## 9. 연결 해제 및 제거
+
+Spotter와 데이터를 유지하면서 Codex 통합만 제거하려면 다음을 실행합니다.
+
+```bash
+spotter teardown codex
+```
+
+Homebrew에서 깨끗하게 제거하려면 다음을 실행합니다.
+
+```bash
+spotter teardown codex
+brew uninstall spotter-agent/spotter/spotter
+```
+
+수동 Python 설치는 명령이 아직 존재할 때 통합을 해제한 다음 같은 환경에서 배포 패키지를
+제거합니다.
+
+```bash
+spotter teardown codex
+spotter daemon stop
+~/.local/share/spotter/venv/bin/python -m pip uninstall spotter-agent
+```
+
+해당 경로가 Spotter 전용임을 확인한 뒤 일반 파일 관리 도구로 가상환경과 소스 체크아웃을 제거할
+수 있습니다.
+
+일반적인 제거는 `~/.spotter` 또는 `SPOTTER_HOME`의 사용자 데이터를 삭제하지 않습니다.
+저장소를 인식하는 `spotter purge` 명령은 **아직 구현되지 않았습니다**. Spotter 소유 Git ref와
+분리된 worktree가 저장소 안에 존재할 수도 있으므로 홈 디렉터리만 지워서는 완전히 purge되지
+않습니다. 지원되는 Git 인식 정리에는 `spotter prune`을 사용하고, 확실하지 않은 데이터는
+보존하며, purge 지원은 [#89](https://github.com/spotter-agent/spotter/issues/89)를 확인하세요.
+
+통합 해제 전에 패키지를 제거했더라도 생성된 Hook은 fail-open으로 동작하도록 설계되어 있습니다.
+같은 방법으로 패키지를 다시 설치하고 `spotter teardown codex`를 실행한 뒤 다시 제거하면 기록된
+소유 통합을 안전하게 정리할 수 있습니다.
+
+## 10. 문제 해결
+
+<details>
+<summary><strong><code>spotter</code> 또는 <code>spotterd</code>를 찾을 수 없음</strong></summary>
+
+```bash
+command -v spotter
+command -v spotterd
+```
+
+Homebrew에서는 Formula가 설치되어 있고 Homebrew의 `bin` 디렉터리가 `PATH`에 있는지 확인합니다.
+수동 설치에서는 사용할 가상환경을 활성화합니다. 두 명령이 서로 다른 설치 루트를 가리키면
+`PATH`를 수정한 뒤 `spotter setup codex`와 `spotter doctor`를 다시 실행하세요.
+
+</details>
+
+<details>
+<summary><strong>설정에서 Codex를 찾을 수 없음</strong></summary>
+
+```bash
+command -v codex
+codex --version
+spotter setup codex --dry-run
+```
+
+설정을 실행하는 것과 같은 로그인 환경의 `PATH`에 Codex를 설치하거나 노출하세요. 사용자 지정
+`CODEX_HOME`을 사용한다면 setup, doctor, 일반 Codex 세션에서 같은 값을 유지해야 합니다.
+
+</details>
+
+<details>
+<summary><strong>데몬을 사용할 수 없거나 빌드가 일치하지 않음</strong></summary>
+
+```bash
+spotter daemon status
+spotter daemon restart
+spotter setup codex
+spotter doctor
+```
+
+업그레이드 후에는 setup을 다시 실행하는 것이 지원되는 조정 절차입니다. Doctor 출력에서 등록된
+서비스 자체가 문제임을 확인하기 전에는 `launchd` 또는 `systemd --user` 정의를 직접 수정하지
+마세요.
+
+</details>
+
+<details>
+<summary><strong>Doctor가 관찰 또는 실시간 제어를 사용할 수 없다고 보고함</strong></summary>
+
+현재 App Server 엔드포인트는 자동 선택되지 않습니다. Hook 적용이 가능하다고 표시되면 결정론적
+게이트는 여전히 동작하지만 App Server 관찰과 실시간 `VERIFY`/`NUDGE`는 동작하지 않습니다.
+이 알려진 제품 경계를 설치 문제로 판단하기 전에 [Status(영문)](status.md)를 확인하세요.
+
+</details>
+
+<details>
+<summary><strong>설정 파일을 파싱하지 못하거나 설정이 무시되는 것처럼 보임</strong></summary>
+
+```bash
+spotter doctor --config /absolute/path/to/spotter.toml
+spotter setup codex --config /absolute/path/to/spotter.toml --dry-run
+```
+
+`[main_agent]`가 존재하고 `adapter = "codex"`가 비어 있지 않은 문자열인지 확인합니다. Setup은
+선택한 설정 경로를 통합 매니페스트에 저장합니다. 기록된 설정을 사용할 수 없게 되면 Hook은
+fail-open 경계 안에서 안전한 기본값을 사용하고 문제를 stderr에 출력합니다.
+
+</details>
+
+<details>
+<summary><strong>세션 또는 최근 관찰이 나타나지 않음</strong></summary>
+
+설정 후 일반 Codex 세션을 실행한 다음 확인합니다.
+
+```bash
+spotter status
+spotter doctor
+spotter observability
+```
+
+Hook 소유권 결과와 마지막 관찰 시간, Codex 세션이 setup에서 확인한 것과 같은 `CODEX_HOME`을
+사용하는지 확인하세요.
+
+</details>
+
+<details>
+<summary><strong>저장소 또는 권한 검사 실패</strong></summary>
+
+기본적으로 변경 가능한 상태는 `~/.spotter` 아래에 있으며 `logs/`, `runtime/`, `sessions/`,
+`integrations/`를 포함합니다. 현재 사용자가 설정된 루트를 소유하고 쓸 수 있는지 확인하세요.
+광범위한 재귀 명령으로 소유권을 바꾸지 말고 doctor가 표시한 정확한 실패 경로를 확인하세요.
+
+</details>
+
+<details>
+<summary><strong>Teardown 없이 Spotter를 제거함</strong></summary>
+
+생성된 Hook은 fail-open이므로 Codex는 계속 동작해야 합니다. 소유한 통합을 정리하려면 Spotter를
+다시 설치하고 `spotter doctor`, `spotter teardown codex`를 차례로 실행한 뒤 다시 제거하세요.
+
+</details>
+
+<p align="right"><a href="#spotter-설치-및-사용-상세-가이드">맨 위로 ↑</a></p>
+
+## 11. 이슈 리포팅
+
+[GitHub 이슈 선택 화면](https://github.com/spotter-agent/spotter/issues/new/choose)에서 버그,
+기능, 문서, 아키텍처, 실험, 유지관리 중 요청에 가장 알맞은 양식을 선택하세요.
+
+유용한 버그 리포트에는 다음을 포함합니다.
+
+- 실제로 발생한 일, 기대한 동작, 영향
+- 문제를 안정적으로 재현하는 최소 단계
+- Homebrew 또는 수동 설치 방식
+- 관련된 Spotter CLI/데몬 버전, Codex 버전, OS, 아키텍처, Python 버전
+- 실패한 정확한 명령과 종료 코드
+- 관련된 `status`, `doctor`, `daemon status` 출력 줄
+- setup, 업그레이드, 설정 변경, 재설치 중 어느 작업 이후 문제가 시작되었는지
+
+기본 진단 정보는 다음 명령으로 수집합니다.
+
+```bash
+spotter --version
+spotterd --version
+codex --version
+spotter status
+spotter doctor
+spotter daemon status
+```
+
+토큰, 자격 증명, 비공개 저장소 이름과 경로, 프롬프트, 소스 코드, 개인정보는 제거하세요. 원시
+저널, 전체 설정 파일, 전체 로그는 내용을 먼저 검토하지 않고 첨부하지 마세요. 보안상 민감하거나
+악용 가능한 문제는 공개 이슈에 세부 정보를 게시하지 말고 저장소의 Security 페이지에서 비공개
+신고 채널을 확인하세요.
+
+## 12. 관련 문서
+
+- [Status(영문)](status.md) — 구현된 기능과 실험적 기능의 권위 있는 경계
+- [Lifecycle](lifecycle.md) — 패키지, 서비스, 통합, 복구, 제거의 전체 계약
+- [설정 레퍼런스](../spotter.example.toml) — 현재 문서화된 모든 설정 키
+- [Homebrew lifecycle smoke](homebrew-lifecycle-smoke.md) — 패키지 수명주기 증거
+- [Contributing](../CONTRIBUTING.md) — 소스 설정과 기여 워크플로

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,500 @@
+<div align="center">
+
+<h1>Spotter Installation and Usage Guide</h1>
+
+<p>
+  <strong>English</strong> ·
+  <a href="user-guide.ko.md">한국어</a> ·
+  <a href="user-guide.zh-CN.md">简体中文</a>
+</p>
+
+<p>
+  Installation, runtime operation, configuration, upgrades, safe removal,<br />
+  troubleshooting, and useful issue reports for advanced users.
+</p>
+
+<p><a href="../README.md">← Back to README</a></p>
+
+</div>
+
+---
+
+> [!IMPORTANT]
+> Spotter is under active development. Deterministic Hook gates work today, but semantic `VERIFY`
+> and `NUDGE` decisions are still recorded in shadow mode rather than delivered into live turns.
+> App Server observation and control require explicit configuration. See [Status](status.md) for the
+> authoritative current boundary.
+
+<table>
+  <tr>
+    <td width="50%" valign="top">
+      <a href="#3-install-with-homebrew"><strong>📦 Install with Homebrew</strong></a><br />
+      <sub>Use the supported packaged installation.</sub>
+    </td>
+    <td width="50%" valign="top">
+      <a href="#4-install-manually-from-source"><strong>🛠️ Install manually</strong></a><br />
+      <sub>Run Spotter from a stable Python environment.</sub>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <a href="#5-connect-spotter-to-codex"><strong>🔌 Connect Codex</strong></a><br />
+      <sub>Preview, apply, and verify the managed integration.</sub>
+    </td>
+    <td width="50%" valign="top">
+      <a href="#9-disconnect-and-uninstall"><strong>🧹 Remove safely</strong></a><br />
+      <sub>Separate integration teardown, package removal, and user data.</sub>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <a href="#10-troubleshooting"><strong>🩺 Troubleshoot</strong></a><br />
+      <sub>Diagnose PATH, daemon, configuration, and observation problems.</sub>
+    </td>
+    <td width="50%" valign="top">
+      <a href="#11-report-an-issue"><strong>📝 Report an issue</strong></a><br />
+      <sub>Collect useful diagnostics without exposing sensitive data.</sub>
+    </td>
+  </tr>
+</table>
+
+## 1. Choose an installation method
+
+| Method | Best for | Maintenance model |
+| --- | --- | --- |
+| Homebrew (recommended) | Normal macOS and Linux use | Homebrew owns the package; Spotter owns only its Codex integration |
+| Dedicated Python environment | Source evaluation and advanced/manual installations | You own Python, the virtual environment, source updates, and executable stability |
+| Editable development install | Contributors changing Spotter itself | Same as a manual install, plus development dependencies and repository checks |
+
+Do not install both Homebrew and a manual copy on the same `PATH` unless you intentionally manage
+which `spotter` and `spotterd` pair is active. Setup records stable executable paths, and mixing
+installations is a common cause of CLI/daemon build mismatches.
+
+## 2. Prerequisites
+
+All installations need:
+
+- the `codex` CLI installed and available on `PATH` before integration setup;
+- a user account that can create files under its home directory;
+- Git when snapshots, forks, replay, or a source installation are used.
+
+Manual installations also need Python 3.11 or newer. Confirm the relevant tools before continuing:
+
+```bash
+codex --version
+git --version
+python3 --version
+```
+
+Do not run Spotter setup with `sudo`. The integration, background service, runtime socket, and data
+belong to the current login account.
+
+## 3. Install with Homebrew
+
+Install from the official tap:
+
+```bash
+brew install spotter-agent/spotter/spotter
+```
+
+Verify that the CLI and daemon come from the same package boundary:
+
+```bash
+command -v spotter
+command -v spotterd
+spotter --version
+spotterd --version
+```
+
+Package installation does not edit Codex configuration, register Hooks, or start a service. Those
+changes happen only during explicit setup.
+
+## 4. Install manually from source
+
+Use a dedicated virtual environment whose path will remain stable. This example keeps source and
+the installed entry points separate:
+
+```bash
+mkdir -p ~/.local/src ~/.local/share/spotter
+git clone https://github.com/spotter-agent/spotter.git ~/.local/src/spotter
+python3 -m venv ~/.local/share/spotter/venv
+~/.local/share/spotter/venv/bin/python -m pip install --upgrade pip
+~/.local/share/spotter/venv/bin/python -m pip install ~/.local/src/spotter
+```
+
+Add the environment's `bin` directory to your shell `PATH`, or invoke its entry points by absolute
+path. Confirm that both commands resolve beside each other before setup:
+
+```bash
+~/.local/share/spotter/venv/bin/spotter --version
+~/.local/share/spotter/venv/bin/spotterd --version
+```
+
+Activate the environment before the remaining examples if it is not already on `PATH`:
+
+```bash
+source ~/.local/share/spotter/venv/bin/activate
+```
+
+Spotter persists the discovered CLI and daemon paths in its integration. Do not move or delete the
+virtual environment after setup. Teardown the integration first, or recreate it at the same stable
+path and rerun setup.
+
+For an editable contributor install, use the repository-local workflow instead:
+
+```bash
+cd ~/.local/src/spotter
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -e '.[dev]'
+```
+
+See [Contributing](../CONTRIBUTING.md#local-setup) before modifying the project.
+
+## 5. Connect Spotter to Codex
+
+Always inspect the mutation plan first:
+
+```bash
+spotter setup codex --dry-run
+```
+
+Then apply the managed integration and verify it end to end:
+
+```bash
+spotter setup codex
+spotter doctor
+```
+
+Managed setup is transactional and idempotent. It updates only Spotter-owned Codex Hook/plugin
+state, keeps fingerprinted backups, registers `spotterd` as a login-scoped user service, verifies a
+synthetic Hook round trip, and commits an ownership manifest under
+`~/.spotter/integrations/codex.json` by default.
+
+If persistent user-service registration is unavailable or unwanted, use portable mode:
+
+```bash
+spotter setup codex --portable
+spotter doctor
+```
+
+Portable mode starts `spotterd` without persistent login registration. You are responsible for
+starting it again after logout, reboot, or process termination:
+
+```bash
+spotter daemon start
+```
+
+After setup, use Codex normally:
+
+```bash
+codex
+```
+
+## 6. Configuration
+
+Configuration is optional. By default, Spotter looks for `~/.spotter/spotter.toml`; setting
+`SPOTTER_HOME` moves the Spotter configuration, data, integration, runtime, and log root together.
+You can also select a file explicitly with `--config` during setup and diagnostics.
+
+A conservative starting configuration is:
+
+```toml
+observation_only = true
+snapshot_on_patch = true
+
+[main_agent]
+adapter = "codex"
+
+[reviewer]
+model = "default"
+# on_signals = true
+# every_steps = 25
+max_per_session = 20
+max_per_day = 100
+
+[gates]
+forbidden_paths = []
+block_dependency_changes = false
+```
+
+Validate and register an explicit configuration with:
+
+```bash
+spotter doctor --config /absolute/path/to/spotter.toml
+spotter setup codex --config /absolute/path/to/spotter.toml
+```
+
+Signal-driven and periodic semantic reviews spend model tokens and are off by default. Enable them
+deliberately, preserve per-session and per-day caps, and remember that their decisions are currently
+recorded only.
+
+## 7. Operate and inspect Spotter
+
+### Health and runtime
+
+```bash
+spotter status
+spotter doctor
+spotter daemon status
+```
+
+`spotter status` is a quick, non-invasive summary. `spotter doctor` performs deeper synthetic
+checks. Their exit codes are:
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | healthy |
+| `1` | supervision works with warnings or a configured surface is degraded |
+| `2` | a required integration, daemon, storage, or ledger contract is broken |
+
+An unconfigured App Server can produce an observation/live-control warning after setup. This is a
+known current boundary: deterministic PreToolUse Hook enforcement remains independent, while full
+App Server observation and live control are unavailable.
+
+Manual daemon controls affect only `spotterd`; they never stop or reset a shared Codex App Server:
+
+```bash
+spotter daemon start
+spotter daemon restart
+spotter daemon stop
+```
+
+### Collected data and coverage
+
+```bash
+spotter metrics
+spotter observability
+spotter analyze
+```
+
+Use `--session <id>` with `analyze`, `metrics`, or `observability` to limit output to one recorded
+session. Treat journals and diagnostics as potentially sensitive: they can contain repository
+paths, prompts, tool payloads, and other work context.
+
+### Storage maintenance
+
+Snapshot pruning is dry-run by default. Run it from, or point it at, the relevant repository:
+
+```bash
+spotter prune --repo /path/to/repository --forks
+spotter prune --repo /path/to/repository --forks --apply
+```
+
+Journal expiry requires an explicit age and can remove the snapshots needed to fork old sessions:
+
+```bash
+spotter prune --repo /path/to/repository --journals --max-age-days 30
+spotter prune --repo /path/to/repository --journals --max-age-days 30 --apply
+```
+
+Read the dry-run output before adding `--apply`. Spotter uses Git-aware cleanup for owned refs and
+worktrees; do not replace it with raw recursive deletion.
+
+## 8. Upgrade and reinstall
+
+For Homebrew:
+
+```bash
+brew upgrade spotter-agent/spotter/spotter
+spotter setup codex
+spotter doctor
+```
+
+Rerunning setup reconciles the installed CLI, the running daemon, generated Hook paths, build
+identity, and integration generation.
+
+For the dedicated source environment:
+
+```bash
+git -C ~/.local/src/spotter pull --ff-only
+~/.local/share/spotter/venv/bin/python -m pip install --upgrade ~/.local/src/spotter
+source ~/.local/share/spotter/venv/bin/activate
+spotter setup codex
+spotter doctor
+```
+
+If an upgrade was interrupted, do not hand-edit generated Hooks first. Run `spotter status`, then
+rerun setup and doctor. Setup is designed to reconcile retained ownership state without duplicating
+Hooks.
+
+## 9. Disconnect and uninstall
+
+To remove only the Codex integration while keeping Spotter and its data:
+
+```bash
+spotter teardown codex
+```
+
+For a clean Homebrew uninstall:
+
+```bash
+spotter teardown codex
+brew uninstall spotter-agent/spotter/spotter
+```
+
+For a manual Python installation, run teardown while its commands still exist, then uninstall the
+distribution from the same environment:
+
+```bash
+spotter teardown codex
+spotter daemon stop
+~/.local/share/spotter/venv/bin/python -m pip uninstall spotter-agent
+```
+
+After confirming those exact paths are dedicated to Spotter, you may remove the virtual environment
+and source checkout with your normal file-management tools.
+
+Normal uninstall does not delete `~/.spotter` (or `SPOTTER_HOME`) user data. A repository-aware
+`spotter purge` command is **not implemented yet**. Spotter-owned Git refs and detached worktrees can
+also exist in repositories, so deleting only the home directory is not a complete purge. Use
+`spotter prune` for supported Git-aware cleanup, retain data you are unsure about, and follow
+[#89](https://github.com/spotter-agent/spotter/issues/89) for purge support.
+
+If the package was removed before teardown, generated Hooks are designed to fail open. Reinstall the
+same package method, run `spotter teardown codex`, and uninstall again to remove the recorded owned
+integration safely.
+
+## 10. Troubleshooting
+
+<details>
+<summary><strong><code>spotter</code> or <code>spotterd</code> is not found</strong></summary>
+
+```bash
+command -v spotter
+command -v spotterd
+```
+
+For Homebrew, confirm the Formula is installed and that Homebrew's `bin` directory is on `PATH`. For
+a manual installation, activate the intended environment. If the two commands resolve to different
+installation roots, fix `PATH`, then rerun `spotter setup codex` and `spotter doctor`.
+
+</details>
+
+<details>
+<summary><strong>Setup cannot find Codex</strong></summary>
+
+```bash
+command -v codex
+codex --version
+spotter setup codex --dry-run
+```
+
+Install or expose Codex on `PATH` in the same login environment that runs setup. If you use a custom
+`CODEX_HOME`, keep it consistent for setup, doctor, and normal Codex sessions.
+
+</details>
+
+<details>
+<summary><strong>The daemon is unavailable or has the wrong build</strong></summary>
+
+```bash
+spotter daemon status
+spotter daemon restart
+spotter setup codex
+spotter doctor
+```
+
+After an upgrade, setup is the supported reconciliation step. Do not edit `launchd` or
+`systemd --user` definitions until doctor output shows that the registered service itself is the
+problem.
+
+</details>
+
+<details>
+<summary><strong>Doctor reports unavailable observation or live control</strong></summary>
+
+An App Server endpoint is not selected automatically today. If Hook enforcement is reported as
+available, deterministic gating still works; App Server observation and live `VERIFY`/`NUDGE` do
+not. Check [Status](status.md) before treating this known product boundary as an installation bug.
+
+</details>
+
+<details>
+<summary><strong>Configuration fails to parse or appears ignored</strong></summary>
+
+```bash
+spotter doctor --config /absolute/path/to/spotter.toml
+spotter setup codex --config /absolute/path/to/spotter.toml --dry-run
+```
+
+Confirm that `[main_agent]` exists and `adapter = "codex"` is a non-empty string. Setup stores the
+chosen configuration path in the integration manifest. Hooks fail open and use safe defaults when
+the recorded configuration becomes unusable, while printing the problem to stderr.
+
+</details>
+
+<details>
+<summary><strong>No sessions or recent observations appear</strong></summary>
+
+Run a normal Codex session after setup, then inspect:
+
+```bash
+spotter status
+spotter doctor
+spotter observability
+```
+
+Check the Hook ownership result, the last-observation age, and whether your Codex session uses the
+same `CODEX_HOME` that setup inspected.
+
+</details>
+
+<details>
+<summary><strong>Storage or permission checks fail</strong></summary>
+
+By default, mutable state is under `~/.spotter`, including `logs/`, `runtime/`, `sessions/`, and
+`integrations/`. Confirm that the current user owns and can write the configured root. Avoid
+changing ownership with a broad recursive command; inspect the exact failing path shown by doctor.
+
+</details>
+
+<details>
+<summary><strong>Spotter was uninstalled without teardown</strong></summary>
+
+Codex should continue because generated Hooks fail open. To clean up the owned integration, reinstall
+Spotter, run `spotter doctor`, then `spotter teardown codex` before uninstalling again.
+
+</details>
+
+<p align="right"><a href="#spotter-installation-and-usage-guide">Back to top ↑</a></p>
+
+## 11. Report an issue
+
+Use the [GitHub issue chooser](https://github.com/spotter-agent/spotter/issues/new/choose) and select
+the bug, feature, documentation, architecture, experiment, or maintenance form that best matches the
+request.
+
+A useful bug report includes:
+
+- what happened, what you expected, and the impact;
+- the smallest reliable reproduction sequence;
+- Homebrew or manual installation method;
+- Spotter CLI and daemon versions, Codex version, OS, architecture, and Python version when relevant;
+- the exact failing command and exit code;
+- relevant `status`, `doctor`, and `daemon status` lines;
+- whether the issue started after setup, an upgrade, configuration change, or reinstall.
+
+Collect the basic diagnostics with:
+
+```bash
+spotter --version
+spotterd --version
+codex --version
+spotter status
+spotter doctor
+spotter daemon status
+```
+
+Redact tokens, credentials, private repository names and paths, prompts, source code, and personal
+information. Do not attach raw journals, complete configuration files, or full logs without first
+reviewing them. For a security-sensitive or exploitable issue, do not publish details in a public
+issue; check the repository Security page for a private reporting channel.
+
+## 12. Related documentation
+
+- [Status](status.md) — authoritative implemented vs. experimental boundary
+- [Lifecycle](lifecycle.md) — complete package, service, integration, recovery, and removal contract
+- [Configuration reference](../spotter.example.toml) — all currently documented configuration keys
+- [Homebrew lifecycle smoke](homebrew-lifecycle-smoke.md) — packaged lifecycle evidence
+- [Contributing](../CONTRIBUTING.md) — source setup and contribution workflow

--- a/docs/user-guide.zh-CN.md
+++ b/docs/user-guide.zh-CN.md
@@ -1,0 +1,484 @@
+<div align="center">
+
+<h1>Spotter 安装与使用详细指南</h1>
+
+<p>
+  <a href="user-guide.md">English</a> ·
+  <a href="user-guide.ko.md">한국어</a> ·
+  <strong>简体中文</strong>
+</p>
+
+<p>
+  面向高级用户的安装、运行时操作、配置、升级、安全移除、<br />
+  故障排查与问题报告指南。
+</p>
+
+<p><a href="../README.zh-CN.md">← 返回 README</a></p>
+
+</div>
+
+---
+
+> [!IMPORTANT]
+> Spotter 正在积极开发中。确定性 Hook 门控现在已经可用，但语义 `VERIFY` 和 `NUDGE` 决策
+> 仍只会在影子模式下记录，不会传递到实时轮次。App Server 观察和控制需要显式配置。权威的
+> 当前能力边界请参阅 [Status（英文）](status.md)。
+
+<table>
+  <tr>
+    <td width="50%" valign="top">
+      <a href="#3-使用-homebrew-安装"><strong>📦 使用 Homebrew 安装</strong></a><br />
+      <sub>使用受支持的官方软件包安装路径。</sub>
+    </td>
+    <td width="50%" valign="top">
+      <a href="#4-从源码手动安装"><strong>🛠️ 手动安装</strong></a><br />
+      <sub>从稳定的 Python 环境运行 Spotter。</sub>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <a href="#5-将-spotter-连接到-codex"><strong>🔌 连接 Codex</strong></a><br />
+      <sub>预览、应用并验证托管集成。</sub>
+    </td>
+    <td width="50%" valign="top">
+      <a href="#9-解除集成与卸载"><strong>🧹 安全移除</strong></a><br />
+      <sub>区分解除集成、软件包卸载和用户数据。</sub>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <a href="#10-故障排查"><strong>🩺 故障排查</strong></a><br />
+      <sub>诊断 PATH、守护进程、配置和观察问题。</sub>
+    </td>
+    <td width="50%" valign="top">
+      <a href="#11-报告问题"><strong>📝 报告问题</strong></a><br />
+      <sub>在不暴露敏感数据的情况下收集有效诊断。</sub>
+    </td>
+  </tr>
+</table>
+
+## 1. 选择安装方式
+
+| 方式 | 适用场景 | 维护方式 |
+| --- | --- | --- |
+| Homebrew（推荐） | 常规 macOS 和 Linux 使用 | Homebrew 管理软件包；Spotter 只管理自己的 Codex 集成 |
+| 独立 Python 环境 | 源码评估和高级/手动安装 | 你负责 Python、虚拟环境、源码更新和可执行文件路径稳定性 |
+| 可编辑开发安装 | 修改 Spotter 本身的贡献者 | 在手动安装责任之外，还需管理开发依赖和仓库检查 |
+
+除非你会主动管理当前使用的 `spotter` 和 `spotterd` 组合，否则不要让 Homebrew 与手动安装
+同时出现在一个 `PATH` 中。设置过程会记录稳定的可执行文件路径；混用安装方式很容易造成 CLI
+与守护进程构建不一致。
+
+## 2. 前置条件
+
+所有安装方式都需要：
+
+- 在集成设置前已安装且能从 `PATH` 调用的 `codex` CLI；
+- 可以在个人主目录中创建文件的用户账户；
+- 使用快照、分支、回放或源码安装时所需的 Git。
+
+手动安装还要求 Python 3.11 或更新版本。继续前请检查相关工具：
+
+```bash
+codex --version
+git --version
+python3 --version
+```
+
+不要用 `sudo` 运行 Spotter 设置。集成、后台服务、运行时套接字和数据都应属于当前登录用户。
+
+## 3. 使用 Homebrew 安装
+
+从官方 tap 安装：
+
+```bash
+brew install spotter-agent/spotter/spotter
+```
+
+确认 CLI 和守护进程来自同一个软件包边界：
+
+```bash
+command -v spotter
+command -v spotterd
+spotter --version
+spotterd --version
+```
+
+安装软件包不会修改 Codex 配置、注册 Hook 或启动服务。这些变化只在显式设置时发生。
+
+## 4. 从源码手动安装
+
+请使用路径长期保持稳定的独立虚拟环境。下面的示例将源码与已安装入口点分开：
+
+```bash
+mkdir -p ~/.local/src ~/.local/share/spotter
+git clone https://github.com/spotter-agent/spotter.git ~/.local/src/spotter
+python3 -m venv ~/.local/share/spotter/venv
+~/.local/share/spotter/venv/bin/python -m pip install --upgrade pip
+~/.local/share/spotter/venv/bin/python -m pip install ~/.local/src/spotter
+```
+
+将该环境的 `bin` 目录加入 shell 的 `PATH`，或通过绝对路径调用入口点。设置前确认两个命令
+位于同一目录：
+
+```bash
+~/.local/share/spotter/venv/bin/spotter --version
+~/.local/share/spotter/venv/bin/spotterd --version
+```
+
+如果该环境尚未位于 `PATH`，请在执行后续示例前激活它：
+
+```bash
+source ~/.local/share/spotter/venv/bin/activate
+```
+
+Spotter 会把发现的 CLI 和守护进程路径持久写入集成配置。设置后不要移动或删除虚拟环境。
+请先解除集成，或者在同一个稳定路径上重建环境并重新运行设置。
+
+贡献者如需可编辑安装，请改用仓库内的工作流：
+
+```bash
+cd ~/.local/src/spotter
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -e '.[dev]'
+```
+
+修改项目前请阅读 [Contributing](../CONTRIBUTING.md#local-setup)。
+
+## 5. 将 Spotter 连接到 Codex
+
+始终先查看变更计划：
+
+```bash
+spotter setup codex --dry-run
+```
+
+然后应用托管集成并进行端到端验证：
+
+```bash
+spotter setup codex
+spotter doctor
+```
+
+托管设置具备事务性和幂等性。它只修改 Spotter 所有的 Codex Hook/插件状态，保留带
+fingerprint 的备份，将 `spotterd` 注册为登录用户范围的服务，验证一次合成 Hook 往返，并默认
+在 `~/.spotter/integrations/codex.json` 中提交所有权清单。
+
+如果无法或不希望注册持久用户服务，请使用 portable 模式：
+
+```bash
+spotter setup codex --portable
+spotter doctor
+```
+
+Portable 模式会启动 `spotterd`，但不会注册登录时自动启动的服务。注销、重启或进程终止后，
+你需要自行再次启动它：
+
+```bash
+spotter daemon start
+```
+
+完成设置后，照常使用 Codex：
+
+```bash
+codex
+```
+
+## 6. 配置
+
+配置文件是可选的。Spotter 默认查找 `~/.spotter/spotter.toml`。设置 `SPOTTER_HOME` 会同时
+移动 Spotter 的配置、数据、集成、运行时和日志根目录。也可以在设置和诊断时用 `--config`
+显式指定文件。
+
+一份保守的初始配置如下：
+
+```toml
+observation_only = true
+snapshot_on_patch = true
+
+[main_agent]
+adapter = "codex"
+
+[reviewer]
+model = "default"
+# on_signals = true
+# every_steps = 25
+max_per_session = 20
+max_per_day = 100
+
+[gates]
+forbidden_paths = []
+block_dependency_changes = false
+```
+
+通过以下命令验证并注册显式配置：
+
+```bash
+spotter doctor --config /absolute/path/to/spotter.toml
+spotter setup codex --config /absolute/path/to/spotter.toml
+```
+
+信号驱动和定期语义审查会消耗模型令牌，并且默认关闭。请有意识地启用它们，保留每会话和每日
+上限，并记住当前的审查决策只会被记录。
+
+## 7. 操作与检查 Spotter
+
+### 健康状态与运行时
+
+```bash
+spotter status
+spotter doctor
+spotter daemon status
+```
+
+`spotter status` 提供快速、非侵入式摘要；`spotter doctor` 执行更深入的合成检查。退出码含义
+如下：
+
+| 退出码 | 含义 |
+| --- | --- |
+| `0` | 健康 |
+| `1` | 监督仍可工作但存在警告，或某个已配置能力降级 |
+| `2` | 必需的集成、守护进程、存储或账本约定已损坏 |
+
+设置后可能出现 App Server 未配置的观察/实时控制警告。这是当前已知边界：确定性的
+PreToolUse Hook 执行不受影响，但完整 App Server 观察和实时控制不可用。
+
+手动守护进程命令只控制 `spotterd`，绝不会停止或重置共享 Codex App Server：
+
+```bash
+spotter daemon start
+spotter daemon restart
+spotter daemon stop
+```
+
+### 已采集数据与覆盖率
+
+```bash
+spotter metrics
+spotter observability
+spotter analyze
+```
+
+对 `analyze`、`metrics` 或 `observability` 使用 `--session <id>`，可以把输出限制到一个已记录
+会话。请把日志和诊断视为潜在敏感信息：它们可能包含仓库路径、提示词、工具 payload 和其他
+工作上下文。
+
+### 存储维护
+
+快照清理默认是 dry-run。请在相关仓库内运行，或显式指定仓库：
+
+```bash
+spotter prune --repo /path/to/repository --forks
+spotter prune --repo /path/to/repository --forks --apply
+```
+
+日志到期清理需要明确指定期限，并可能移除用于从旧会话分支的快照：
+
+```bash
+spotter prune --repo /path/to/repository --journals --max-age-days 30
+spotter prune --repo /path/to/repository --journals --max-age-days 30 --apply
+```
+
+添加 `--apply` 前请先阅读 dry-run 输出。Spotter 会通过 Git 感知的方式清理其所有的 ref 和
+worktree；不要用原始递归删除代替它。
+
+## 8. 升级与重装
+
+Homebrew 安装的升级方式：
+
+```bash
+brew upgrade spotter-agent/spotter/spotter
+spotter setup codex
+spotter doctor
+```
+
+重新运行设置会协调已安装 CLI、正在运行的守护进程、生成的 Hook 路径、构建标识和集成版本。
+
+独立源码环境的升级方式：
+
+```bash
+git -C ~/.local/src/spotter pull --ff-only
+~/.local/share/spotter/venv/bin/python -m pip install --upgrade ~/.local/src/spotter
+source ~/.local/share/spotter/venv/bin/activate
+spotter setup codex
+spotter doctor
+```
+
+如果升级中断，不要先手动编辑生成的 Hook。运行 `spotter status`，然后重新执行 setup 和
+doctor。设置过程会利用保留的所有权状态进行协调，而不会重复添加 Hook。
+
+## 9. 解除集成与卸载
+
+如需保留 Spotter 和数据，只移除 Codex 集成：
+
+```bash
+spotter teardown codex
+```
+
+如需完整卸载 Homebrew 安装：
+
+```bash
+spotter teardown codex
+brew uninstall spotter-agent/spotter/spotter
+```
+
+对于手动 Python 安装，请在命令仍然存在时先解除集成，再从同一环境卸载发行包：
+
+```bash
+spotter teardown codex
+spotter daemon stop
+~/.local/share/spotter/venv/bin/python -m pip uninstall spotter-agent
+```
+
+确认这些准确路径专用于 Spotter 后，可以用常用文件管理工具删除虚拟环境和源码检出。
+
+普通卸载不会删除 `~/.spotter` 或 `SPOTTER_HOME` 中的用户数据。仓库感知的 `spotter purge`
+命令**尚未实现**。Spotter 所有的 Git ref 和分离 worktree 也可能存在于各仓库中，因此只删除
+主目录下的数据并不等于完整 purge。请用 `spotter prune` 执行受支持的 Git 感知清理，保留
+不确定的数据，并通过 [#89](https://github.com/spotter-agent/spotter/issues/89) 跟踪 purge 支持。
+
+如果在 teardown 前就卸载了软件包，生成的 Hook 会按设计采用 fail-open 行为。使用相同方式
+重新安装软件包，运行 `spotter teardown codex`，然后再次卸载，即可安全清理已记录的所有
+集成。
+
+## 10. 故障排查
+
+<details>
+<summary><strong>找不到 <code>spotter</code> 或 <code>spotterd</code></strong></summary>
+
+```bash
+command -v spotter
+command -v spotterd
+```
+
+对于 Homebrew，请确认 Formula 已安装且 Homebrew 的 `bin` 目录位于 `PATH`。对于手动安装，
+请激活目标虚拟环境。如果两个命令指向不同的安装根目录，请修正 `PATH`，然后重新运行
+`spotter setup codex` 和 `spotter doctor`。
+
+</details>
+
+<details>
+<summary><strong>设置找不到 Codex</strong></summary>
+
+```bash
+command -v codex
+codex --version
+spotter setup codex --dry-run
+```
+
+请在运行设置的同一登录环境中安装 Codex，或将它加入 `PATH`。如果使用自定义 `CODEX_HOME`，
+请在 setup、doctor 和日常 Codex 会话中保持一致。
+
+</details>
+
+<details>
+<summary><strong>守护进程不可用或构建不匹配</strong></summary>
+
+```bash
+spotter daemon status
+spotter daemon restart
+spotter setup codex
+spotter doctor
+```
+
+升级后重新运行 setup 是受支持的协调步骤。在 doctor 输出明确指出已注册服务本身有问题之前，
+不要手动编辑 `launchd` 或 `systemd --user` 定义。
+
+</details>
+
+<details>
+<summary><strong>Doctor 报告观察或实时控制不可用</strong></summary>
+
+目前不会自动选择 App Server 端点。如果 Hook 执行显示可用，确定性门控仍然工作；App Server
+观察和实时 `VERIFY`/`NUDGE` 则不可用。将这个已知产品边界当作安装错误前，请先检查
+[Status（英文）](status.md)。
+
+</details>
+
+<details>
+<summary><strong>配置解析失败或似乎被忽略</strong></summary>
+
+```bash
+spotter doctor --config /absolute/path/to/spotter.toml
+spotter setup codex --config /absolute/path/to/spotter.toml --dry-run
+```
+
+确认 `[main_agent]` 存在，并且 `adapter = "codex"` 是非空字符串。Setup 会把选定配置路径写入
+集成清单。如果已记录的配置变得不可用，Hook 会在 fail-open 边界内使用安全默认值，并将问题
+输出到 stderr。
+
+</details>
+
+<details>
+<summary><strong>没有显示会话或最近观察</strong></summary>
+
+设置后运行一次普通 Codex 会话，然后检查：
+
+```bash
+spotter status
+spotter doctor
+spotter observability
+```
+
+检查 Hook 所有权结果、最后观察时间，以及 Codex 会话是否使用了 setup 检查时相同的
+`CODEX_HOME`。
+
+</details>
+
+<details>
+<summary><strong>存储或权限检查失败</strong></summary>
+
+默认情况下，可变状态位于 `~/.spotter`，其中包括 `logs/`、`runtime/`、`sessions/` 和
+`integrations/`。确认当前用户拥有并可写入所配置的根目录。不要用宽泛的递归命令修改所有权；
+请检查 doctor 显示的准确失败路径。
+
+</details>
+
+<details>
+<summary><strong>未执行 teardown 就卸载了 Spotter</strong></summary>
+
+Codex 应继续运行，因为生成的 Hook 会采用 fail-open 行为。要清理 Spotter 所有的集成，请重新
+安装 Spotter，运行 `spotter doctor`，再运行 `spotter teardown codex`，最后再次卸载。
+
+</details>
+
+<p align="right"><a href="#spotter-安装与使用详细指南">返回顶部 ↑</a></p>
+
+## 11. 报告问题
+
+打开 [GitHub 议题选择器](https://github.com/spotter-agent/spotter/issues/new/choose)，根据请求选择
+错误、功能、文档、架构、实验或维护表单。
+
+一份有用的错误报告应包含：
+
+- 实际发生的情况、预期行为及影响；
+- 能稳定重现问题的最小步骤；
+- Homebrew 或手动安装方式；
+- 相关的 Spotter CLI/守护进程版本、Codex 版本、操作系统、架构和 Python 版本；
+- 失败的准确命令与退出码；
+- 相关的 `status`、`doctor` 和 `daemon status` 输出行；
+- 问题是否在 setup、升级、配置变更或重装后开始出现。
+
+通过以下命令收集基础诊断：
+
+```bash
+spotter --version
+spotterd --version
+codex --version
+spotter status
+spotter doctor
+spotter daemon status
+```
+
+请删去令牌、凭据、私有仓库名称和路径、提示词、源代码及个人信息。未经检查，不要附上原始
+日志、完整配置文件或完整运行日志。对于涉及安全或可被利用的问题，不要在公开议题中发布
+细节；请在仓库 Security 页面检查是否提供私密报告渠道。
+
+## 12. 相关文档
+
+- [Status（英文）](status.md) — 已实现能力与实验性能力的权威边界
+- [Lifecycle](lifecycle.md) — 软件包、服务、集成、恢复和移除的完整约定
+- [配置参考](../spotter.example.toml) — 当前已文档化的全部配置项
+- [Homebrew lifecycle smoke](homebrew-lifecycle-smoke.md) — 软件包生命周期证据
+- [Contributing](../CONTRIBUTING.md) — 源码设置与贡献流程


### PR DESCRIPTION
## Purpose

Make Spotter's current capabilities, installation path, and operational guidance easier to understand and find for English, Korean, and Simplified Chinese readers.

## What changed

- Restructure the main README around product value, current capabilities, installation, and common operations.
- Add Korean and Simplified Chinese README translations.
- Add detailed user guides in English, Korean, and Simplified Chinese covering installation, configuration, upgrades, troubleshooting, removal, and issue reporting.
- Update the documentation index, status landing page, and lifecycle navigation.
- Ignore local `.grepai/` index artifacts.

## Accuracy check

These documents describe current behavior and preserve the implemented-versus-experimental boundary from `docs/status.md`. Target architecture and lifecycle contracts remain in their existing source-of-truth documents. No runtime behavior or public API changed.

## Validation

- `git diff --check`
- Verified that local Markdown and HTML link targets exist across the nine changed documentation files.
- No code tests were run because this PR changes documentation only.

## Out of scope

- Runtime implementation changes
- Changes to architecture or lifecycle contracts