### PR TITLE
fix(metrics): align detector rates with sampled populations

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -178,7 +178,8 @@ A signal is a hypothesis, not a verdict.
 
 Report together:
 
-- precision / false-positive rate;
+- precision / false-discovery rate among emitted flags; true false-positive rate only when a
+  per-rule true-negative frame exists;
 - miss rate or recall estimate;
 - abstention / blind-spot rate;
 - detection delay / wasted actions;

--- a/docs/status.md
+++ b/docs/status.md
@@ -126,6 +126,11 @@ preflight, resumable classified execution, and a [first real three-task developm
 All three pairs were tie-success; this qualifies the instrument but is not evidence of intervention
 advantage.
 
+Detector-quality reports preserve each declared multi-event-kind silence batch as one sampling
+stratum, so its rate and eligibility/exclusion denominator describe the same frame. Gate
+`fp / (tp + fp)` is named false discovery (`1 - precision`); true false-positive rate remains
+unavailable until #38 has a per-rule true-negative sampling frame.
+
 ---
 
 ## Quick capability status

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -357,9 +357,11 @@ spotter metrics --session <id>
 ```
 
 Repeated sampling with the same detector, event kinds, and rate consumes only the new journal
-suffix. Metrics preserve the frame probability and exclusions, report coverage separately per
-detector/event-kind/rate stratum, and explicitly avoid generalizing the result to unsampled event
-kinds.
+suffix. Metrics preserve the frame probability and exclusions, keep every declared multi-kind batch
+as one detector/event-kind-set/rate stratum, and explicitly avoid generalizing the result to
+unsampled event kinds. Gate `fp / (tp + fp)` is reported as false discovery (`1 - precision`), not
+false-positive rate; true FPR remains unavailable until a per-rule true-negative sampling frame
+exists.
 
 For detection-delay studies, record both the retrospective semantic window and the separate window
 where Spotter could actually observe the required evidence. The two intervals are not assumed to be

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -2011,11 +2011,12 @@ def _metrics_main(session: str | None) -> int:
             print(f"metrics aborted: {error}", file=sys.stderr)
             return 1
 
-    print("P3 gate false positives (label each flag tp|fp):")
+    print("P3 gate flag precision (label each flag tp|fp):")
     if not gates:
         print("  no gate flags recorded")
     for rule, tally in sorted(gates.items()):
-        print("  " + tally.rate_line(rule, "false-positive", count_negative=True))
+        print("  " + tally.rate_line(rule, "false-discovery (1 - precision)", count_negative=True))
+    print("  true FPR unavailable: no per-rule true-negative sampling frame")
     if blind_spots:
         rules = ", ".join(f"{rule}={count}" for rule, count in sorted(blind_spots.items()))
         print(

--- a/src/spotter/labels.py
+++ b/src/spotter/labels.py
@@ -2,7 +2,7 @@
 
 The plan's evidence gates wait on the same thing: was a judgment right?
 - P1 observability ceiling: was a failure visible in the observable stream?
-- P3 active gates: what fraction of shadow blocks were false positives?
+- P3 active gates: what fraction of shadow blocks were false discoveries?
 - P4 injection: what fraction of reviewer nudges were correct?
 
 Labels live in their own store, NOT in the session journal. Two reasons:

--- a/src/spotter/metrics.py
+++ b/src/spotter/metrics.py
@@ -292,7 +292,8 @@ def tally_signal_silence(
     tallies: dict[str, Tally] = {}
     for sample in samples.values():
         batch = batches_by_id[sample.batch_id]
-        key = f"{sample.signal_type}/{sample.event_kind}@p={batch.inclusion_probability:g}"
+        event_kinds = ",".join(batch.event_kinds)
+        key = f"{sample.signal_type}/{event_kinds}@p={batch.inclusion_probability:g}"
         label = labels[sample.signal_type].get(sample.step)
         stale = not sample_matches(sample, records) or bool(
             label is not None and not matches(label, records)

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -328,7 +328,7 @@ def test_rate_is_withheld_below_minimum_samples() -> None:
         add_label("s1", step, "fp", "", records)
     gates, _, _ = tally_session("s1", records)
     line = gates["git_reset_hard"].rate_line(
-        "git_reset_hard", "false-positive", count_negative=True
+        "git_reset_hard", "false-discovery (1 - precision)", count_negative=True
     )
     assert "too few decided labels" in line
     assert "%" not in line  # no headline number from two samples
@@ -341,7 +341,7 @@ def test_rate_is_marked_provisional_until_coverage_is_complete() -> None:
         add_label("s1", step, "fp", "", records)
     gates, _, _ = tally_session("s1", records)
     line = gates["git_reset_hard"].rate_line(
-        "git_reset_hard", "false-positive", count_negative=True
+        "git_reset_hard", "false-discovery (1 - precision)", count_negative=True
     )
     assert "provisional" in line and f"{MIN_SAMPLES}/{MIN_SAMPLES + 2} labeled" in line
 
@@ -349,11 +349,11 @@ def test_rate_is_marked_provisional_until_coverage_is_complete() -> None:
         add_label("s1", step, "fp", "", records)
     gates, _, _ = tally_session("s1", records)
     complete = gates["git_reset_hard"].rate_line(
-        "git_reset_hard", "false-positive", count_negative=True
+        "git_reset_hard", "false-discovery (1 - precision)", count_negative=True
     )
-    # all seven labels were fp: the gate report must show 100% false positives,
+    # All seven labels were fp: the flagged set has 100% false discovery,
     # not the 0% true-positive share the old wording printed (PR #17 review P2)
-    assert "provisional" not in complete and "false-positive 100%" in complete
+    assert "provisional" not in complete and "false-discovery (1 - precision) 100%" in complete
 
 
 def test_gate_miss_rate_counts_only_correlated_unflagged_proposals() -> None:
@@ -470,7 +470,8 @@ def test_cli_label_and_metrics_roundtrip(capsys: pytest.CaptureFixture[str]) -> 
     out = capsys.readouterr().out
     assert "step 1: fp by alice" in out
     assert "step 2: miss by bob" in out
-    assert "P3 gate false positives" in out
+    assert "P3 gate flag precision" in out
+    assert "true FPR unavailable" in out
     assert "P3 gate misses" in out
     assert "Signal candidate precision" in out
     assert "P4 reviewer precision" in out
@@ -480,6 +481,21 @@ def test_cli_label_and_metrics_roundtrip(capsys: pytest.CaptureFixture[str]) -> 
     assert "Runtime cost / efficiency (coverage-aware)" in out
     assert "Rater agreement (double-label subset)" in out
     assert "too few decided labels" in out  # honest about n=1
+
+
+def test_cli_names_flagged_denominator_false_discovery(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    records = _journal("s1", _flagged(MIN_SAMPLES))
+    for record in records:
+        if record.event.kind == "gate_shadow_block":
+            add_label("s1", record.step, "fp", "", records)
+
+    assert main(["metrics", "--session", "s1"]) == 0
+
+    output = capsys.readouterr().out
+    assert "false-discovery (1 - precision) 100%" in output
+    assert "true FPR unavailable" in output
 
 
 def test_cli_label_rejects_bad_verdict(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -136,6 +136,48 @@ def test_scoped_signal_labels_coexist_with_gate_negative_labels() -> None:
     assert agreement.double_labeled_targets == agreement.agreed_targets == 1
 
 
+def test_signal_silence_tally_preserves_a_multi_kind_sampling_frame() -> None:
+    records = _journal(
+        "s1",
+        [
+            _event("tool-1"),
+            TraceEvent("file_edit", {}, event_id="edit-1", identity=_identity()),
+        ],
+    )
+    sample_signal_silence(
+        "s1",
+        records,
+        "failure_streak",
+        ("tool_proposal", "file_edit"),
+        1,
+    )
+    add_label(
+        "s1",
+        0,
+        "miss",
+        "tool failure criterion met",
+        records,
+        signal_type="failure_streak",
+    )
+    add_label(
+        "s1",
+        1,
+        "tn",
+        "file edit criterion absent",
+        records,
+        signal_type="failure_streak",
+    )
+
+    tallies, batches = tally_signal_silence("s1", records)
+
+    assert len(batches) == 1
+    assert batches[0].eligible == batches[0].selected == 2
+    assert set(tallies) == {"failure_streak/file_edit,tool_proposal@p=1"}
+    tally = tallies["failure_streak/file_edit,tool_proposal@p=1"]
+    assert tally.total == tally.labeled == 2
+    assert tally.positive == tally.negative == 1
+
+
 def test_sampling_appends_only_the_new_journal_suffix() -> None:
     records = _journal("s1", [_event("source-1")])
     first = sample_signal_silence("s1", records, "failure_streak", ("tool_proposal",), 1)


### PR DESCRIPTION
## Why

#38 requires precision, false-positive behavior, miss rate, blind spots, label coverage, and agreement to be reported together. The current instrumentation is largely present, but two reporting errors attached rates to the wrong statistical population.

### 1. False discovery was called false-positive rate

Gate flags are labeled `tp|fp`. The existing rate used:

```text
FP / (TP + FP)
```

That is false-discovery proportion among emitted flags, equal to `1 - precision`. A true false-positive rate is:

```text
FP / (FP + TN)
```

Spotter does not currently have a per-rule true-negative frame, so printing the first quantity as FPR overstated what was measured.

### 2. Multi-kind silence samples mixed numerator and denominator frames

`sample-signals` accepts multiple `--event-kind` values and persists one sampling batch with:

- one normalized event-kind set;
- one inclusion probability;
- one eligible/selected denominator;
- one emitted/suppressed/unobservable exclusion report.

`tally_signal_silence()` nevertheless split the selected labels by each sample's individual event kind. The CLI then printed per-kind rates beside batch-wide eligibility/exclusion metadata. The rate and bias metadata no longer described the same population.

## What changed

### Honest gate metric naming

The gate section is now:

```text
P3 gate flag precision (label each flag tp|fp)
  <rule>: false-discovery (1 - precision) ...
  true FPR unavailable: no per-rule true-negative sampling frame
```

The calculation is unchanged; only the claim is corrected. Existing minimum-sample withholding, labeled coverage, unclear/stale handling, and provisional qualifiers remain intact.

Spotter does not synthesize TNs from pooled unflagged proposals. A future FPR implementation must declare and persist a per-rule negative frame.

### Exact batch-level signal-silence strata

Signal-silence tallies now key each sample by its persisted batch definition:

```text
<signal_type>/<full sorted event-kind set>@p=<inclusion probability>
```

Examples:

```text
single kind:
failure_streak/tool_proposal@p=1

multi kind:
failure_streak/file_edit,tool_proposal@p=1
```

All labels from one batch now aggregate into one tally, so:

- tally total matches the batch's selected population;
- rate numerator/denominator match eligibility and exclusion metadata;
- one inclusion probability describes the full stratum;
- existing single-kind key shape remains unchanged;
- batches with incompatible overlapping event-kind/rate definitions remain rejected by existing sampling validation.

## Tests

### Multi-kind frame regression

A persisted batch containing one `tool_proposal` and one `file_edit` is labeled:

- one `miss`;
- one `tn`.

The test requires exactly one combined key with:

- eligible/selected: 2/2;
- tally total/labeled: 2/2;
- positive/negative: 1/1.

It fails under the previous per-sample event-kind split.

### Gate metric terminology regression

Five emitted flags labeled `fp` must produce:

```text
false-discovery (1 - precision) 100%
true FPR unavailable
```

The existing low-sample and provisional/full-coverage tests now use the same false-discovery wording.

## Documentation

- User guide explains batch-level multi-kind strata and the FDR/FPR denominator distinction.
- Roadmap asks for flag precision/false discovery and permits true FPR only when a per-rule TN frame exists.
- Status records the implemented reporting contract without claiming empirical detector quality.
- Label module terminology now says false discovery among active flags.

## Review feedback incorporated

### Test audit — APPROVE

Confirmed:

- batch event-kind normalization keeps keys stable;
- multi-kind tally and batch metadata now share one population;
- single-kind compatibility is preserved;
- FDR/FPR wording tests cover the CLI path.

### Code review — APPROVE

Confirmed:

- no schema/version change;
- inclusion probabilities and overlap guards remain intact;
- no stale-label or denominator regression;
- metric terminology is consistent across code/docs/tests.

### Architect verification — APPROVED

Confirmed the exact math:

- `count_negative=True` is negative share of decided emitted flags (`FP/(TP+FP)`);
- true FPR is correctly withheld;
- multi-kind selected labels now match the persisted batch frame;
- #38 remains open and no empirical outcome is claimed.

## Validation

- focused sampling/label review suite — **42 passed**
- `ruff format --check .` — 184 files already formatted
- `ruff check .` — passed
- `mypy src tests` — no issues in 119 source files
- isolated full suite — **1000 passed in 36.74s**
- independent test review — APPROVE
- independent code review — APPROVE
- architect verification — APPROVED
- changed-file-only deslop pass followed by full re-verification

## Test-environment issue discovered

The first post-deslop run used the real user Spotter home and exposed an unrelated existing isolation defect: `test_live_opt_in_delivers_a_fresh_intervention_decision` reads the user's review-spend ledger and fails when the budget is exhausted. It reproduced alone and is tracked by #310 (Bug, Medium, XS, Evaluation/Harden).

The #38 suite was then rerun with an isolated `SPOTTER_HOME` and passed 1000/1000. Production budget behavior is unchanged by this PR.

## User/developer impact

- Users no longer see false discovery mislabeled as true FPR.
- Multi-kind detector-negative studies report one rate per declared sampling frame.
- Existing persisted samples remain readable; tally presentation is corrected at read time.
- No detector thresholds, signal emission, or intervention behavior changes.

## Remaining #38 work

This PR does **not** close #38. Representative evidence still requires:

- a predeclared App Server/failure trajectory cohort;
- positive and silence-frame labels with coverage;
- a preselected double-label subset and agreement report;
- per-signal/failure-family coverage;
- abstention/blind-spot coverage;
- conservative activation thresholds based on real results.

## Related

- Refs #38
- Test isolation follow-up: #310
- Does not unblock #26 or enable default live intervention.

