### PR TITLE
feat(app-server): expose turn start

### DIFF
--- a/src/spotter/app_server.py
+++ b/src/spotter/app_server.py
@@ -289,6 +289,33 @@ class CodexAppServerClient:
     async def resume_thread(self, thread_id: str) -> Mapping[str, Any]:
         return await self._object_request("thread/resume", {"threadId": thread_id})
 
+    async def start_turn(
+        self,
+        thread_id: str,
+        text: str,
+        *,
+        cwd: str | None = None,
+        client_user_message_id: str | None = None,
+    ) -> Mapping[str, Any]:
+        """Start a turn without exposing Codex JSON-RPC shapes to callers."""
+
+        if not text.strip():
+            raise ValueError("turn input must be non-empty")
+        params: JsonObject = {
+            "threadId": thread_id,
+            "input": [{"type": "text", "text": text}],
+        }
+        if cwd is not None:
+            if not cwd.strip():
+                raise ValueError("cwd must be non-empty")
+            params["cwd"] = cwd
+            params["runtimeWorkspaceRoots"] = [cwd]
+        if client_user_message_id is not None:
+            if not client_user_message_id.strip():
+                raise ValueError("client_user_message_id must be non-empty")
+            params["clientUserMessageId"] = client_user_message_id
+        return await self._object_request("turn/start", params)
+
     async def steer(
         self,
         thread_id: str,

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -131,11 +131,20 @@ def test_thread_queries_and_controls_hide_codex_method_names() -> None:
             for method, result in [
                 ("thread/read", {"thread": {"id": "thread-1"}}),
                 ("thread/resume", {"thread": {"id": "thread-1"}}),
+                ("turn/start", {"turn": {"id": "turn-1"}}),
                 ("turn/steer", {"turnId": "turn-1"}),
                 ("turn/interrupt", {}),
             ]:
                 request = await _receive(connection, method)
-                if method == "turn/steer":
+                if method == "turn/start":
+                    assert request["params"] == {
+                        "threadId": "thread-1",
+                        "input": [{"type": "text", "text": "continue the task"}],
+                        "cwd": "/tmp/fork",
+                        "runtimeWorkspaceRoots": ["/tmp/fork"],
+                        "clientUserMessageId": "experiment-control-1",
+                    }
+                elif method == "turn/steer":
                     assert request["params"] == {
                         "threadId": "thread-1",
                         "expectedTurnId": "turn-1",
@@ -151,6 +160,14 @@ def test_thread_queries_and_controls_hide_codex_method_names() -> None:
             assert (await client.read_thread("thread-1"))["thread"] == {"id": "thread-1"}
             await client.resume_thread("thread-1")
             assert (
+                await client.start_turn(
+                    "thread-1",
+                    "continue the task",
+                    cwd="/tmp/fork",
+                    client_user_message_id="experiment-control-1",
+                )
+            )["turn"] == {"id": "turn-1"}
+            assert (
                 await client.steer(
                     "thread-1",
                     "turn-1",
@@ -163,6 +180,25 @@ def test_thread_queries_and_controls_hide_codex_method_names() -> None:
             assert client.capabilities.steer == CapabilityStatus.AVAILABLE
             assert client.capabilities.interrupt == CapabilityStatus.AVAILABLE
             await client.disconnect()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    (
+        {"text": ""},
+        {"text": "continue", "cwd": " "},
+        {"text": "continue", "client_user_message_id": ""},
+    ),
+)
+def test_turn_start_rejects_empty_inputs_before_rpc(kwargs: dict[str, str]) -> None:
+    async def scenario() -> None:
+        client = CodexAppServerClient("ws://unused")
+        values = kwargs.copy()
+        text = values.pop("text")
+        with pytest.raises(ValueError):
+            await client.start_turn("thread-1", text, **values)
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## Why

The #23 real-steer experiment runner must start the neutral continuation on each prepared replay fork before it can inject a wrong nudge into that exact active turn.

Refs #23.

## What changed

- add a typed `start_turn` adapter to the Codex App Server client
- keep JSON-RPC method/shape details behind the adapter boundary
- override both cwd and runtime workspace roots to the prepared fork worktree
- support durable client user-message correlation for the continuation input
- reject empty turn input, cwd, or correlation IDs before dispatch

## Validation

- `ruff format --check .`
- `ruff check .`
- `mypy src tests`
- `pytest` (916 passed)