### PR TITLE
experiment: measure App Server observability ceiling

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -525,10 +525,10 @@ The target Codex integration should keep only the hook surface that provides a u
 
 | Hook | Current use | Target |
 | --- | --- | --- |
-| `SessionStart` | legacy session baseline snapshot | App Server `thread/started` now owns the baseline; remove the redundant Hook |
-| `UserPromptSubmit` | user goal capture | replace with App Server user-message events |
+| `SessionStart` | legacy session baseline snapshot | retain after the #303 lifecycle minimum stopped incomplete |
+| `UserPromptSubmit` | user goal capture | retain: Codex 0.147.0 exposed no user-input notification in the #303 ceiling run |
 | `PreToolUse` | proposal observation + gate | **retain for deterministic atomic enforcement** |
-| `PostToolUse` | legacy result/snapshot/reviewer cadence | App Server terminal items now own after-state snapshots; finish result/reviewer migration, then remove the Hook |
+| `PostToolUse` | legacy result/snapshot/reviewer cadence | retain until failure, patch, MCP, approval, interrupt, and reconnect parity is measured |
 
 ### Appropriate synchronous policies
 
@@ -761,7 +761,7 @@ only be created by an explicit verification-satisfied event. Duplicate event IDs
 out-of-order lifecycle is recorded as partial coverage, and thread identities remain isolated.
 
 Journal hydration deterministically replays Trace IR but clears active-turn/control readiness. A
-recovered daemon receives a live `runtime_reconciled` event only after the App Server thread list/read
+recovered daemon receives a live `runtime_reconciled` event only after the App Server thread list/resume
 pass proves current attachment and exact active-turn identity. Until then control remains unavailable.
 
 ## 8.2 Durable journal

--- a/docs/experiments/app-server-observability-v1-plan.json
+++ b/docs/experiments/app-server-observability-v1-plan.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "declared_at": "2026-08-18",
+  "issue": 303,
+  "runtime": {
+    "minimum_codex_cli": "0.147.0",
+    "transport": "local_websocket",
+    "isolated_spotter_home": true,
+    "isolated_codex_home": true
+  },
+  "minimum_complete_cohort": {
+    "distinct_threads": 7,
+    "turns": 9,
+    "attempts_per_scenario": 2
+  },
+  "scenarios": [
+    "ASO-NORMAL-1",
+    "ASO-NORMAL-2",
+    "ASO-FAIL-1",
+    "ASO-PATCH-1",
+    "ASO-MCP-1",
+    "ASO-LONG-1",
+    "ASO-APPROVAL-1",
+    "ASO-RECONNECT-1",
+    "ASO-LIFECYCLE-1"
+  ],
+  "failure_families": [
+    "normal",
+    "command_failure",
+    "degraded",
+    "interrupted",
+    "long_running",
+    "approval_blocked",
+    "disconnect_reconnect"
+  ],
+  "responsibilities": {
+    "SessionStart": ["new", "stored", "late_attached", "resumed", "reconnected"],
+    "UserPromptSubmit": ["initial", "later", "spotter_steer", "other_client", "replay", "history"],
+    "PostToolUse": [
+      "command_success",
+      "command_failure",
+      "patch",
+      "mcp",
+      "streaming",
+      "approval",
+      "interruption",
+      "reconnect",
+      "partial_unknown"
+    ],
+    "overlap_deduplication": ["hook_first", "app_server_first"]
+  },
+  "stop_rule": [
+    "all_minimums_met",
+    "second_failed_attempt_for_any_scenario",
+    "unsafe_runtime_or_collection_failure"
+  ],
+  "decision_rule": "Any unmet minimum, unjudgeable consequential boundary, or semantic-action duplicate is NO-GO for the affected responsibility."
+}

--- a/docs/experiments/app-server-observability-v1-plan.md
+++ b/docs/experiments/app-server-observability-v1-plan.md
@@ -1,0 +1,108 @@
+# App Server observability v1 predeclaration
+
+**Declared:** 2026-08-18, before cohort execution
+
+**Issue:** [#303](https://github.com/spotter-agent/spotter/issues/303)
+
+This plan freezes the cohort, classifications, minimum coverage, and stop rule used to decide
+whether App Server evidence can replace each observation Hook responsibility. The resulting report
+must cite the commit containing this file and must not silently remove failed or unsupported rows.
+
+## Runtime and retained evidence
+
+- Run Codex CLI 0.147.0 or newer against one explicitly selected local WebSocket App Server.
+- Run `spotterd` from this revision with a fresh, isolated `SPOTTER_HOME`; no pre-existing Hook or
+  App Server journals may enter the cohort.
+- Use throwaway fixture repositories and an isolated `CODEX_HOME`. Authentication may be linked
+  read-only from the local Codex installation, but user configuration and sessions are excluded.
+- Retain Spotter journals, source-audit samples, daemon logs, bounded observer summaries, and the
+  exact commands used. Commit only shape/timing/classification summaries and SHA-256 digests; raw
+  values, model text, command output, secrets, and local absolute paths stay out of Git.
+- Synthetic conformance fixtures and unit tests remain regression evidence only and never count as
+  cohort samples.
+
+## Cohort
+
+Each scenario gets at most two attempts. An unavailable capability or second failed attempt remains
+an explicit gap and forces the affected Hook decision to **NO-GO**.
+
+| ID | Required trajectory | Minimum evidence |
+| --- | --- | --- |
+| `ASO-NORMAL-1` | new thread, initial user turn, successful command | thread/turn identity, input provenance, streamed command start/completion, exit status |
+| `ASO-NORMAL-2` | later user turn on the same thread | later input distinguishable from initial input, history, replay, and Spotter steer |
+| `ASO-FAIL-1` | command exits non-zero | failed outcome and exit status visible before turn completion |
+| `ASO-PATCH-1` | file mutation followed by verification | patch/change identity and resulting diff or explicit source limitation |
+| `ASO-MCP-1` | deterministic local MCP call | MCP start/completion, tool identity, success/failure outcome |
+| `ASO-LONG-1` | long-running command interrupted with `turn/interrupt` | streaming lifecycle, interruption request, partial/unknown result, final turn status |
+| `ASO-APPROVAL-1` | command reaches an approval boundary and is not approved | approval request, blocked/denied outcome, no invented execution result |
+| `ASO-RECONNECT-1` | observer disconnects during an active command, then reconnects | explicit gap, connection epoch, stored/reconciled state, post-reconnect completion |
+| `ASO-LIFECYCLE-1` | observer attaches late, reads stored state, resumes, and reconnects | new, stored, late-attached, resumed, and reconnected thread identity |
+
+The minimum complete cohort is seven distinct App Server threads and nine turns, with every row
+attempted and at least one classified sample for each required evidence item. Scenarios may share a
+thread only where the table requires continuity (`ASO-NORMAL-1/2`) or disconnect state
+(`ASO-RECONNECT-1/ASO-LIFECYCLE-1`).
+
+## Inclusion and exclusion
+
+Include every source notification and canonical record from the first declared scenario start
+through the final scenario stop, including duplicates, unknown methods, uncorrelated evidence,
+connection gaps, and failed attempts. Include a trajectory only when its scenario ID, thread ID,
+attempt number, start/end time, and expected boundary were recorded before its first user turn.
+
+Exclude readiness probes completed before the first scenario, daemon self-health traffic, and
+threads whose working directory is outside the throwaway cohort root. Exclusions are reported by
+reason and count. Missing identity, late attachment, loss, or unsupported protocol behavior is a
+classification, never an exclusion.
+
+## Measurement
+
+For each required fact, classify source, Trace IR, and ThreadState independently using the existing
+coverage vocabulary. For consequential failure boundaries, also classify earliest availability as
+`VISIBLE_IN_TIME`, `VISIBLE_TOO_LATE`, `STRUCTURALLY_INVISIBLE`, `LOST_BY_ADAPTER`, `LOST_BY_GAP`,
+or `UNJUDGEABLE`. Report opportunity denominators by responsibility and failure family rather than
+using raw event counts as semantic coverage.
+
+The report keeps these buckets separate:
+
+- source-not-exposed / encrypted / uncorrelated;
+- normalization or adapter loss;
+- ThreadState loss;
+- observation gaps and late evidence;
+- not performed / not applicable;
+- unknown or unjudgeable.
+
+Overlap deduplication is exercised by attaching Hook and App Server observation to at least one
+successful command and one file mutation, once in each arrival order when the runtime permits it.
+The report compares canonical semantic actions and metric inputs, not notification counts.
+
+## Labels
+
+Every failed, degraded, interrupted, approval-blocked, and reconnect trajectory receives a session
+visibility label. Each consequential boundary also receives a stable opportunity ID, semantic
+window, observable window, and required evidence steps via `spotter label-opportunity`. A second
+labeler is not required for this ceiling experiment, but the rater identity is recorded.
+
+## Stop rule
+
+Stop collection at the first of:
+
+1. every cohort row and overlap order meets its minimum coverage;
+2. a row reaches two attempts without its minimum evidence; or
+3. a runtime or safety failure makes further collection unsafe.
+
+Rules 2 and 3 do not permit substitution with a similar event. The report records the shortfall
+and the affected responsibility remains **NO-GO**. Token cost, elapsed time, or a favorable interim
+rate is not an early-stop condition.
+
+## Per-Hook decisions
+
+- `SessionStart` is **GO** only if every lifecycle variant has correlated identity and bootstrap
+  state by its decision boundary, with no consequential source, adapter, state, or gap loss.
+- `UserPromptSubmit` is **GO** only if all initial/later user inputs are correlated and remain
+  distinguishable from Spotter steer, other clients, replay, and historical input.
+- `PostToolUse` is **GO** only if command success/failure, patch, MCP, approval, interruption,
+  reconnect, and partial/unknown outcomes are classified in time with no consequential unknown.
+- Any unmet minimum, unjudgeable consequential boundary, or semantic-action duplicate produces
+  **NO-GO** for that responsibility. Decisions are independent; there is no aggregate Hook verdict.
+

--- a/docs/experiments/app-server-observability-v1-result.json
+++ b/docs/experiments/app-server-observability-v1-result.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": 1,
+  "run_date": "2026-08-18",
+  "issue": 303,
+  "predeclaration_commit": "b47eb611afaf61ddcc76e784426ccf7da5ef4e5f",
+  "runtime_fix_commit": "5a6160bf263104921c324b26b8fb326659a1523d",
+  "codex_version": "0.147.0",
+  "stop_rule": "second_failed_attempt_for_any_scenario",
+  "stop_scenario": "ASO-NORMAL-2",
+  "cohort": {
+    "distinct_app_server_threads": 1,
+    "hook_turns": 3,
+    "planned_distinct_threads": 7,
+    "planned_turns": 9,
+    "complete": false
+  },
+  "decisions": {
+    "SessionStart": "NO-GO",
+    "UserPromptSubmit": "NO-GO",
+    "PostToolUse": "NO-GO"
+  },
+  "decisive_attempt": {
+    "scenario": "ASO-NORMAL-2",
+    "attempt": 2,
+    "app_server_events": 45,
+    "observation_gaps": 3,
+    "source_vs_adapter": {
+      "observed_exact": 15,
+      "unknown": 22
+    },
+    "trace_ir": {
+      "command_tool_call_observed_exact": 2,
+      "runtime_usage_observed_exact": 4,
+      "thread_turn_identity_observed_exact": 9,
+      "tool_outcome_observed_exact": 1
+    },
+    "thread_state": {
+      "command_tool_call_observed_exact": 2,
+      "runtime_usage_adapter_dropped": 4,
+      "thread_turn_identity_observed_exact": 3,
+      "thread_turn_identity_observed_partial": 6,
+      "tool_outcome_observed_exact": 2
+    },
+    "later_user_input": "STRUCTURALLY_INVISIBLE",
+    "command_outcome": "VISIBLE_IN_TIME",
+    "cross_surface_overlap": 0
+  },
+  "raw_artifact_sha256": {
+    "hook_journal": "7a28bc644e8bea2b3cca5742f86fdeb4532bb1332d39e670069fd51e4fe4bd65",
+    "app_server_thread_journal": "54f722c00ebfd2a7371c73e7182acbad8f1d482686eee970a39309fb7b7c5be4",
+    "app_server_unscoped_journal": "5e64af5e1becf24cef5fe9b26f17097b293d10909fddd17023462044b9e334d8",
+    "source_audit": "8b278bca4c989f0c1d309269f9d0862cd1c65f84ff1327a15fbb99707939724d"
+  }
+}

--- a/docs/experiments/app-server-observability-v1-result.md
+++ b/docs/experiments/app-server-observability-v1-result.md
@@ -1,0 +1,108 @@
+# App Server observability v1 result
+
+**Run date:** 2026-08-18  
+**Issue:** [#303](https://github.com/spotter-agent/spotter/issues/303)  
+**Predeclaration commit:** `b47eb611afaf61ddcc76e784426ccf7da5ef4e5f`  
+**Decision:** **NO-GO for removing `SessionStart`, `UserPromptSubmit`, or `PostToolUse`**
+
+The run stopped under rule 2 of the
+[predeclared protocol](app-server-observability-v1-plan.md): `ASO-NORMAL-2` reached two attempts
+without App Server evidence for the later user input. The second attempt did expose the turn,
+streamed command start/completion, exit status, and terminal turn status, but Codex 0.147.0 emitted
+no source notification containing the user input or its provenance. Unrun rows were not replaced
+with easier trajectories and remain explicit missing minimums.
+
+## Runtime and corrective findings
+
+The isolated run used Codex CLI 0.147.0, one local WebSocket App Server, a fresh `SPOTTER_HOME`, a
+fresh `CODEX_HOME`, and a throwaway Git repository. Raw prompt text and command output are not
+committed.
+
+Two runtime defects surfaced before the decisive attempt:
+
+1. Codex Desktop identifies the same 0.147.0 App Server with a bounded desktop user-agent shape,
+   rather than the CLI-only shape that setup previously accepted. Commit `267a36b` accepts that
+   host identity without accepting arbitrary suffixes.
+2. `spotterd` used `thread/read` while reconciling and therefore learned thread identity without
+   subscribing to item/turn notifications. Commit `5a6160b` uses `thread/resume`, retries the
+   expected pre-rollout race on later lifecycle notifications, and keeps `thread/read` only as the
+   pre-rollout state fallback.
+
+The first failed attempt remains in the result. After the subscription fix, the observer captured
+the authoritative command lifecycle, proving that the remaining user-input gap is at the source
+surface rather than the adapter subscription path.
+
+## Cohort disposition
+
+| Scenario | Attempt | Result | Disposition |
+| --- | ---: | --- | --- |
+| `ASO-NORMAL-1` | 1 | Hook captured initial input and command; App Server captured identity only before the subscription fix | failed minimum |
+| `ASO-NORMAL-2` | 1 | Hook captured later input and command; App Server captured identity only before the subscription fix | failed minimum |
+| `ASO-NORMAL-2` | 2 | App Server captured turn and successful command outcome, but no user-input source notification | failed minimum; stop rule 2 |
+| remaining six rows | — | Not performed after the mandatory stop | missing minimum |
+
+The retained cohort therefore contains one distinct App Server thread and three Hook turns, not the
+planned seven threads and nine turns. This is an early-stop result, not a completed representative
+cohort.
+
+## Source → Trace IR → ThreadState
+
+For the decisive post-fix turn, the App Server journal contains 45 events and three explicit
+observation gaps. Its source audit classified 15 samples exact and 22 unknown within the selected
+thread; no deduplicated source notifications were excluded.
+
+| Required fact | Source | Trace IR | ThreadState | Timing classification |
+| --- | --- | --- | --- | --- |
+| later user input/content/provenance | not exposed | absent | absent | `STRUCTURALLY_INVISIBLE` |
+| turn identity | exact | exact | exact/partial across lifecycle | visible in time |
+| command start | exact | exact | exact | visible in time |
+| command completion and exit status | exact | exact | exact | `VISIBLE_IN_TIME` before turn completion |
+| runtime usage | exact | exact | adapter-dropped from state | not consequential to this Hook decision |
+
+The source methods observed during the bounded run were thread start/status/token usage,
+turn start/completion, item start/completion and agent-message deltas, hook start/completion,
+goal clearing, rate limits, app-list updates, and remote-control status. There was no user-message
+or input notification. Unknown methods remain in the source audit rather than being discarded.
+
+Hook overlap captured the exact later prompt and successful result, while the App Server captured
+one semantic command action and outcome. The metric still reported `cross_surface_overlap=0`, so
+the two surfaces were not safely correlated into one global semantic action. This unresolved
+identity/correlation gap is additional evidence against Hook removal.
+
+## Labels and timing
+
+- The App Server session is labeled `invisible` for the user-input responsibility.
+- The overlapping Hook session is labeled `visible`.
+- Opportunity `ASO-NORMAL-2-user-prompt-attempt-2` anchors the inferred semantic window from
+  App Server turn start to command start and records the exact-input evidence as absent. The
+  opportunity is consequently unjudgeable for evidence-linked detection rather than treated as a
+  miss or success.
+
+## Per-Hook decision
+
+| Hook | Decision | Reason |
+| --- | --- | --- |
+| `SessionStart` | **NO-GO** | Lifecycle minimums were not completed before the mandatory stop, and identity correlation remained incomplete. |
+| `UserPromptSubmit` | **NO-GO** | Two attempts did not expose the later user input or provenance through App Server notifications. |
+| `PostToolUse` | **NO-GO** | Successful command outcome was exact and timely, but failure, patch, MCP, approval, interrupt, and reconnect minimums were not run after the mandatory stop. |
+
+The command result is encouraging for future `PostToolUse` narrowing, but the predeclared rule does
+not permit promoting a partial surface. All three observation Hooks remain required until a later
+protocol/runtime surface closes the gaps and a new cohort is predeclared.
+
+## Reproduction and retained evidence
+
+The run used the repository's `spotter setup --portable --endpoint`, `spotter daemon restart`,
+remote Codex TUI resume, `spotter observability`, `spotter metrics`, `spotter label`, and
+`spotter label-opportunity` paths. The bounded machine-readable summary is
+[app-server-observability-v1-result.json](app-server-observability-v1-result.json).
+
+Raw isolated artifacts are retained outside Git with these SHA-256 digests:
+
+| Artifact | SHA-256 |
+| --- | --- |
+| Hook journal | `7a28bc644e8bea2b3cca5742f86fdeb4532bb1332d39e670069fd51e4fe4bd65` |
+| App Server thread journal | `54f722c00ebfd2a7371c73e7182acbad8f1d482686eee970a39309fb7b7c5be4` |
+| App Server unscoped journal | `5e64af5e1becf24cef5fe9b26f17097b293d10909fddd17023462044b9e334d8` |
+| Source-audit samples | `8b278bca4c989f0c1d309269f9d0862cd1c65f84ff1327a15fbb99707939724d` |
+

--- a/docs/status.md
+++ b/docs/status.md
@@ -61,7 +61,7 @@ PreToolUse Hook only
 (deterministic synchronous enforcement)
 ```
 
-The shared App Server gate is resolved: an explicitly connected TUI and Spotter can observe and steer the same real turn. The Hook now uses bounded daemon IPC for deterministic enforcement, and `spotterd` owns reconnect/reconciliation for configured App Server endpoints. The #37 instrument now separates Hook, App Server source, Trace IR, and ThreadState coverage, but the available snapshot has no App Server or labeled failure samples, so the post-migration ceiling remains unmeasured under [#303](https://github.com/spotter-agent/spotter/issues/303). See [Observability ceiling baseline](observability-baseline.md).
+The shared App Server gate is resolved: an explicitly connected TUI and Spotter can observe and steer the same real turn. The Hook now uses bounded daemon IPC for deterministic enforcement, and `spotterd` owns reconnect/reconciliation and explicit thread subscriptions for configured App Server endpoints. The [#303 ceiling run](experiments/app-server-observability-v1-result.md) stopped after two attempts exposed no later-user-input notification: command outcomes were exact and timely after the subscription fix, but all three observation Hooks remain **NO-GO** for removal. See [Observability ceiling baseline](observability-baseline.md) for the instrument's earlier zero-sample state.
 The roadmap no longer uses `P0–P9` / `E0–E5`. It is organized by named outcomes:
 
 ```text
@@ -117,8 +117,8 @@ In parallel, the highest-value evidence foundations remain:
 
 - [#42](https://github.com/spotter-agent/spotter/issues/42) — replay/fork fidelity and noise floor;
 - [#37](https://github.com/spotter-agent/spotter/issues/37) — implemented the observability
-  instrument and zero-sample baseline; [#303](https://github.com/spotter-agent/spotter/issues/303)
-  owns representative post-migration measurement and the Hook-removal decision;
+  instrument and zero-sample baseline; the [#303](https://github.com/spotter-agent/spotter/issues/303)
+  run found a structural user-input gap and retained every observation Hook;
 - [#38](https://github.com/spotter-agent/spotter/issues/38) and [#34](https://github.com/spotter-agent/spotter/issues/34) — use the completed #33 runtime cost/timing foundation to measure detection and intervention benefit or harm.
 
 [#21](https://github.com/spotter-agent/spotter/issues/21) now has frozen dev/validation v2 sets,
@@ -139,7 +139,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 
 | Area | Status | What exists now | Next concrete step |
 | --- | --- | --- | --- |
-| Hook ingestion | ✅ | `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse` are journaled | Measure App Server parity in #303, then remove only proven-redundant Hooks in #86 |
+| Hook ingestion | ✅ | `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse` are journaled; #303 found no removable observation Hook | Retain all Hooks; revisit only after a newer source surface closes the measured gaps |
 | Deterministic gate | ✅ | Shell-aware daemon evaluation over bounded local IPC; unavailable/timeout uses the local Gate, while incompatible responses fail open; each Hook request and its IPC/correlated-block telemetry retain the exact resolved config generation; enforced and shadow blocks carry stable supervision IDs, rule versions, normalized effect/resource context, and an on-demand actionable explanation | Continue policy precision/miss-rate measurement |
 | Journal | ✅ | Crash-tolerant JSONL stores identity-rich App Server Trace IR with locking, fsync, torn-tail recovery, recovery gaps, and the bounded retention lifecycle implemented in #89 | Keep retention and recovery behavior in the release regression gate |
 | Snapshot | ✅ | App Server thread baselines and terminal local-mutation snapshots, Hook before-state snapshots, deduplication, pruning, detached restore | Remove only observation Hooks whose snapshot responsibilities pass #303/#86 parity |
@@ -151,7 +151,7 @@ Legend: ✅ implemented · 🟡 partial/shadow · 🧪 proof required · 🎯 ta
 | Counterfactual harness | ✅ | Same-prefix experiments preflight both forks and support explicit neutral-noise or guidance modes; their independently versioned result journal reads legacy history and refuses incompatible or corrupt history before fsynced appends, and durable aggregate reporting preserves neutral outcome disagreement, exact preflight-failure categories, and infrastructure-failure classifications. Frozen task, task-set, and resumable batch schemas are independently identified; batch resume validates before preflight, uses locked fsynced appends and atomic torn-tail repair, and retains optional replay-source session provenance; capture-requested batches prove the exact owned Hook, selected homes, config, and reversible journal round-trip before paid execution, then pin that readiness receipt across incomplete resume | Execute broader natural-failure/noise cohorts in #42 before interpreting intervention effects |
 | Standalone runtime | 🟡 | Long-lived process, IPC, lifecycle, isolated per-thread state, App Server recovery ownership, and verified explicit endpoint setup | Validate multi-TUI and ordinary-launch product behavior in #304 |
 | Runtime identity | ✅ | Logical threads/turns remain separate from per-connection attachment IDs and monotonically recovered epochs; signal-driven reviewer jobs retain their exact turn/epoch target | Enforce the same target identity at future reviewer delivery |
-| App Server primary observation | 🟡 | Configured endpoints route through `spotterd` into independently versioned durable Trace IR with schema-validated, rebuildable journal sidecars and incremental ThreadState; a bounded value-free, independently versioned source audit and conformance corpus measure projection coverage, including Spotter advisory inputs as intervention delivery rather than dropped user-goal evidence; unknown audit schemas degrade visibly without interrupting primary journals | Collect labeled App Server failures in #303, then reduce only proven-redundant Hooks in #86 |
+| App Server primary observation | 🟡 | Configured endpoints subscribe through `thread/resume` and route into independently versioned durable Trace IR with schema-validated, rebuildable journal sidecars and incremental ThreadState; #303 proved exact timely successful-command outcomes but found no later-user-input source notification | Keep App Server observation additive and retain Hooks until a new predeclared parity run closes the source and correlation gaps |
 | Managed Codex lifecycle | 🟡 | Transactional setup/teardown, verified explicit external endpoints, an independently versioned ownership manifest with rollback, managed service, diagnostics, configured-endpoint recovery, and temporary observation Hooks until #86 parity; shared App Server process ownership remains external | Productize ordinary Codex launch in #304 without weakening ownership boundaries |
 | Runtime reconnect/recovery | ✅ | Explicit connect/reconcile/backoff states, restart hydration, durable gaps, capability/server fingerprints, stale-control fencing, and the retention/checkpoint lifecycle implemented in #89 | Keep reconnect, hydration, and retention behavior in the release regression gate |
 | Event-driven detection | 🟡 | All eight initial families journal identity/evidence-rich active, cooled-down, resolved, and stale candidates for explicit normalized failures, equivalent calls, frontierless reads, deterministic-block recurrence, request-scope growth, scope-matched unvalidated edits, causal stale-hypothesis reuse, and relative token/duration pressure; opted-in active candidates merge into priority-ordered, budget-capped asynchronous reviews with bounded immutable inputs, while stale targets never deliver; queue/decision provenance and metrics now stratify signal, periodic, and manual launches | Compare event-driven, periodic-only, and mixed fallback-cadence precision/cost in #38/#24 using #33 telemetry |
@@ -205,7 +205,7 @@ Implementation progress and research evidence remain separate.
 | Is there a reproducible mechanically scored task corpus? | **Yes for the synthetic v2 foundation — six frozen tasks and a reportable 6/6-arm dev run; external/ecosystem breadth remains future work (#21)** |
 | Has live Spotter guidance been shown to improve outcomes? | **No** |
 | Is the App Server control boundary operationally viable? | **Yes for a configured Spotter-managed external path, including daemon reconnect/reconciliation** |
-| Is the post-App-Server visible-in-time ceiling measured? | **No — #37 implemented the instrument, but the current sample has 0 App Server sessions and 0/9 labeled sessions; #303 owns representative measurement** |
+| Is the post-App-Server visible-in-time ceiling measured? | **Partially — #303 stopped by rule after the later-user-input row failed twice; command success was visible in time, but every observation Hook remains NO-GO for removal** |
 
 A mechanism being implemented does not prove it improves outcomes. Null and negative results are first-class outcomes for this project.
 

--- a/src/spotter/codex_host.py
+++ b/src/spotter/codex_host.py
@@ -4,10 +4,18 @@ import re
 from dataclasses import dataclass
 
 _CODEX_VERSION = re.compile(
-    r"^(?:codex|codex-cli|codex_cli_rs)[ /]"
+    r"^(?:(?:codex|codex-cli|codex_cli_rs)[ /]|Codex Desktop/)"
     r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)"
     r"(?:\.(?P<patch>0|[1-9]\d*))?"
     r"(?P<suffix>[-+][0-9A-Za-z.-]+)?$"
+)
+
+_CODEX_DESKTOP_VERSION = re.compile(
+    r"^Codex Desktop/"
+    r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)"
+    r"(?:\.(?P<patch>0|[1-9]\d*))?"
+    r"(?P<suffix>[-+][0-9A-Za-z.-]+)?"
+    r" \([^()\r\n]+\) [^()\s]+ \([^()\r\n]+\)$"
 )
 
 
@@ -32,7 +40,8 @@ def parse_codex_host_version(raw: object) -> CodexHostVersion:
     """Parse CLI and App Server identities without guessing arbitrary text."""
     if not isinstance(raw, str) or not raw.strip():
         raise CodexHostVersionError("Codex host version is missing")
-    match = _CODEX_VERSION.fullmatch(raw.strip())
+    value = raw.strip()
+    match = _CODEX_VERSION.fullmatch(value) or _CODEX_DESKTOP_VERSION.fullmatch(value)
     if match is None:
         raise CodexHostVersionError(f"malformed Codex host version {raw!r}")
     suffix = match.group("suffix")

--- a/src/spotter/runtime_connection.py
+++ b/src/spotter/runtime_connection.py
@@ -18,6 +18,7 @@ from spotter.app_server import (
     AppServerCapabilities,
     AppServerControlError,
     AppServerError,
+    AppServerEvent,
     AppServerRpcError,
     AppServerTransportError,
     CapabilityStatus,
@@ -149,6 +150,7 @@ class AppServerRecoveryLoop:
         self._stop = asyncio.Event()
         self._retry = asyncio.Event()
         self._attachments: dict[ThreadId, AttachmentId] = {}
+        self._subscribed_threads: set[str] = set()
         self._disconnected_at: float | None = None
         self._control_telemetry_queue_size = control_telemetry_queue_size
         self._control_telemetry_queue: asyncio.Queue[_QueuedControlEvent] | None = None
@@ -599,6 +601,7 @@ class AppServerRecoveryLoop:
                     stack.push_async_callback(client.disconnect)
                     self._connection_epoch += 1
                     epoch = self._connection_epoch
+                    self._subscribed_threads.clear()
                     attachment_id = uuid4().hex
                     connected_at = time.time()
                     server_fingerprint = _fingerprint(client.server_info or {})
@@ -710,6 +713,7 @@ class AppServerRecoveryLoop:
                     disposition="ingested" if record is not None else "deduplicated",
                     state_status=state_status,
                 )
+                await self._subscribe_from_event(client, raw_event)
             except IngestionError as error:
                 self.last_error = str(error)
             except AppServerError:
@@ -720,6 +724,34 @@ class AppServerRecoveryLoop:
                 self._set_state(RecoveryState.DEGRADED, message)
                 await client.disconnect()
                 raise AppServerTransportError(message) from error
+
+    async def _subscribe_from_event(
+        self, client: CodexAppServerClient, raw_event: AppServerEvent
+    ) -> None:
+        if raw_event.method not in {"thread/started", "thread/status/changed", "turn/started"}:
+            return
+        params = raw_event.raw.get("params")
+        if not isinstance(params, Mapping):
+            return
+        external_thread_id = params.get("threadId")
+        if not isinstance(external_thread_id, str):
+            thread = params.get("thread")
+            external_thread_id = thread.get("id") if isinstance(thread, Mapping) else None
+        if (
+            not isinstance(external_thread_id, str)
+            or not external_thread_id
+            or external_thread_id in self._subscribed_threads
+        ):
+            return
+        try:
+            await client.resume_thread(external_thread_id)
+        except AppServerRpcError as error:
+            if _rollout_pending(error):
+                return
+            raise RuntimeError(
+                f"could not subscribe to App Server thread {external_thread_id}"
+            ) from error
+        self._subscribed_threads.add(external_thread_id)
 
     async def _reconcile(
         self,
@@ -749,7 +781,14 @@ class AppServerRecoveryLoop:
         capabilities = _available_capabilities(client.capabilities)
         ended_at = time.time()
         for external_thread_id in sorted(discovered):
-            result = await client.read_thread(external_thread_id, include_turns=True)
+            try:
+                result = await client.resume_thread(external_thread_id)
+            except AppServerRpcError as error:
+                if not _rollout_pending(error):
+                    raise
+                result = await client.read_thread(external_thread_id, include_turns=True)
+            else:
+                self._subscribed_threads.add(external_thread_id)
             thread = result.get("thread")
             thread = thread if isinstance(thread, Mapping) else discovered[external_thread_id]
             active_turn_id = _active_turn_id(thread)
@@ -1275,6 +1314,10 @@ def _active_turn_id(thread: Mapping[str, Any]) -> str | None:
             if status in {"active", "inProgress", "running"} and isinstance(turn_id, str):
                 return turn_id
     return None
+
+
+def _rollout_pending(error: AppServerRpcError) -> bool:
+    return "no rollout found" in error.message.casefold()
 
 
 def _available_capabilities(capabilities: AppServerCapabilities) -> tuple[str, ...]:

--- a/tests/test_codex_host.py
+++ b/tests/test_codex_host.py
@@ -14,6 +14,10 @@ from spotter.codex_host import (
         ("codex_cli_rs/1.2.3", CodexHostVersion(1, 2, 3)),
         ("codex 1.0", CodexHostVersion(1, 0, 0)),
         ("codex-cli 0.147.0+homebrew", CodexHostVersion(0, 147, 0)),
+        (
+            "Codex Desktop/0.147.0 (Mac OS 26.5.1; arm64) dumb (spotter; 0.1.0)",
+            CodexHostVersion(0, 147, 0),
+        ),
     ],
 )
 def test_supported_codex_host_versions(raw: str, expected: CodexHostVersion) -> None:
@@ -26,6 +30,7 @@ def test_supported_codex_host_versions(raw: str, expected: CodexHostVersion) -> 
         ("codex-cli 0.146.9", "too old"),
         ("codex-cli 0.148.0-beta.1", "prerelease"),
         ("codex development", "malformed"),
+        ("Codex Desktop/0.147.0 arbitrary metadata", "malformed"),
         ("0.147.0", "malformed"),
         (None, "missing"),
     ],

--- a/tests/test_runtime_connection.py
+++ b/tests/test_runtime_connection.py
@@ -127,6 +127,63 @@ def test_turn_boundary_callback_runs_before_turn_is_reduced(tmp_path: Path) -> N
     asyncio.run(scenario())
 
 
+def test_new_thread_notification_subscribes_to_followup_events(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await _initialize(connection)
+            listed = await _receive(connection, "thread/list")
+            await _reply(connection, listed, {"data": [], "nextCursor": None})
+            await connection.send(
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "method": "thread/started",
+                        "params": {"thread": {"id": "thread-1"}},
+                    }
+                )
+            )
+            resumed = await _receive(connection, "thread/resume")
+            assert resumed["params"]["threadId"] == "thread-1"
+            await _reply_error(connection, resumed, -32000, "no rollout found for thread")
+            await connection.send(
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "method": "thread/status/changed",
+                        "params": {"threadId": "thread-1", "status": "active"},
+                    }
+                )
+            )
+            resumed = await _receive(connection, "thread/resume")
+            await _reply(connection, resumed, {"thread": {"id": "thread-1", "turns": []}})
+            await connection.send(
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "method": "turn/started",
+                        "params": {"threadId": "thread-1", "turn": {"id": "turn-1"}},
+                    }
+                )
+            )
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            recovery = AppServerRecoveryLoop(endpoint, tmp_path / "sessions", ThreadStateStore())
+            await recovery.start()
+            await _wait_until(
+                lambda: (
+                    bool(recovery.thread_states.snapshots())
+                    and recovery.thread_states.snapshots()[0].active_turn_id is not None
+                )
+            )
+            state = recovery.thread_states.snapshots()[0]
+            assert state.identity.provenance.agent_thread_id == "thread-1"
+            assert state.identity.provenance.agent_turn_id == "turn-1"
+            await recovery.close()
+
+    asyncio.run(scenario())
+
+
 def test_runtime_records_the_active_config_generation(tmp_path: Path) -> None:
     recovery = AppServerRecoveryLoop(
         "ws://unused",
@@ -155,7 +212,7 @@ def test_reconnect_reconciles_epoch_gap_and_stale_control(tmp_path: Path) -> Non
                 listed,
                 {"data": [{"id": "thread-1"}], "nextCursor": None},
             )
-            read = await _receive(connection, "thread/read")
+            read = await _receive(connection, "thread/resume")
             turns = [{"id": "turn-1", "status": "active"}] if number == 1 else []
             await _reply(
                 connection,
@@ -274,9 +331,7 @@ def test_reconnect_records_server_and_capability_change(tmp_path: Path) -> None:
         async def list_threads(self, *, limit: int, cursor: str | None = None) -> dict[str, object]:
             return {"data": [{"id": "thread-1"}], "nextCursor": None}
 
-        async def read_thread(
-            self, thread_id: str, *, include_turns: bool = False
-        ) -> dict[str, object]:
+        async def resume_thread(self, thread_id: str) -> dict[str, object]:
             return {
                 "thread": {
                     "id": thread_id,
@@ -345,7 +400,7 @@ def test_restart_hydrates_without_control_until_live_reconciliation(tmp_path: Pa
                 listed,
                 {"data": [{"id": "thread-1"}], "nextCursor": None},
             )
-            read = await _receive(connection, "thread/read")
+            read = await _receive(connection, "thread/resume")
             await _reply(
                 connection,
                 read,
@@ -393,7 +448,7 @@ def test_settled_final_answer_fences_steer_but_not_interrupt(tmp_path: Path) -> 
                 listed,
                 {"data": [{"id": "thread-1"}], "nextCursor": None},
             )
-            read = await _receive(connection, "thread/read")
+            read = await _receive(connection, "thread/resume")
             await _reply(
                 connection,
                 read,
@@ -456,7 +511,7 @@ def test_control_rejection_and_unknown_acceptance_are_distinct(tmp_path: Path) -
                 listed,
                 {"data": [{"id": "thread-1"}], "nextCursor": None},
             )
-            read = await _receive(connection, "thread/read")
+            read = await _receive(connection, "thread/resume")
             await _reply(
                 connection,
                 read,
@@ -556,7 +611,7 @@ def test_accepted_steer_without_observed_input_finishes_durably(
                 listed,
                 {"data": [{"id": "thread-1"}], "nextCursor": None},
             )
-            read = await _receive(connection, "thread/read")
+            read = await _receive(connection, "thread/resume")
             await _reply(
                 connection,
                 read,
@@ -626,7 +681,7 @@ def test_turn_terminal_before_steer_ack_closes_acceptance_once(tmp_path: Path) -
                 listed,
                 {"data": [{"id": "thread-1"}], "nextCursor": None},
             )
-            read = await _receive(connection, "thread/read")
+            read = await _receive(connection, "thread/resume")
             await _reply(
                 connection,
                 read,
@@ -703,7 +758,7 @@ def test_control_rpc_does_not_wait_for_bounded_telemetry_io(
                 listed,
                 {"data": [{"id": "thread-1"}], "nextCursor": None},
             )
-            read = await _receive(connection, "thread/read")
+            read = await _receive(connection, "thread/resume")
             await _reply(
                 connection,
                 read,
@@ -787,7 +842,7 @@ def test_intervention_input_is_scoped_without_replacing_later_user_goals(tmp_pat
                 listed,
                 {"data": [{"id": "thread-1"}], "nextCursor": None},
             )
-            read = await _receive(connection, "thread/read")
+            read = await _receive(connection, "thread/resume")
             await _reply(
                 connection,
                 read,
@@ -943,7 +998,7 @@ def test_reconciliation_keeps_multiple_threads_isolated(tmp_path: Path) -> None:
                 },
             )
             for thread_id, turn_id in (("thread-1", "turn-1"), ("thread-2", "turn-2")):
-                read = await _receive(connection, "thread/read")
+                read = await _receive(connection, "thread/resume")
                 assert read["params"]["threadId"] == thread_id
                 await _reply(
                     connection,


### PR DESCRIPTION
## Why

#303 requires a predeclared, source-aware ceiling measurement before any observation Hook can be removed. The live run exposed two runtime blockers and then hit the frozen stop rule when a later user input remained absent from App Server notifications on a second attempt.

## What changed

- predeclare the App Server cohort, coverage matrix, labels, and stop rule before execution
- accept the bounded Codex Desktop 0.147.0 App Server host identity
- subscribe reconciled and newly observed threads with `thread/resume`, including the expected pre-rollout retry path
- publish the bounded result and SHA-256 evidence digests
- record independent NO-GO decisions for `SessionStart`, `UserPromptSubmit`, and `PostToolUse`
- update status and architecture so no observation Hook is treated as removable

The decisive post-fix attempt captured command start/completion and exit status in time, but the App Server source emitted no user-input content/provenance notification. Per the predeclared rule, the remaining rows were not substituted after the second failed attempt.

## Validation

- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy src tests`
- `python -m pytest` — 1003 passed
- live Codex CLI/App Server 0.147.0 run with isolated Spotter/Codex homes and throwaway repository

Closes #303