### PR TITLE
fix(effects): parse clustered curl options

### DIFF
--- a/src/spotter/effects.py
+++ b/src/spotter/effects.py
@@ -112,6 +112,37 @@ _SCRIPT_RUNNERS = frozenset(
 )
 _HTTP_READ_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 _HTTP_WRITE_METHODS = frozenset({"DELETE", "PATCH", "POST", "PUT"})
+_CURL_BOOLEAN_SHORT_OPTIONS = frozenset("#0123456789:BaGfghiIJjklLMnNOqRSsvVZ")
+_CURL_VALUE_SHORT_OPTIONS = frozenset(
+    {
+        "A",
+        "b",
+        "C",
+        "c",
+        "D",
+        "d",
+        "E",
+        "e",
+        "F",
+        "H",
+        "K",
+        "m",
+        "o",
+        "P",
+        "Q",
+        "r",
+        "T",
+        "t",
+        "U",
+        "u",
+        "w",
+        "X",
+        "x",
+        "Y",
+        "y",
+        "z",
+    }
+)
 _SQL_READ_VERBS = frozenset({"DESC", "DESCRIBE", "SHOW"})
 _SQL_WRITE_VERBS = frozenset(
     {
@@ -389,8 +420,14 @@ def _classify_terraform(words: Sequence[str], values: dict[str, Any]) -> Classif
 
 
 def _classify_curl(words: Sequence[str], values: dict[str, Any]) -> Classification:
+    normalized = _normalize_curl_args(words)
+    if normalized is None:
+        return _unknown("unsupported_curl_cluster", "http", "curl")
+    words = normalized
     if _has_option_prefix(words, "-K", "--config") or _has_option(words, "-:", "--next"):
         return _unknown("unsupported_curl_shape", "http", "curl")
+    if _has_option(words, "-Q", "--quote"):
+        return _unknown("unsupported_curl_remote_command", "http", "curl")
     url = _curl_url(words)
     if url is None:
         return _unknown("missing_http_resource", "http", "curl")
@@ -636,22 +673,12 @@ def _option_values(words: Sequence[str], *names: str) -> list[str]:
             if len(name) == 2 and token.startswith(name) and len(token) > len(name):
                 values.append(token[len(name) :])
                 break
-            if len(name) == 2 and _short_cluster_contains(token, name[1]):
-                suffix = token[token.index(name[1], 1) + 1 :]
-                if suffix:
-                    values.append(suffix)
-                elif index + 1 < len(words):
-                    values.append(words[index + 1])
-                break
     return values
 
 
 def _has_option(words: Sequence[str], *names: str) -> bool:
     return any(
-        token in names
-        or any(token.startswith(name + "=") for name in names)
-        or any(len(name) == 2 and _short_cluster_contains(token, name[1]) for name in names)
-        for token in words
+        token in names or any(token.startswith(name + "=") for name in names) for token in words
     )
 
 
@@ -662,17 +689,44 @@ def _has_option_prefix(words: Sequence[str], *names: str) -> bool:
                 return True
             if len(name) == 2 and token.startswith(name) and len(token) > len(name):
                 return True
-            if len(name) == 2 and _short_cluster_contains(token, name[1]):
-                return True
     return False
 
 
 def _has_short_flag(words: Sequence[str], flag: str) -> bool:
-    return any(token == f"-{flag}" or _short_cluster_contains(token, flag) for token in words)
+    return any(token == f"-{flag}" for token in words)
 
 
-def _short_cluster_contains(token: str, flag: str) -> bool:
-    return token.startswith("-") and not token.startswith("--") and flag in token[1:]
+def _normalize_curl_args(words: Sequence[str]) -> list[str] | None:
+    normalized: list[str] = []
+    index = 0
+    while index < len(words):
+        token = words[index]
+        if not token.startswith("-") or token.startswith("--") or token == "-":
+            normalized.append(token)
+            index += 1
+            continue
+        cluster = token[1:]
+        offset = 0
+        while offset < len(cluster):
+            option = cluster[offset]
+            if option in _CURL_BOOLEAN_SHORT_OPTIONS:
+                normalized.append(f"-{option}")
+                offset += 1
+                continue
+            if option not in _CURL_VALUE_SHORT_OPTIONS:
+                return None
+            normalized.append(f"-{option}")
+            attached = cluster[offset + 1 :]
+            if attached:
+                normalized.append(attached)
+            elif index + 1 < len(words):
+                index += 1
+                normalized.append(words[index])
+            else:
+                return None
+            break
+        index += 1
+    return normalized
 
 
 def _executable(value: str) -> str:

--- a/src/spotter/effects.py
+++ b/src/spotter/effects.py
@@ -636,12 +636,22 @@ def _option_values(words: Sequence[str], *names: str) -> list[str]:
             if len(name) == 2 and token.startswith(name) and len(token) > len(name):
                 values.append(token[len(name) :])
                 break
+            if len(name) == 2 and _short_cluster_contains(token, name[1]):
+                suffix = token[token.index(name[1], 1) + 1 :]
+                if suffix:
+                    values.append(suffix)
+                elif index + 1 < len(words):
+                    values.append(words[index + 1])
+                break
     return values
 
 
 def _has_option(words: Sequence[str], *names: str) -> bool:
     return any(
-        token in names or any(token.startswith(name + "=") for name in names) for token in words
+        token in names
+        or any(token.startswith(name + "=") for name in names)
+        or any(len(name) == 2 and _short_cluster_contains(token, name[1]) for name in names)
+        for token in words
     )
 
 
@@ -652,15 +662,17 @@ def _has_option_prefix(words: Sequence[str], *names: str) -> bool:
                 return True
             if len(name) == 2 and token.startswith(name) and len(token) > len(name):
                 return True
+            if len(name) == 2 and _short_cluster_contains(token, name[1]):
+                return True
     return False
 
 
 def _has_short_flag(words: Sequence[str], flag: str) -> bool:
-    return any(
-        token == f"-{flag}"
-        or (token.startswith("-") and not token.startswith("--") and flag in token[1:])
-        for token in words
-    )
+    return any(token == f"-{flag}" or _short_cluster_contains(token, flag) for token in words)
+
+
+def _short_cluster_contains(token: str, flag: str) -> bool:
+    return token.startswith("-") and not token.startswith("--") and flag in token[1:]
 
 
 def _executable(value: str) -> str:
@@ -741,7 +753,11 @@ def _sanitize_remote_resource(value: str) -> str:
         parsed = urlsplit(value)
         port = parsed.port
     except ValueError:
-        return value.partition("?")[0].partition("#")[0][:300]
+        without_query = value.partition("?")[0].partition("#")[0]
+        scheme, separator, remainder = without_query.partition("://")
+        if separator:
+            return f"{scheme}{separator}{remainder.rsplit('@', 1)[-1]}"[:300]
+        return without_query[:300]
     if not parsed.scheme or not parsed.hostname:
         return value.partition("?")[0].partition("#")[0][:300]
     host = parsed.hostname

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -207,6 +207,43 @@ def test_curl_unknown_shapes_never_inherit_get_semantics() -> None:
     )
 
 
+def test_curl_clustered_short_options_preserve_methods_and_local_outputs() -> None:
+    download = classify(
+        "Bash",
+        {"command": "curl -so result.json https://api.example.com/items"},
+    )
+    post = classify(
+        "Bash",
+        {"command": "curl -sXPOST https://api.example.com/items"},
+    )
+    data = classify(
+        "Bash",
+        {"command": "curl -sd payload https://api.example.com/items"},
+    )
+    config = classify(
+        "Bash",
+        {"command": "curl -sKrequest.conf https://api.example.com/items"},
+    )
+
+    assert (download.reversibility_class, download.resource) == (
+        "B",
+        "result.json <- https://api.example.com/items",
+    )
+    assert (post.reversibility_class, post.semantic_operation) == ("C", "http.post")
+    assert (data.reversibility_class, data.semantic_operation) == ("C", "http.post")
+    assert config.reason_code == "unsupported_curl_shape"
+
+
+def test_invalid_url_port_fallback_still_redacts_credentials() -> None:
+    assessment = classify(
+        "Bash",
+        {"command": ("curl 'https://user:secret@example.com:99999/items?token=secret#fragment'")},
+    )
+
+    assert assessment.reversibility_class == "A"
+    assert assessment.resource == "https://example.com:99999/items"
+
+
 def test_database_cli_classification_limits_reads_to_bounded_metadata_queries() -> None:
     postgres_list = classify(
         "Bash",

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -224,6 +224,14 @@ def test_curl_clustered_short_options_preserve_methods_and_local_outputs() -> No
         "Bash",
         {"command": "curl -sKrequest.conf https://api.example.com/items"},
     )
+    data_with_flag_letters = classify(
+        "Bash",
+        {"command": "curl -dsize=BIG https://api.example.com/items"},
+    )
+    unknown_cluster = classify(
+        "Bash",
+        {"command": "curl -s@ https://api.example.com/items"},
+    )
 
     assert (download.reversibility_class, download.resource) == (
         "B",
@@ -231,7 +239,12 @@ def test_curl_clustered_short_options_preserve_methods_and_local_outputs() -> No
     )
     assert (post.reversibility_class, post.semantic_operation) == ("C", "http.post")
     assert (data.reversibility_class, data.semantic_operation) == ("C", "http.post")
+    assert (
+        data_with_flag_letters.reversibility_class,
+        data_with_flag_letters.semantic_operation,
+    ) == ("C", "http.post")
     assert config.reason_code == "unsupported_curl_shape"
+    assert unknown_cluster.reason_code == "unsupported_curl_cluster"
 
 
 def test_invalid_url_port_fallback_still_redacts_credentials() -> None:


### PR DESCRIPTION
## Why

The #228 review identified two fidelity gaps after merge: common clustered curl output flags such as `-so` could stay Class A instead of local-write Class B, and malformed-port URL fallback could retain userinfo.

## What changed

- parse value-taking short options inside bounded clusters (`-so`, `-sXPOST`, `-sd`, `-sKfile`)
- reuse clustered recognition for boolean/presence checks so config-driven requests still refuse classification
- strip userinfo in the invalid-URL fallback before persisting the resource
- add regressions for output, POST/data, config, and malformed-port credential cases

## Validation

- ruff format --check .
- ruff check .
- mypy src tests
- SPOTTER_HOME=/tmp/spotter-test-home.wvWzFP pytest (656 passed)

Refs #98