### PR TITLE
test: isolate review delivery from user spend state

### DIFF
--- a/tests/test_review_executor.py
+++ b/tests/test_review_executor.py
@@ -169,7 +169,11 @@ def test_running_and_queued_reviews_pin_their_submission_config_generation(
     asyncio.run(scenario())
 
 
-def test_live_opt_in_delivers_a_fresh_intervention_decision(tmp_path: Path) -> None:
+def test_live_opt_in_delivers_a_fresh_intervention_decision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path / "home"))
+
     async def scenario() -> None:
         runtime = AppServerRecoveryLoop("ws://unused", tmp_path / "sessions", ThreadStateStore())
         delivered: list[tuple[ReviewerJob, ReviewerDecision]] = []


### PR DESCRIPTION
## Why

The first post-deslop verification for PR #311 failed in:

```text
test_live_opt_in_delivers_a_fresh_intervention_decision
assert len(delivered) == 1
E assert 0 == 1
```

The failure reproduced when run alone. The test constructed a real `ReviewExecutor`, which always reserves review budget, but unlike every adjacent direct-executor test it did not set an isolated `SPOTTER_HOME`. It therefore read the user's real `~/.spotter/review-spend.json`. Once that ledger was exhausted, the executor correctly refused the review and the test incorrectly failed.

Running the suite with an externally isolated Spotter home passed 1000/1000, confirming test-state contamination rather than a production delivery defect.

## Root cause

```text
test uses tmp_path for runtime journals
  but leaves SPOTTER_HOME unset
    → ReviewExecutor.reserve()
      → real user review-spend ledger
        → exhausted budget
          → no delivery
```

## What changed

The test now accepts `monkeypatch` and sets:

```python
monkeypatch.setenv("SPOTTER_HOME", str(tmp_path / "home"))
```

This happens before the async scenario and before `ReviewExecutor` construction/reservation.

No production code changed. Budget reservation, settlement, charging, caps, and delivery semantics are untouched.

## Adjacent test audit

Every neighboring test that directly constructs `ReviewExecutor` already uses the same isolated-home pattern. A nearby test without the environment override calls `deliver_review_decision()` directly and never touches the spend ledger.

## Verification

- focused failing test against the existing real exhausted ledger — **1 passed**
- full `tests/test_review_executor.py` — passed
- `ruff format --check .` — 184 files already formatted
- `ruff check .` — passed
- `mypy src tests` — no issues in 119 source files
- full suite with no external `SPOTTER_HOME` override — **1000 passed in 36.83s**
- independent code review — APPROVE
- architect verification — APPROVED
- changed-file-only deslop and post-deslop full verification — passed

## Review findings

The independent reviewer and architect confirmed:

- the override is applied before budget reservation;
- adjacent direct-executor tests are already isolated;
- the edited test still exercises real reserve/settle/delivery behavior;
- production budget semantics are unchanged;
- the diff is one test file only.

## Impact

- Full-suite results no longer depend on developer review history.
- Tests no longer read or modify the user's real Spotter spend ledger.
- CI/local parity improves without weakening budget coverage.

## Related

- Closes #310
- Discovered during PR #311 verification.

