### PR TITLE
fix(metrics): require terminal evidence for never

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -742,6 +742,8 @@ post-window actions, failed outcomes, and files. Unrelated candidates never stop
 clock, stale annotations remain outside the distribution, and an open journal cannot become a
 fabricated `NEVER`. An observation gap crossing the measured interval also makes delay and
 post-window work `UNJUDGEABLE` rather than pretending the missing surface was quiet.
+`NEVER` requires a terminal turn/thread/session event at or after the annotated window; unrelated
+later activity in a still-live trajectory keeps the opportunity `UNJUDGEABLE` and re-derivable.
 
 ## 8.3 Snapshot state
 

--- a/src/spotter/opportunity_metrics.py
+++ b/src/spotter/opportunity_metrics.py
@@ -188,13 +188,14 @@ def _linked_signal(
 
 
 def _window_closed(latest: int, records: list[StepRecord]) -> bool:
-    if latest + 1 < len(records):
-        return True
-    return bool(
-        records
-        and records[latest].event.kind
-        in {"session_end", "thread_archived", "thread_closed", "thread_deleted", "turn_completed"}
-    )
+    terminal_kinds = {
+        "session_end",
+        "thread_archived",
+        "thread_closed",
+        "thread_deleted",
+        "turn_completed",
+    }
+    return any(record.event.kind in terminal_kinds for record in records[latest:])
 
 
 def _has_observation_gap(records: list[StepRecord]) -> bool:

--- a/tests/test_opportunity_metrics.py
+++ b/tests/test_opportunity_metrics.py
@@ -169,6 +169,16 @@ def test_stale_opportunity_is_unjudgeable_instead_of_counted_as_never() -> None:
 
 def test_open_window_without_a_signal_is_not_yet_a_never() -> None:
     records = _records()[:8]
+    records.append(
+        _record(
+            8,
+            "tool_proposal",
+            {},
+            event_id="later-live-action",
+            operation_id="op-later",
+            occurred_at=9.0,
+        )
+    )
     add_opportunity(
         "s1",
         "still-open",
@@ -178,7 +188,7 @@ def test_open_window_without_a_signal_is_not_yet_a_never() -> None:
         observable_earliest=7,
         observable_latest=7,
         required_evidence=(7,),
-        note="the session can still continue",
+        note="later activity does not prove the turn is terminal",
     )
 
     report = measure_opportunity_timing("s1", records)


### PR DESCRIPTION
## Why

The review of #212 identified that any later journal event closed an opportunity window. In a still-live turn, ordinary later activity does not prove a signal will never fire; reporting NEVER there would temporarily overstate detector misses.

## What changed

- classify an undetected opportunity as NEVER only when a terminal turn/thread/session event exists at or after the annotated window
- keep still-live windows UNJUDGEABLE even when unrelated actions appear later
- document that NEVER is terminal evidence and live opportunities remain re-derivable

## Validation

- `ruff format --check .`
- `ruff check .`
- `mypy src tests`
- `pytest` (620 passed)

Refs #24