### PR TITLE
feat(intervention): correlate observed advisories

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
 > **Status:** this document describes both the current hook-based prototype and the target architecture. Active implementation is tracked by the [Roadmap](roadmap.md) and native GitHub Milestones.
-> The `spotterd` process/control foundation, bounded Hook gate IPC, shared-server PoC, production App Server transport, durable Trace IR ingestion, daemon reconnect/reconciliation, and stable packaged runtime layout are implemented. Live supervision delivery remains **target behavior**.
+> The `spotterd` process/control foundation, bounded Hook gate IPC, shared-server PoC, production App Server transport, durable Trace IR ingestion, daemon reconnect/reconciliation, stable packaged runtime layout, and off-by-default live advisory delivery are implemented. Broader live enablement remains evidence-gated.
 
 ---
 
@@ -399,10 +399,15 @@ failure records. Terminal outcomes distinguish an RPC rejection (`failed`), loss
 dispatch (`unknown`), and an epoch/turn freshness rejection (`stale`). For steering, the same ID is
 sent as App Server `clientUserMessageId`; the normalized `userMessage.clientId` becomes
 `client_user_message_id`. Only a matching ID on the same thread, turn, and connection epoch counts
-as an observed adoption, and that observation must be durably ordered after its dispatch. A control
+as an observed adoption, and that observation must be durably ordered after its dispatch. The live
+reconciler annotates that input as `spotter_supervision`, journals a `control_observed_in_turn`
+outcome, and reduces the advisory into supervision state without replacing the authoritative user
+goal. A known intervention ID observed outside its target identity instead journals
+`control_observed_outside_target` with `expired_advisory_visible`; it is diagnostic evidence, not a
+new user goal. A control
 ID already present in durable runtime history is rejected before RPC; ambiguous legacy history with
 multiple dispatches for one ID is reported and excluded from adoption. RPC acceptance alone does
-not. `spotter metrics` reports same-clock
+not prove observation. `spotter metrics` reports same-clock
 dispatch and adoption latency, evidence-to-adoption latency, adoption lead/lag against the target
 turn boundary, and decision-to-stale-delivery latency with coverage denominators. Dispatch lifecycle
 records capture receipt timing inline but enter a bounded queue; journal locking, history recovery,

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -811,7 +811,10 @@ shadow-only unless active mode and the separate `reviewer.deliver_on_signals = t
 fresh signal-driven `VERIFY`/`NUDGE` decisions issue one current-turn advisory through the exact
 App Server attachment/turn/epoch. RPC acceptance, stale/failed/unknown outcomes, and later observed
 input remain distinct durable states; ambiguous acceptance is never blindly retried. Both options
-are off by default, and configured session/day ceilings are enforced before inference.
+are off by default, and configured session/day ceilings are enforced before inference. A correlated
+advisory input is tagged as Spotter supervision before live-state reduction, so it cannot replace the
+user goal. Exact-target observation becomes `control_observed_in_turn`; the same intervention ID
+appearing outside its target becomes an `expired_advisory_visible` diagnostic instead of a new goal.
 
 At journal append, each lifecycle record receives local receipt wall time plus a monotonic timestamp
 and process clock-domain ID. Metrics correlate evidence, candidate, queue, start, and terminal events

--- a/docs/status.md
+++ b/docs/status.md
@@ -27,11 +27,11 @@
     </td>
     <td width="33%" valign="top">
       <strong>🟡 Partial or shadow</strong><br />
-      <sub>App Server observation, live state, event-driven detection, and semantic review.</sub>
+      <sub>App Server observation, live state, event-driven detection, semantic review, and opt-in live advisories.</sub>
     </td>
     <td width="33%" valign="top">
       <strong>❌ Not live yet</strong><br />
-      <sub>Delivered <code>VERIFY</code>/<code>NUDGE</code> and live recovery interventions.</sub>
+      <sub>Broadly enabled <code>VERIFY</code>/<code>NUDGE</code> and live recovery interventions.</sub>
     </td>
   </tr>
 </table>
@@ -144,7 +144,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Managed Codex lifecycle | 🟡 | Transactional setup/teardown, managed service, diagnostics, configured-endpoint recovery, and temporary observation Hooks until #86 parity | Add verified endpoint selection without claiming shared-process ownership |
 | Runtime reconnect/recovery | ✅ | Explicit connect/reconcile/backoff states, restart hydration, durable gaps, capability/server fingerprints, and stale-control fencing | Add retention/checkpoints in #89 |
 | Event-driven detection | 🟡 | All eight initial families journal identity/evidence-rich active, cooled-down, resolved, and stale candidates for explicit normalized failures, equivalent calls, frontierless reads, deterministic-block recurrence, request-scope growth, scope-matched unvalidated edits, causal stale-hypothesis reuse, and relative token/duration pressure; opted-in active candidates merge into priority-ordered, budget-capped asynchronous reviews with bounded immutable inputs, while stale targets never deliver; queue/decision provenance and metrics now stratify signal, periodic, and manual launches | Compare event-driven, periodic-only, and mixed fallback-cadence precision/cost in #38/#24 using #33 telemetry |
-| Live `VERIFY` / `NUDGE` | 🟡 | Separate off-by-default opt-in delivers fresh signal-driven decisions once through exact attachment/turn/epoch `turn/steer`, with current-turn advisory provenance and durable acceptance/outcome telemetry | Test task ownership, terminal races, and history contamination in #22/#23 before broader enablement |
+| Live `VERIFY` / `NUDGE` | 🟡 | Separate off-by-default opt-in delivers fresh signal-driven decisions once through exact attachment/turn/epoch `turn/steer`; correlated inputs become durable observed-in-turn outcomes, remain supervision rather than replacing the user goal in live state, and surface outside-target appearances as expired-advisory diagnostics | Test terminal races and history contamination in #22/#23 before broader enablement |
 | `INTERRUPT` / `RESTART` | ❌ | No live recovery path | #26 + #30 after soft intervention is understood |
 | Packaging / long-term operations | 🟡 | Exact version tags publish verified release artifacts; the dedicated Homebrew tap installs immutable releases and opens repeatable Formula-update PRs; the macOS lifecycle gate proves clean install, live G1→G2 upgrade/reconcile, teardown-less fail-open uninstall, retained data, and reinstall/teardown without Cellar assumptions | #89 retention/purge and #90 broader configuration/protocol/schema compatibility |
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -328,7 +328,10 @@ also followed through control dispatch and RPC acceptance/terminal outcome; miss
 unknown, and gap-crossed control stages stay visible rather than receiving fabricated delay.
 Accepted steers count as adopted only when their client message ID is observed on the exact target
 thread, turn, and connection epoch. Target completion without that evidence remains
-`RPC_ACCEPTED_ONLY`; stale-after-accept and identity/gap-limited cases remain explicit.
+`RPC_ACCEPTED_ONLY`; stale-after-accept and identity/gap-limited cases remain explicit. Spotter-tagged
+advisory inputs stay in supervision state rather than replacing the user goal. If a known advisory
+ID appears outside its target turn or connection epoch, Spotter records an expired-advisory
+diagnostic for later safety evaluation.
 
 ### Storage maintenance
 

--- a/src/spotter/runtime_connection.py
+++ b/src/spotter/runtime_connection.py
@@ -137,6 +137,7 @@ class AppServerRecoveryLoop:
         self._control_telemetry_writer: asyncio.Task[None] | None = None
         self._control_telemetry_ids: set[str] = set()
         self._control_request_ids: set[str] = set()
+        self._control_requests: dict[str, dict[str, object]] = {}
 
         records = self.ingestor.records()
         self._control_telemetry_ids.update(
@@ -151,6 +152,15 @@ class AppServerRecoveryLoop:
             and isinstance(control_id, str)
             and control_id
         )
+        for record in records:
+            control_id = record.event.payload.get("control_id")
+            if (
+                isinstance(control_id, str)
+                and control_id
+                and record.event.payload.get("intervention_id") == control_id
+                and record.event.payload.get("outcome") != "stale"
+            ):
+                self._control_requests.setdefault(control_id, dict(record.event.payload))
         if records:
             self.thread_states.hydrate(records)
             for candidate, trigger in self.signals.hydrate(records):
@@ -336,6 +346,8 @@ class AppServerRecoveryLoop:
             )
             raise
 
+        if payload.get("intervention_id") == request_id:
+            self._control_requests[request_id] = dict(payload)
         self._record_control_event("control_dispatch_started", target, payload)
         try:
             if control_kind == "steer":
@@ -554,6 +566,7 @@ class AppServerRecoveryLoop:
                     identity=self._epoch_identity(event.identity, attachment_id),
                     connection_epoch=epoch,
                 )
+                event = self._annotate_intervention_input(event)
                 record = self._record(event)
                 state_status = None
                 if (
@@ -706,6 +719,8 @@ class AppServerRecoveryLoop:
         except ThreadStateError:
             state_before = None
         state = self.thread_states.observe(record.event)
+        if (observation := self._intervention_observation(record.event)) is not None:
+            self._append_derived(observation)
         self._record_review_transitions(
             self.review_scheduler.update(record.event, state_before, state)
         )
@@ -720,6 +735,75 @@ class AppServerRecoveryLoop:
                 self.review_scheduler.update_candidates(candidate_events, state, current)
             )
         return record
+
+    def _annotate_intervention_input(self, event: TraceEvent) -> TraceEvent:
+        if event.kind != "user_prompt":
+            return event
+        control_id = event.payload.get("client_user_message_id")
+        control = self._control_requests.get(control_id) if isinstance(control_id, str) else None
+        if control is None or control.get("intervention_id") != control_id:
+            return event
+        identity = event.identity
+        exact_target = (
+            identity is not None
+            and identity.turn_id is not None
+            and identity.turn_id.value == control.get("target_turn_id")
+            and event.connection_epoch == control.get("target_connection_epoch")
+            and (
+                identity.attachment_id is None
+                or identity.attachment_id.value == control.get("runtime_attachment_id")
+            )
+        )
+        return replace(
+            event,
+            payload={
+                **event.payload,
+                "input_origin": "spotter_supervision",
+                "intervention_id": control_id,
+                "review_job_id": control.get("review_job_id"),
+                "supervision_scope": control.get("supervision_scope"),
+                "must_not_become_user_goal": control.get("must_not_become_user_goal"),
+                "expires_on": control.get("expires_on"),
+                "intervention_relation": "target_turn" if exact_target else "outside_target",
+            },
+        )
+
+    def _intervention_observation(self, event: TraceEvent) -> TraceEvent | None:
+        if (
+            event.kind != "user_prompt"
+            or event.payload.get("input_origin") != "spotter_supervision"
+        ):
+            return None
+        control_id = event.payload.get("intervention_id")
+        if not isinstance(control_id, str) or not control_id:
+            return None
+        relation = event.payload.get("intervention_relation")
+        in_target = relation == "target_turn"
+        control = self._control_requests.get(control_id, {})
+        payload = {
+            **control,
+            "control_id": control_id,
+            "intervention_id": control_id,
+            "outcome": "observed_in_turn" if in_target else "observed_outside_target",
+            "observed_input_event_id": event.event_id,
+        }
+        if not in_target:
+            payload["reason_code"] = "expired_advisory_visible"
+        return TraceEvent(
+            "control_observed_in_turn" if in_target else "control_observed_outside_target",
+            payload,
+            event_id=(
+                f"spotter:control:{control_id}:observed_in_turn"
+                if in_target
+                else f"spotter:control:{control_id}:observed_outside_target:{event.event_id}"
+            ),
+            occurred_at=event.occurred_at,
+            identity=event.identity,
+            provenance=TraceProvenance("spotterd", "control_reconciliation"),
+            connection_epoch=event.connection_epoch,
+            observed_monotonic_ns=event.observed_monotonic_ns,
+            monotonic_clock_id=event.monotonic_clock_id,
+        )
 
     def _record_review_transitions(self, transitions: tuple[TraceEvent, ...]) -> None:
         for transition in transitions:

--- a/src/spotter/thread_state.py
+++ b/src/spotter/thread_state.py
@@ -271,6 +271,22 @@ class ThreadStateReducer:
         )
         if event.kind == "user_prompt":
             text = _user_text(event.payload)
+            if event.payload.get("input_origin") == "spotter_supervision":
+                if not text:
+                    return state
+                intervention = StateItem(
+                    item_id,
+                    StateItemKind.INTERVENTION,
+                    text,
+                    provenance,
+                )
+                return replace(
+                    state,
+                    supervision=replace(
+                        state.supervision,
+                        interventions=_bounded(state.supervision.interventions + (intervention,)),
+                    ),
+                )
             if text:
                 goal = StateItem(item_id, StateItemKind.GOAL, text, provenance)
                 previous = state.task.goal

--- a/tests/test_runtime_connection.py
+++ b/tests/test_runtime_connection.py
@@ -3,6 +3,7 @@ import json
 import threading
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
 
@@ -10,6 +11,7 @@ import pytest
 from websockets.asyncio.server import ServerConnection, serve
 
 from spotter.app_server import AppServerRpcError, AppServerTransportError
+from spotter.identity import TurnId
 from spotter.runtime_connection import (
     AppServerRecoveryLoop,
     RecoveryState,
@@ -376,6 +378,127 @@ def test_control_rpc_does_not_wait_for_bounded_telemetry_io(
             assert controls[0].at is not None and controls[1].at is not None
             assert controls[0].at <= controls[1].at
             assert recovery.metrics.control_telemetry_errors == 0
+            await recovery.close()
+
+    asyncio.run(scenario())
+
+
+def test_intervention_input_is_correlated_without_replacing_user_goal(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await _initialize(connection)
+            listed = await _receive(connection, "thread/list")
+            await _reply(
+                connection,
+                listed,
+                {"data": [{"id": "thread-1"}], "nextCursor": None},
+            )
+            read = await _receive(connection, "thread/read")
+            await _reply(
+                connection,
+                read,
+                {
+                    "thread": {
+                        "id": "thread-1",
+                        "turns": [{"id": "turn-1", "status": "active"}],
+                    }
+                },
+            )
+            request = await _receive(connection, "turn/steer")
+            await _reply(connection, request, {"turnId": "turn-1"})
+            await connection.send(
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "method": "item/completed",
+                        "params": {
+                            "threadId": "thread-1",
+                            "turnId": "turn-1",
+                            "item": {
+                                "id": "spotter-message-1",
+                                "type": "userMessage",
+                                "clientId": "spotter:intervention:job-1",
+                                "content": [
+                                    {"type": "text", "text": "Verify the retry assumption"}
+                                ],
+                            },
+                        },
+                    }
+                )
+            )
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            recovery = AppServerRecoveryLoop(endpoint, tmp_path / "sessions", ThreadStateStore())
+            await recovery.start()
+            await _wait_until(lambda: recovery.state == RecoveryState.READY)
+            state = recovery.thread_states.snapshots()[0]
+            recovery._record(
+                TraceEvent(
+                    "user_prompt",
+                    {"prompt": "Fix the original bug"},
+                    event_id="original-goal",
+                    identity=state.identity,
+                    connection_epoch=state.connection_epoch,
+                )
+            )
+            target = RuntimeControlTarget(state.identity, state.connection_epoch or 0)
+
+            await recovery.steer(
+                target,
+                "Verify the retry assumption",
+                control_id="spotter:intervention:job-1",
+                review_job_id="job-1",
+            )
+            await _wait_until(
+                lambda: any(
+                    record.event.kind == "control_observed_in_turn"
+                    for record in recovery.ingestor.records()
+                )
+            )
+            await recovery.flush_control_telemetry()
+
+            records = [record.event for record in recovery.ingestor.records()]
+            prompt = next(
+                event
+                for event in records
+                if event.kind == "user_prompt"
+                and event.payload.get("client_user_message_id") == "spotter:intervention:job-1"
+            )
+            observed = next(event for event in records if event.kind == "control_observed_in_turn")
+            current = recovery.thread_states.snapshots()[0]
+            assert prompt.payload["input_origin"] == "spotter_supervision"
+            assert prompt.payload["intervention_relation"] == "target_turn"
+            assert observed.payload["outcome"] == "observed_in_turn"
+            assert observed.payload["observed_input_event_id"] == prompt.event_id
+            assert current.task.goal is not None
+            assert current.task.goal.text == "Fix the original bug"
+            assert current.supervision.interventions[-1].text == "Verify the retry assumption"
+
+            later_identity = replace(
+                state.identity,
+                turn_id=TurnId("turn-2"),
+                provenance=replace(state.identity.provenance, agent_turn_id="turn-2"),
+            )
+            leaked = recovery._annotate_intervention_input(
+                TraceEvent(
+                    "user_prompt",
+                    {"client_user_message_id": "spotter:intervention:job-1", "prompt": "old"},
+                    event_id="leaked-advisory",
+                    identity=later_identity,
+                    connection_epoch=state.connection_epoch,
+                )
+            )
+            recovery._record(leaked)
+            leaked_observation = next(
+                record.event
+                for record in recovery.ingestor.records()
+                if record.event.kind == "control_observed_outside_target"
+            )
+            assert leaked.payload["intervention_relation"] == "outside_target"
+            assert leaked_observation.payload["outcome"] == "observed_outside_target"
+            assert leaked_observation.payload["reason_code"] == "expired_advisory_visible"
+            assert recovery.thread_states.snapshots()[0].task.goal.text == "Fix the original bug"  # type: ignore[union-attr]
             await recovery.close()
 
     asyncio.run(scenario())

--- a/tests/test_thread_state.py
+++ b/tests/test_thread_state.py
@@ -159,6 +159,30 @@ def test_interleaved_threads_remain_isolated() -> None:
     )
 
 
+def test_spotter_advisory_input_does_not_replace_the_user_goal() -> None:
+    store = ThreadStateStore()
+    original = store.observe(
+        _event("user_prompt", {"prompt": "Fix the login timeout"}, event_id="goal")
+    )
+
+    advised = store.observe(
+        _event(
+            "user_prompt",
+            {
+                "content": [{"type": "text", "text": "Verify the retry assumption"}],
+                "client_user_message_id": "spotter:intervention:job-1",
+                "input_origin": "spotter_supervision",
+                "intervention_relation": "target_turn",
+            },
+            event_id="advisory",
+        )
+    )
+
+    assert advised.task.goal == original.task.goal
+    assert advised.evidence.items == original.evidence.items
+    assert advised.supervision.interventions[-1].text == "Verify the retry assumption"
+
+
 def test_snapshot_is_deeply_immutable_and_version_anchored() -> None:
     store = ThreadStateStore()
     snapshot = store.observe(_event("user_prompt", {"prompt": "Goal"}, event_id="goal"))


### PR DESCRIPTION
## Why

Live `turn/steer` inputs are serialized by Codex as user messages. Without Spotter-owned correlation, the live-state reducer can mistake its own advisory for a new authoritative user goal, and RPC acceptance remains indistinguishable from an input actually observed on the target turn.

## What changed

- correlate known intervention `clientUserMessageId` values to their durable control request and exact attachment/turn/epoch
- journal `control_observed_in_turn` when the advisory input appears on its intended target
- journal `control_observed_outside_target` / `expired_advisory_visible` when the same intervention appears outside its scope
- tag correlated inputs as Spotter supervision so ThreadState preserves the original user goal
- cover exact-target adoption, later-target leakage, and task-ownership reduction behavior
- update architecture, lifecycle, status, and user guidance for the live contract

## Validation

- `ruff format --check .`
- `ruff check .`
- `mypy src tests`
- `pytest` (630 passed)

Refs #22