### PR TITLE
fix(lifecycle): stabilize integration preview

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1398,7 +1398,7 @@ checks every recorded Hook entry, reconstructs and compares the managed service 
 manifest runtime layout, validates backup content against its fingerprinted filename, and reports
 the manifest and companion lock. Recorded resources already absent remain safely idempotent;
 unrecorded or modified Spotter-like Hooks, changed services/backups, future or legacy manifests,
-non-regular paths, and unknown integration-directory entries remain ambiguous. The preview is
+orphan locks, non-regular paths, and unknown integration-directory entries remain ambiguous. The preview is
 non-mutating and destructive `--integration` remains disabled.
 
 `purge --snapshots` removes only exact `SAFE_OWNED`, unreferenced registered worktrees and snapshot

--- a/src/spotter/integration_inventory.py
+++ b/src/spotter/integration_inventory.py
@@ -78,10 +78,8 @@ class IntegrationInventory:
                 or raw.get("schema_version") != MANIFEST_SCHEMA_VERSION
             ):
                 raise IntegrationError("manifest does not match the current exact schema")
-            manifest = IntegrationManifest.load(self.manifest_path)
-            if manifest is None:
-                raise IntegrationError("manifest disappeared during inspection")
-        except (OSError, ValueError, IntegrationError) as error:
+            manifest = IntegrationManifest(**raw)
+        except (OSError, ValueError, TypeError, IntegrationError) as error:
             inspections.append(self._ambiguous("manifest", self.manifest_path, str(error)))
             return None
         inspections.append(self._safe("manifest", self.manifest_path, "current manifest schema"))
@@ -112,6 +110,10 @@ class IntegrationInventory:
                         inspections.append(self._ambiguous("lock", entry, "not a regular file"))
                     elif manifest is not None:
                         inspections.append(self._safe("lock", entry, "manifest companion lock"))
+                    else:
+                        inspections.append(
+                            self._ambiguous("lock", entry, "lock has no ownership manifest")
+                        )
                 continue
             inspections.append(self._ambiguous("integration_file", entry, "unrecognized entry"))
         return inspections

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -301,7 +301,25 @@ def test_integration_inventory_surfaces_hooks_without_manifest(
 
     inspections = IntegrationInventory(manager.layout, manager.codex_home).inspect()
 
-    assert sum(item.confidence.value == "AMBIGUOUS" for item in inspections) == 4
+    assert sum(item.confidence.value == "AMBIGUOUS" for item in inspections) == 5
+    assert any(item.resource_type == "lock" for item in inspections)
+
+
+def test_integration_inventory_constructs_manifest_from_validated_bytes(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manager, _ = _manager(homes)
+    manager.setup()
+
+    monkeypatch.setattr(
+        IntegrationManifest,
+        "load",
+        lambda _: (_ for _ in ()).throw(AssertionError("manifest must not be read twice")),
+    )
+
+    inspections = IntegrationInventory(manager.layout, manager.codex_home).inspect()
+
+    assert any(item.resource_type == "manifest" for item in inspections)
 
 
 def test_integration_inventory_verifies_service_definition(


### PR DESCRIPTION
## Why

PR #263 review identified two non-blocking consistency gaps that should be closed before destructive integration purge: manifest validation and construction used separate reads, and an orphan regular codex.lock was invisible without a manifest.

Related: #89

## What changed

- Construct IntegrationManifest directly from the exact bytes whose current schema was validated, eliminating the read-to-read race.
- Report a regular codex.lock without an ownership manifest as AMBIGUOUS while continuing to leave it untouched.
- Add regression tests proving the inventory does not call the second-read loader and surfaces all no-manifest Hook/lock residue.
- Document orphan lock visibility in the lifecycle contract.

## Validation

- ruff format --check .
- ruff check .
- mypy src tests
- pytest (814 passed)

## Notes

This remains a non-mutating preview. Destructive integration cleanup follows after this ownership snapshot is stable.