### PR TITLE
feat(site): launch GitHub Pages project site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,59 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/pages.yml"
+      - "docs/assets/main.png"
+      - "docs/assets/social-preview.png"
+      - "site/**"
+  pull_request:
+    paths:
+      - ".github/workflows/pages.yml"
+      - "docs/assets/main.png"
+      - "docs/assets/social-preview.png"
+      - "site/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build static site
+        run: python site/build.py
+      - name: Validate links and metadata
+        run: python site/check.py site/_build
+      - name: Configure Pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@v5
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/_build
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ __pycache__/
 .venv/
 build/
 dist/
+site/_build/
 
 .grepai/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 <p>
   <a href="#install"><strong>Install</strong></a>&nbsp;&nbsp;·&nbsp;&nbsp;
   <a href="#connect-spotter-to-codex"><strong>Quick start</strong></a>&nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="https://spotter-agent.github.io/spotter/"><strong>Project site</strong></a>&nbsp;&nbsp;·&nbsp;&nbsp;
   <a href="docs/user-guide.md"><strong>Detailed guide</strong></a>&nbsp;&nbsp;·&nbsp;&nbsp;
   <a href="docs/status.md">Current status</a>&nbsp;&nbsp;·&nbsp;&nbsp;
   <a href="docs/README.md">Documentation</a>

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,30 @@
+# Spotter project site
+
+This directory is the source for <https://spotter-agent.github.io/spotter/>. The site is a
+dependency-free static entry point; detailed and fast-changing implementation information remains
+canonical in the repository documentation.
+
+## Preview and validate
+
+From the repository root:
+
+```bash
+python site/build.py
+python site/check.py site/_build
+python -m http.server --directory site/_build 8000
+```
+
+Then open <http://localhost:8000>. The generated `site/_build/` directory is ignored by Git.
+
+## Update
+
+- Edit `site/index.html` or `site/styles.css`.
+- Reuse repository branding from `docs/assets/`; `site/build.py` copies the selected web assets.
+- Keep current/target capability statements aligned with `docs/status.md` and `docs/architecture.md`.
+- Run the build, link check, and repository full checks before opening a pull request.
+
+## Deploy
+
+`.github/workflows/pages.yml` validates site changes on pull requests. A site change merged to
+`main` builds the same static output and deploys it with GitHub's Pages artifact action. The default
+repository Pages URL is retained; a future custom-domain file can be added independently.

--- a/site/build.py
+++ b/site/build.py
@@ -1,0 +1,31 @@
+"""Build the dependency-free static project site."""
+
+import shutil
+from pathlib import Path
+
+SITE_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = SITE_DIR.parent
+OUTPUT_DIR = SITE_DIR / "_build"
+
+SITE_FILES = ("index.html", "styles.css")
+BRAND_ASSETS = {
+    REPOSITORY_ROOT / "docs/assets/main.png": "favicon.png",
+    REPOSITORY_ROOT / "docs/assets/social-preview.png": "social-preview.png",
+}
+
+
+def main() -> None:
+    if OUTPUT_DIR.exists():
+        shutil.rmtree(OUTPUT_DIR)
+
+    assets_dir = OUTPUT_DIR / "assets"
+    assets_dir.mkdir(parents=True)
+
+    for filename in SITE_FILES:
+        shutil.copy2(SITE_DIR / filename, OUTPUT_DIR / filename)
+    for source, filename in BRAND_ASSETS.items():
+        shutil.copy2(source, assets_dir / filename)
+
+
+if __name__ == "__main__":
+    main()

--- a/site/check.py
+++ b/site/check.py
@@ -1,0 +1,99 @@
+"""Validate local links and required metadata in the built static site."""
+
+from argparse import ArgumentParser
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+ALLOWED_EXTERNAL_SCHEMES = {"https", "mailto"}
+REQUIRED_META = {
+    "description",
+    "og:description",
+    "og:image",
+    "og:title",
+    "og:type",
+    "og:url",
+    "twitter:card",
+}
+
+
+class SiteParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ids: set[str] = set()
+        self.references: list[str] = []
+        self.meta: set[str] = set()
+        self.has_title = False
+        self.has_canonical = False
+        self.has_favicon = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = dict(attrs)
+        element_id = attributes.get("id")
+        if element_id:
+            self.ids.add(element_id)
+
+        if tag in {"a", "link"} and attributes.get("href"):
+            self.references.append(attributes["href"])
+        if tag in {"img", "script"} and attributes.get("src"):
+            self.references.append(attributes["src"])
+
+        if tag == "meta":
+            key = attributes.get("name") or attributes.get("property")
+            if key:
+                self.meta.add(key)
+        if tag == "link" and attributes.get("rel") == "canonical":
+            self.has_canonical = True
+        if tag == "link" and attributes.get("rel") == "icon":
+            self.has_favicon = True
+        if tag == "title":
+            self.has_title = True
+
+
+def validate_page(page: Path, site_root: Path) -> list[str]:
+    parser = SiteParser()
+    parser.feed(page.read_text(encoding="utf-8"))
+    errors: list[str] = []
+
+    missing_meta = REQUIRED_META - parser.meta
+    if missing_meta:
+        errors.append(f"{page}: missing metadata: {', '.join(sorted(missing_meta))}")
+    if not parser.has_title:
+        errors.append(f"{page}: missing title")
+    if not parser.has_canonical:
+        errors.append(f"{page}: missing canonical link")
+    if not parser.has_favicon:
+        errors.append(f"{page}: missing favicon")
+
+    for reference in parser.references:
+        parsed = urlsplit(reference)
+        if parsed.scheme:
+            if parsed.scheme not in ALLOWED_EXTERNAL_SCHEMES:
+                errors.append(f"{page}: unsupported URL scheme in {reference!r}")
+            continue
+        if parsed.netloc:
+            errors.append(f"{page}: protocol-relative URL is not allowed: {reference!r}")
+            continue
+        if parsed.path:
+            target = site_root / unquote(parsed.path.lstrip("/"))
+            if not target.exists():
+                errors.append(f"{page}: missing local target {reference!r}")
+        if parsed.fragment and not parsed.path and parsed.fragment not in parser.ids:
+            errors.append(f"{page}: missing fragment target #{parsed.fragment}")
+
+    return errors
+
+
+def main() -> None:
+    argument_parser = ArgumentParser()
+    argument_parser.add_argument("site_root", type=Path)
+    site_root = argument_parser.parse_args().site_root.resolve()
+
+    errors = validate_page(site_root / "index.html", site_root)
+    if errors:
+        raise SystemExit("\n".join(errors))
+    print(f"validated {site_root}")
+
+
+if __name__ == "__main__":
+    main()

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,311 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Spotter — Runtime supervision for coding agents</title>
+    <meta
+      name="description"
+      content="Spotter is an experimental, local-first runtime supervisor that catches bad coding-agent trajectories before wasted work compounds."
+    />
+    <meta name="theme-color" content="#090806" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://spotter-agent.github.io/spotter/" />
+    <link rel="icon" type="image/png" href="assets/favicon.png" />
+    <link rel="stylesheet" href="styles.css" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Spotter" />
+    <meta property="og:title" content="Spotter — Runtime supervision for coding agents" />
+    <meta
+      property="og:description"
+      content="Catch bad coding-agent trajectories before wasted work compounds."
+    />
+    <meta property="og:url" content="https://spotter-agent.github.io/spotter/" />
+    <meta
+      property="og:image"
+      content="https://spotter-agent.github.io/spotter/assets/social-preview.png"
+    />
+    <meta property="og:image:alt" content="Spotter runtime supervisor project artwork" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Spotter — Runtime supervision for coding agents" />
+    <meta
+      name="twitter:description"
+      content="Catch bad coding-agent trajectories before wasted work compounds."
+    />
+    <meta
+      name="twitter:image"
+      content="https://spotter-agent.github.io/spotter/assets/social-preview.png"
+    />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header">
+      <a class="brand" href="#top" aria-label="Spotter home">
+        <span class="brand-mark" aria-hidden="true"></span>
+        <span>SPOTTER</span>
+      </a>
+      <nav aria-label="Primary navigation">
+        <a href="#model">Model</a>
+        <a href="#status">Status</a>
+        <a href="#roadmap">Roadmap</a>
+        <a href="#start">Get started</a>
+      </nav>
+      <a class="header-github" href="https://github.com/spotter-agent/spotter">GitHub ↗</a>
+    </header>
+
+    <main id="main">
+      <section class="hero" id="top" aria-labelledby="hero-title">
+        <div class="hero-copy">
+          <p class="eyebrow"><span></span> Experimental · local-first · open source</p>
+          <h1 id="hero-title">Catch the turn<br /><em>before it drifts.</em></h1>
+          <p class="lede">
+            Spotter supervises coding agents while they work. It watches the trajectory—not only
+            the final diff—so weak assumptions, repeated failures, and unsafe actions can be caught
+            before their cost compounds.
+          </p>
+          <div class="actions">
+            <a class="button button-primary" href="#start">Get started <span>→</span></a>
+            <a class="button button-secondary" href="https://github.com/spotter-agent/spotter"
+              >View on GitHub <span>↗</span></a
+            >
+          </div>
+          <p class="maturity-note">
+            <strong>Prototype status:</strong> deterministic gates are active. Semantic advisories
+            remain off by default; recovery controls are not shipped.
+          </p>
+        </div>
+
+        <div class="orbit" aria-label="A stylized trajectory moving through observation checkpoints">
+          <div class="orbit-ring orbit-ring-one"></div>
+          <div class="orbit-ring orbit-ring-two"></div>
+          <div class="orbit-crosshair"></div>
+          <div class="orbit-core"><span></span></div>
+          <div class="orbit-node node-one"></div>
+          <div class="orbit-node node-two"></div>
+          <div class="orbit-node node-three"></div>
+          <div class="orbit-label label-observe">01 / OBSERVE</div>
+          <div class="orbit-label label-detect">02 / DETECT</div>
+          <div class="orbit-label label-act">03 / ACT</div>
+        </div>
+      </section>
+
+      <section class="problem ruled" aria-labelledby="problem-title">
+        <div class="section-number">01 / WHY</div>
+        <div>
+          <p class="eyebrow">The cost of late feedback</p>
+          <h2 id="problem-title">A bad trajectory rarely begins with a bad diff.</h2>
+        </div>
+        <div class="problem-copy">
+          <p>
+            A weak assumption shapes the next search. The search shapes the next edit. By the time
+            review catches the result, the agent may have spent minutes, tokens, and repository
+            churn defending the wrong path.
+          </p>
+          <p>
+            Post-hoc review asks whether the output is acceptable. Runtime supervision asks whether
+            the work is still heading somewhere worth going—and whether the next action is safe.
+          </p>
+        </div>
+      </section>
+
+      <section class="model" id="model" aria-labelledby="model-title">
+        <div class="section-heading">
+          <div class="section-number">02 / MODEL</div>
+          <div>
+            <p class="eyebrow">Supervision loop</p>
+            <h2 id="model-title">Observe the work.<br />Change the outcome.</h2>
+          </div>
+          <p>
+            Spotter keeps deterministic enforcement fast and local while slower semantic review
+            stays off the synchronous tool path.
+          </p>
+        </div>
+
+        <ol class="loop-grid">
+          <li>
+            <span class="step-index">01</span>
+            <h3>Observe</h3>
+            <p>Collect actions, evidence, edits, validation, and runtime identity into a durable trajectory.</p>
+          </li>
+          <li>
+            <span class="step-index">02</span>
+            <h3>Detect</h3>
+            <p>Find repeated failures, stalled exploration, scope growth, missing validation, and stale hypotheses.</p>
+          </li>
+          <li>
+            <span class="step-index">03</span>
+            <h3>Intervene</h3>
+            <p>Block deterministic violations now; evaluate careful semantic guidance before broader use.</p>
+          </li>
+          <li>
+            <span class="step-index">04</span>
+            <h3>Recover</h3>
+            <p>Preserve snapshots and replay material today while live interrupt and restart remain target capabilities.</p>
+          </li>
+        </ol>
+
+        <div class="ladder" aria-labelledby="ladder-title">
+          <div>
+            <p class="eyebrow">Intervention ladder</p>
+            <h3 id="ladder-title">Escalate only as evidence warrants.</h3>
+          </div>
+          <ol>
+            <li class="is-active"><span>BLOCK</span><small>active · deterministic</small></li>
+            <li class="is-experimental"><span>VERIFY</span><small>experimental · opt-in</small></li>
+            <li class="is-experimental"><span>NUDGE</span><small>experimental · opt-in</small></li>
+            <li><span>INTERRUPT</span><small>target · not shipped</small></li>
+            <li><span>RESTART</span><small>target · not shipped</small></li>
+          </ol>
+        </div>
+      </section>
+
+      <section class="architecture ruled" aria-labelledby="architecture-title">
+        <div class="section-number">03 / ARCHITECTURE</div>
+        <div>
+          <p class="eyebrow">Current and target</p>
+          <h2 id="architecture-title">A prototype with a deliberate runtime boundary.</h2>
+        </div>
+        <div class="architecture-grid">
+          <article>
+            <span class="status-chip active">CURRENT</span>
+            <h3>Hook-backed supervision</h3>
+            <div class="flow" aria-label="Current architecture flow">
+              <span>Codex Hooks</span><b>↓</b><span>spotterd</span><b>↓</b><span>Journal · Gate · Review</span>
+            </div>
+            <p>
+              Durable journals, daemon-backed deterministic gates, snapshots, replay, diagnostics,
+              signal detection, and shadow semantic review exist today.
+            </p>
+          </article>
+          <article>
+            <span class="status-chip target">TARGET</span>
+            <h3>Standalone runtime control</h3>
+            <div class="flow" aria-label="Target architecture flow">
+              <span>Codex App Server</span><b>↕</b><span>spotterd</span><b>↓</b><span>Observe · Steer · Recover</span>
+            </div>
+            <p>
+              App Server ingestion and control foundations are partial. Broad live advisories,
+              interrupt, and verified restart remain gated by evidence and hardening.
+            </p>
+          </article>
+        </div>
+        <a class="text-link" href="https://github.com/spotter-agent/spotter/blob/main/docs/architecture.md"
+          >Read the architecture contract →</a
+        >
+      </section>
+
+      <section class="status" id="status" aria-labelledby="status-title">
+        <div class="section-heading">
+          <div class="section-number">04 / STATUS</div>
+          <div>
+            <p class="eyebrow">Honest by design</p>
+            <h2 id="status-title">What works today.</h2>
+          </div>
+          <p>
+            This is a stable summary, not a duplicate changelog. The repository status document is
+            the source of truth for exact capability boundaries.
+          </p>
+        </div>
+        <div class="status-columns">
+          <article>
+            <span class="status-dot implemented"></span>
+            <h3>Implemented</h3>
+            <ul>
+              <li>Durable trajectory journals</li>
+              <li>Bounded deterministic gates</li>
+              <li>Snapshots, forks, and replay</li>
+              <li>Runtime health diagnostics</li>
+            </ul>
+          </article>
+          <article>
+            <span class="status-dot partial"></span>
+            <h3>Partial / shadow</h3>
+            <ul>
+              <li>App Server observation</li>
+              <li>Event-driven detection</li>
+              <li>Semantic review</li>
+              <li>Opt-in live advisories</li>
+            </ul>
+          </article>
+          <article>
+            <span class="status-dot target-dot"></span>
+            <h3>Not live yet</h3>
+            <ul>
+              <li>Broad VERIFY / NUDGE</li>
+              <li>Live INTERRUPT</li>
+              <li>Verified RESTART</li>
+              <li>Proven outcome benefit</li>
+            </ul>
+          </article>
+        </div>
+        <a class="text-link" href="https://github.com/spotter-agent/spotter/blob/main/docs/status.md"
+          >Check the canonical current status →</a
+        >
+      </section>
+
+      <section class="roadmap ruled" id="roadmap" aria-labelledby="roadmap-title">
+        <div class="section-number">05 / ROADMAP</div>
+        <div>
+          <p class="eyebrow">Evidence before escalation</p>
+          <h2 id="roadmap-title">Build trust in named outcomes.</h2>
+        </div>
+        <ol class="roadmap-track">
+          <li><span>01</span><strong>Runtime</strong></li>
+          <li><span>02</span><strong>Observe</strong></li>
+          <li><span>03</span><strong>Detect</strong></li>
+          <li><span>04</span><strong>Intervene</strong></li>
+          <li><span>05</span><strong>Recover</strong></li>
+          <li><span>06</span><strong>Harden</strong></li>
+        </ol>
+        <p class="roadmap-note">
+          Each outcome has an evidence gate. Implementing a mechanism is not the same as proving it
+          improves results.
+        </p>
+        <a class="text-link" href="https://github.com/spotter-agent/spotter/blob/main/docs/roadmap.md"
+          >Explore the roadmap and evidence gates →</a
+        >
+      </section>
+
+      <section class="start" id="start" aria-labelledby="start-title">
+        <div>
+          <p class="eyebrow">Get started</p>
+          <h2 id="start-title">Run Spotter locally.</h2>
+          <p>
+            Install the CLI and daemon from the official Homebrew tap. Setup is explicit,
+            transactional, and does not silently change Codex during package installation.
+          </p>
+        </div>
+        <div class="terminal" aria-label="Installation commands">
+          <div class="terminal-bar"><span></span><span></span><span></span><small>terminal</small></div>
+          <pre><code><span class="prompt">$</span> brew install spotter-agent/spotter/spotter
+<span class="prompt">$</span> spotter setup codex --dry-run
+<span class="prompt">$</span> spotter setup codex
+<span class="prompt">$</span> spotter doctor</code></pre>
+        </div>
+        <div class="actions">
+          <a class="button button-primary" href="https://github.com/spotter-agent/spotter#install"
+            >Installation guide <span>↗</span></a
+          >
+          <a class="button button-secondary" href="https://github.com/spotter-agent/spotter/blob/main/docs/user-guide.md"
+            >Detailed user guide <span>↗</span></a
+          >
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-brand">
+        <span class="brand-mark" aria-hidden="true"></span>
+        <strong>SPOTTER</strong>
+        <p>Runtime supervision for coding agents.</p>
+      </div>
+      <nav aria-label="Project links">
+        <div><strong>Project</strong><a href="https://github.com/spotter-agent/spotter">Repository</a><a href="https://github.com/spotter-agent/spotter/issues">Issues</a></div>
+        <div><strong>Learn</strong><a href="https://github.com/spotter-agent/spotter/tree/main/docs">Documentation</a><a href="https://github.com/spotter-agent/spotter/blob/main/docs/concept.md">Concept</a></div>
+        <div><strong>Research</strong><a href="https://github.com/spotter-agent/spotter/blob/main/docs/research.md">Research questions</a><a href="https://github.com/spotter-agent/spotter/blob/main/docs/reference.md">References</a></div>
+      </nav>
+      <p class="footer-meta">Experimental software · Apache-2.0</p>
+    </footer>
+  </body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -305,7 +305,7 @@
         <div><strong>Learn</strong><a href="https://github.com/spotter-agent/spotter/tree/main/docs">Documentation</a><a href="https://github.com/spotter-agent/spotter/blob/main/docs/concept.md">Concept</a></div>
         <div><strong>Research</strong><a href="https://github.com/spotter-agent/spotter/blob/main/docs/research.md">Research questions</a><a href="https://github.com/spotter-agent/spotter/blob/main/docs/reference.md">References</a></div>
       </nav>
-      <p class="footer-meta">Experimental software · Apache-2.0</p>
+      <p class="footer-meta">Experimental software · MIT</p>
     </footer>
   </body>
 </html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,167 @@
+:root {
+  --ink: #f0e8da;
+  --muted: #a99d8b;
+  --dim: #6c6255;
+  --bg: #090806;
+  --panel: #100e0b;
+  --line: #2c271f;
+  --amber: #d8a35f;
+  --amber-bright: #f2c982;
+  --green: #77b899;
+  --red: #c9856f;
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background: var(--bg);
+  font-synthesis: none;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body { margin: 0; overflow-x: hidden; background: var(--bg); }
+a { color: inherit; }
+a:focus-visible { outline: 2px solid var(--amber-bright); outline-offset: 5px; }
+
+.skip-link { position: fixed; top: 1rem; left: 1rem; z-index: 100; padding: .75rem 1rem; transform: translateY(-200%); background: var(--ink); color: var(--bg); }
+.skip-link:focus { transform: translateY(0); }
+
+.site-header { position: relative; z-index: 10; display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; min-height: 76px; padding: 0 clamp(1.25rem, 5vw, 5rem); border-bottom: 1px solid var(--line); font: 700 .72rem/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .13em; }
+.brand { display: inline-flex; gap: .7rem; align-items: center; width: max-content; text-decoration: none; }
+.brand-mark { width: 13px; height: 13px; display: inline-block; border: 1px solid var(--amber-bright); border-radius: 50%; box-shadow: 0 0 0 4px #17130e, 0 0 24px #d8a35f66; }
+.site-header nav { display: flex; gap: clamp(1rem, 3vw, 2.6rem); color: var(--muted); }
+.site-header nav a, .header-github { text-decoration: none; }
+.site-header nav a:hover, .header-github:hover { color: var(--amber-bright); }
+.header-github { justify-self: end; }
+
+main, footer { max-width: 1600px; margin: 0 auto; }
+section { padding: clamp(5rem, 10vw, 10rem) clamp(1.25rem, 6vw, 7rem); }
+.hero { min-height: calc(100vh - 76px); display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(360px, .95fr); gap: clamp(3rem, 7vw, 8rem); align-items: center; background: radial-gradient(circle at 80% 35%, #5b3c171d, transparent 32%), linear-gradient(90deg, transparent 49.9%, #211d1755 50%, transparent 50.1%); }
+.eyebrow, .section-number, .step-index, .status-chip { margin: 0 0 1.5rem; color: var(--amber); font: 700 .68rem/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .17em; text-transform: uppercase; }
+.eyebrow span { display: inline-block; width: 5px; height: 5px; margin: 0 .7rem 1px 0; border-radius: 50%; background: var(--amber-bright); box-shadow: 0 0 10px var(--amber); }
+h1, h2, h3, p { margin-top: 0; }
+h1 { margin-bottom: 2rem; font: 500 clamp(3.5rem, 7.8vw, 8rem)/.89 Georgia, "Times New Roman", serif; letter-spacing: -.055em; }
+h1 em { color: var(--amber-bright); font-weight: 400; }
+h2 { margin-bottom: 1.5rem; font: 500 clamp(2.5rem, 5vw, 5.25rem)/.96 Georgia, "Times New Roman", serif; letter-spacing: -.045em; }
+h3 { font: 500 clamp(1.3rem, 2vw, 1.75rem)/1.1 Georgia, "Times New Roman", serif; }
+.lede { max-width: 660px; color: #c5b8a5; font-size: clamp(1.05rem, 1.35vw, 1.3rem); line-height: 1.7; }
+.actions { display: flex; flex-wrap: wrap; gap: .85rem; margin-top: 2.2rem; }
+.button { min-height: 49px; display: inline-flex; gap: 1.2rem; align-items: center; justify-content: space-between; padding: .9rem 1.2rem; border: 1px solid var(--line); text-decoration: none; font: 700 .72rem/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .08em; text-transform: uppercase; transition: border-color .2s, background .2s, color .2s; }
+.button-primary { background: var(--amber-bright); border-color: var(--amber-bright); color: #181108; }
+.button-primary:hover { background: #ffe0a9; }
+.button-secondary:hover { border-color: var(--amber); color: var(--amber-bright); }
+.maturity-note { max-width: 650px; margin: 2rem 0 0; padding-left: 1rem; border-left: 1px solid var(--amber); color: var(--muted); font-size: .82rem; line-height: 1.6; }
+.maturity-note strong { color: var(--ink); }
+
+.orbit { position: relative; aspect-ratio: 1; max-width: 640px; width: 100%; justify-self: center; border: 1px solid #554631; border-radius: 50%; background: radial-gradient(circle, #e7b76d17 0 2%, transparent 3%), repeating-radial-gradient(circle, transparent 0 13%, #6c563620 13.2% 13.5%); box-shadow: inset 0 0 90px #b1782c12, 0 0 120px #6b46151a; }
+.orbit-ring { position: absolute; inset: 12%; border: 1px solid #b78c506b; border-radius: 50%; transform: rotate(-18deg) scaleY(.52); }
+.orbit-ring-two { inset: 4%; transform: rotate(31deg) scaleY(.28); border-color: #edc77e99; }
+.orbit-crosshair::before, .orbit-crosshair::after { content: ""; position: absolute; background: #7e664239; }
+.orbit-crosshair::before { left: 50%; top: -7%; width: 1px; height: 114%; }
+.orbit-crosshair::after { top: 50%; left: -7%; height: 1px; width: 114%; }
+.orbit-core { position: absolute; inset: 38%; display: grid; place-items: center; border: 1px solid var(--amber-bright); border-radius: 50%; box-shadow: 0 0 0 14px #a8783830, 0 0 60px #d89e4540; }
+.orbit-core span { width: 24%; aspect-ratio: 1; border-radius: 50%; background: var(--amber-bright); box-shadow: 0 0 24px var(--amber-bright); }
+.orbit-node { position: absolute; width: 13px; height: 13px; border: 2px solid #1a1209; border-radius: 50%; background: var(--amber-bright); box-shadow: 0 0 14px var(--amber); }
+.node-one { top: 16%; left: 34%; }.node-two { top: 60%; right: 4%; }.node-three { bottom: 9%; left: 28%; }
+.orbit-label { position: absolute; padding: .5rem .65rem; border: 1px solid var(--line); background: #090806cc; color: var(--muted); font: 600 .58rem/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .1em; }
+.label-observe { top: 8%; left: 6%; }.label-detect { top: 45%; right: -4%; }.label-act { bottom: 6%; left: 7%; }
+
+.ruled { border-top: 1px solid var(--line); }
+.problem, .architecture, .roadmap { display: grid; grid-template-columns: .3fr 1.05fr 1fr; gap: clamp(2rem, 6vw, 6rem); }
+.problem-copy { padding-top: 2.3rem; color: var(--muted); font-size: 1.05rem; line-height: 1.75; }
+.problem-copy p + p { margin-top: 1.5rem; }
+.section-number { color: var(--dim); }
+.section-heading { display: grid; grid-template-columns: .3fr 1.05fr 1fr; gap: clamp(2rem, 6vw, 6rem); margin-bottom: clamp(3rem, 6vw, 6rem); }
+.section-heading > p { padding-top: 2.3rem; color: var(--muted); line-height: 1.7; }
+
+.model { background: var(--panel); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.loop-grid { display: grid; grid-template-columns: repeat(4, 1fr); margin: 0; padding: 0; list-style: none; border: 1px solid var(--line); }
+.loop-grid li { min-height: 285px; padding: 1.6rem; border-right: 1px solid var(--line); }
+.loop-grid li:last-child { border-right: 0; }
+.loop-grid h3 { margin-top: 4.5rem; color: var(--amber-bright); }
+.loop-grid p { color: var(--muted); line-height: 1.65; font-size: .9rem; }
+.step-index { color: var(--dim); }
+.ladder { display: grid; grid-template-columns: .8fr 2fr; gap: 4rem; align-items: end; margin-top: 6rem; }
+.ladder ol { display: grid; grid-template-columns: repeat(5, 1fr); margin: 0; padding: 0; list-style: none; }
+.ladder li { position: relative; min-height: 105px; padding: 1.2rem .8rem; border-top: 1px solid var(--line); color: var(--dim); font: 700 .68rem/1 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.ladder li::before { content: ""; position: absolute; top: -4px; left: 0; width: 7px; height: 7px; border-radius: 50%; background: currentColor; }
+.ladder small { display: block; margin-top: .8rem; font-weight: 400; line-height: 1.4; }
+.ladder .is-active { color: var(--green); }.ladder .is-experimental { color: var(--amber); }
+
+.architecture-grid { grid-column: 2 / 4; display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.architecture-grid article { padding: clamp(1.5rem, 3vw, 2.5rem); border: 1px solid var(--line); background: linear-gradient(145deg, #12100d, #0b0a08); }
+.status-chip { display: inline-block; padding: .4rem .55rem; border: 1px solid currentColor; }
+.status-chip.active { color: var(--green); }.status-chip.target { color: var(--dim); }
+.flow { display: grid; grid-template-columns: 1fr auto 1fr auto 1.25fr; gap: .6rem; align-items: center; margin: 2rem 0; font: 600 .65rem/1.35 ui-monospace, SFMono-Regular, Menlo, monospace; text-align: center; }
+.flow span { padding: .75rem .5rem; border: 1px solid var(--line); }
+.flow b { color: var(--amber); }
+.architecture-grid p { color: var(--muted); line-height: 1.65; }
+.text-link { display: inline-block; width: max-content; margin-top: 2rem; color: var(--amber-bright); font: 700 .7rem/1.3 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .06em; text-decoration: none; text-transform: uppercase; }
+.text-link:hover { text-decoration: underline; text-underline-offset: 5px; }
+.architecture > .text-link { grid-column: 2 / 4; }
+
+.status-columns { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; background: var(--line); border: 1px solid var(--line); }
+.status-columns article { padding: 2rem; background: var(--bg); }
+.status-dot { display: block; width: 8px; height: 8px; margin-bottom: 3rem; border-radius: 50%; background: var(--dim); box-shadow: 0 0 12px currentColor; }
+.status-dot.implemented { background: var(--green); }.status-dot.partial { background: var(--amber); }.status-dot.target-dot { background: var(--red); }
+.status-columns ul { padding-left: 1.1rem; color: var(--muted); line-height: 2; }
+
+.roadmap-track { grid-column: 2 / 4; display: grid; grid-template-columns: repeat(6, 1fr); margin: 2rem 0 0; padding: 0; list-style: none; border-top: 1px solid var(--line); }
+.roadmap-track li { position: relative; padding: 1.2rem .5rem 2rem 0; }
+.roadmap-track li::before { content: ""; position: absolute; top: -5px; left: 0; width: 8px; height: 8px; border: 1px solid var(--amber); border-radius: 50%; background: var(--bg); }
+.roadmap-track span { display: block; margin-bottom: 2.3rem; color: var(--dim); font: .65rem/1 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.roadmap-track strong { font: 500 clamp(1rem, 1.5vw, 1.35rem)/1 Georgia, "Times New Roman", serif; }
+.roadmap-note, .roadmap > .text-link { grid-column: 2 / 4; }
+.roadmap-note { max-width: 700px; color: var(--muted); line-height: 1.7; }
+
+.start { display: grid; grid-template-columns: .85fr 1.15fr; gap: clamp(3rem, 8vw, 8rem); background: radial-gradient(circle at 15% 35%, #8f5f2319, transparent 35%), var(--panel); border-top: 1px solid var(--line); }
+.start > div:first-child p:last-child { max-width: 560px; color: var(--muted); line-height: 1.7; }
+.terminal { align-self: center; border: 1px solid #4b4031; background: #080706; box-shadow: 0 30px 80px #0008; }
+.terminal-bar { display: flex; gap: .4rem; align-items: center; padding: .8rem 1rem; border-bottom: 1px solid var(--line); }
+.terminal-bar span { width: 7px; height: 7px; border: 1px solid var(--dim); border-radius: 50%; }
+.terminal-bar small { margin-left: auto; color: var(--dim); font: .6rem/1 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.terminal pre { margin: 0; padding: clamp(1.25rem, 3vw, 2rem); overflow-x: auto; color: #d8d0c4; font: clamp(.68rem, 1.1vw, .88rem)/2 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.prompt { color: var(--amber-bright); }
+.start > .actions { grid-column: 1 / 3; margin-top: 0; }
+
+footer { display: grid; grid-template-columns: 1fr 1.3fr; gap: 4rem; padding: 5rem clamp(1.25rem, 6vw, 7rem) 2rem; border-top: 1px solid var(--line); }
+.footer-brand strong { margin-left: .7rem; font: 700 .75rem/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .13em; }
+.footer-brand p { margin-top: 1.3rem; color: var(--muted); }
+footer nav { display: grid; grid-template-columns: repeat(3, 1fr); gap: 2rem; }
+footer nav div { display: flex; flex-direction: column; gap: .8rem; }
+footer nav strong { margin-bottom: .6rem; color: var(--amber); font: 700 .64rem/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .13em; text-transform: uppercase; }
+footer nav a { width: max-content; color: var(--muted); text-decoration: none; font-size: .85rem; }
+footer nav a:hover { color: var(--ink); }
+.footer-meta { grid-column: 1 / 3; margin: 3rem 0 0; padding-top: 1.5rem; border-top: 1px solid var(--line); color: var(--dim); font: .6rem/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .09em; text-transform: uppercase; }
+
+@media (max-width: 980px) {
+  .site-header { grid-template-columns: 1fr auto; }.site-header nav { display: none; }
+  .hero { grid-template-columns: 1fr; padding-top: 6rem; }.orbit { max-width: 520px; }
+  .problem, .architecture, .roadmap, .section-heading { grid-template-columns: .22fr 1fr; }
+  .problem-copy, .section-heading > p { grid-column: 2; padding-top: 0; }
+  .architecture-grid, .roadmap-track, .roadmap-note, .roadmap > .text-link, .architecture > .text-link { grid-column: 2; }
+  .loop-grid { grid-template-columns: 1fr 1fr; }.loop-grid li:nth-child(2) { border-right: 0; }.loop-grid li:nth-child(-n+2) { border-bottom: 1px solid var(--line); }
+  .ladder { grid-template-columns: 1fr; gap: 2rem; }
+  .start { grid-template-columns: 1fr; }.start > .actions { grid-column: 1; }
+}
+
+@media (max-width: 680px) {
+  .site-header { min-height: 64px; }.header-github { font-size: .62rem; }
+  section { padding-top: 4.5rem; padding-bottom: 4.5rem; }
+  .hero { min-height: auto; grid-template-columns: 1fr; background: radial-gradient(circle at 50% 70%, #5b3c171d, transparent 30%); }
+  h1 { font-size: clamp(3.2rem, 17vw, 5rem); }.lede { font-size: 1rem; }
+  .orbit { max-width: 390px; }.orbit-label { font-size: .48rem; }.label-detect { right: 0; }
+  .problem, .architecture, .roadmap, .section-heading { display: block; }
+  .section-number { margin-bottom: 3rem; }.section-heading > p { padding-top: 0; }
+  .problem-copy { padding-top: 1rem; }
+  .loop-grid, .architecture-grid, .status-columns { grid-template-columns: 1fr; }
+  .loop-grid li { min-height: 220px; border-right: 0; border-bottom: 1px solid var(--line); }.loop-grid li:last-child { border-bottom: 0; }.loop-grid h3 { margin-top: 2.5rem; }
+  .ladder ol { grid-template-columns: 1fr; }.ladder li { min-height: 74px; border-top: 0; border-left: 1px solid var(--line); }.ladder li::before { top: 0; left: -4px; }
+  .architecture-grid { display: grid; }.flow { grid-template-columns: 1fr; }.flow b { transform: rotate(90deg); }
+  .roadmap-track { grid-template-columns: 1fr 1fr; border-top: 0; }.roadmap-track li { border-top: 1px solid var(--line); }
+  .start { display: grid; }.terminal pre { font-size: .61rem; }
+  footer { grid-template-columns: 1fr; }.footer-meta { grid-column: 1; } footer nav { gap: 1rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after { transition-duration: .01ms !important; }
+}


### PR DESCRIPTION
## Why

Give Spotter a focused public entry point that explains its runtime-supervision model and maturity without asking visitors to navigate the engineering docs first.

Closes #109.

## What changed

- add a responsive, accessible static landing page under `site/`
- distinguish implemented, partial/shadow, and target capabilities and link back to canonical status/architecture docs
- reuse the existing Spotter favicon and social-preview branding at build time
- add dependency-free static build and internal-link/metadata validation
- deploy Pages artifacts from `main` through GitHub Actions, while validating pull requests without deploying
- document local preview, maintenance, and deployment

## Validation

- `python site/build.py`
- `python site/check.py site/_build`
- `ruff format --check .`
- `ruff check .`
- `mypy src tests`
- `pytest` (962 passed)

After merge, the Pages workflow publishes the site at <https://spotter-agent.github.io/spotter/>.