### PR TITLE
docs: scope the supported-launch statement to a configured endpoint

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -767,8 +767,10 @@ Spotter sees/attaches same thread
 RuntimeAttachment becomes ACTIVE
 ```
 
-`status` and `doctor` always name `spotter codex` as the supported launch. Plain `codex` selects an
-embedded server and is reported as lacking Spotter observation and live control for that TUI.
+`status` and `doctor` name `spotter codex` as the supported launch whenever an App Server
+endpoint is configured; without one that launch is unavailable and the endpoint checks report it.
+Plain `codex` selects an embedded server and is reported as lacking Spotter observation and live
+control for that TUI.
 
 ## 7.2 Thread initialization
 


### PR DESCRIPTION
## Why

#319 added a `Codex launch` runtime diagnostic and a lifecycle sentence stating that `status` and `doctor` *always* name `spotter codex` as the supported launch. They do not: the check is emitted only when `app_server_endpoint` is configured.

That gate is correct — `spotter codex` refuses to launch without an endpoint, and `setup` prints its "Start the shared Codex TUI" line under the same condition — so the code is internally consistent. Only the doc sentence claims a contract the runtime does not honor.

## What changed

- `docs/lifecycle.md`: scope the statement to a configured endpoint and say what happens without one.

## Validation

Documentation only; no code paths touched. `ruff format --check .` and `ruff check .` are unaffected by a Markdown-only change.

Refs #304