### PR TITLE
feat: diagnose plain Codex launch

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -767,6 +767,9 @@ Spotter sees/attaches same thread
 RuntimeAttachment becomes ACTIVE
 ```
 
+`status` and `doctor` always name `spotter codex` as the supported launch. Plain `codex` selects an
+embedded server and is reported as lacking Spotter observation and live control for that TUI.
+
 ## 7.2 Thread initialization
 
 For a newly observed thread, Spotter should create live state and a durable provenance header.

--- a/src/spotter/doctor.py
+++ b/src/spotter/doctor.py
@@ -544,6 +544,15 @@ def check_runtime(*, deep: bool = False) -> list[Check]:
     endpoint = (
         integration.manifest.app_server_endpoint if integration.manifest is not None else None
     )
+    if endpoint is not None:
+        checks.append(
+            Check(
+                "Codex launch",
+                INFO,
+                "use `spotter codex`; plain `codex` selects an embedded App Server, so "
+                "Spotter observation and live control do not follow that TUI",
+            )
+        )
     if endpoint is not None and daemon.available:
         capability_summary = ", ".join(
             f"{name}={value}" for name, value in (daemon.app_server_capabilities or ())

--- a/tests/test_runtime_diagnostics.py
+++ b/tests/test_runtime_diagnostics.py
@@ -125,6 +125,20 @@ def test_configured_integration_with_dead_daemon_is_broken_with_local_fallback(
     assert "local fallback" in by_name["enforcement"].detail
 
 
+def test_configured_endpoint_reports_the_supported_codex_launch(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest = replace(_ready_manifest(homes), app_server_endpoint="ws://127.0.0.1:4500")
+    manifest.save(homes[0] / "integrations/codex.json")
+    _daemon_status(monkeypatch, RuntimeHealth.HEALTHY)
+
+    check = {item.name: item for item in check_runtime()}["Codex launch"]
+
+    assert check.status == INFO
+    assert "use `spotter codex`" in check.detail
+    assert "plain `codex` selects an embedded App Server" in check.detail
+
+
 def test_integration_check_detects_duplicate_owned_hooks(homes: tuple[Path, Path]) -> None:
     manifest = _ready_manifest(homes)
     hooks = json.loads(Path(manifest.hooks_file).read_text())


### PR DESCRIPTION
## Why

A configured external App Server can be healthy while a user launches plain `codex`, which selects an embedded server outside Spotter observation and control. Diagnostics should name that boundary explicitly.

## What changed

- add a `Codex launch` runtime diagnostic directing users to `spotter codex`
- explain why plain `codex` is degraded even with a configured endpoint
- document the supported launch contract

Refs #304

## Validation

- `ruff format --check .`
- `ruff check .`
- `mypy src tests`
- `pytest tests/test_runtime_diagnostics.py -q` (25 passed)