### PR TITLE
fix: bound interrupt settlement bookkeeping to in-flight interrupts

### DIFF
--- a/src/spotter/runtime_connection.py
+++ b/src/spotter/runtime_connection.py
@@ -164,6 +164,7 @@ class AppServerRecoveryLoop:
         self._accepted_controls: dict[str, dict[str, object]] = {}
         self._observed_control_ids: set[str] = set()
         self._terminal_turn_status: dict[str, str | None] = {}
+        self._interrupt_target_turns: set[str] = set()
         self._interrupt_settlement_timeout = interrupt_settlement_timeout
         self._settled_interrupt_ids: set[str] = set()
         self._interrupt_deadlines: dict[str, asyncio.Task[None]] = {}
@@ -219,6 +220,12 @@ class AppServerRecoveryLoop:
                     self._settled_interrupt_ids.add(control_id)
                     pending_interrupts.pop(control_id, None)
         self._pending_interrupt_deadlines = tuple(pending_interrupts.values())
+        # A resumed interrupt still needs its target turn watched, or the status
+        # lookup would be empty for the one boundary it is waiting on.
+        for _, payload in self._pending_interrupt_deadlines:
+            target_turn = payload.get("target_turn_id")
+            if isinstance(target_turn, str) and target_turn:
+                self._interrupt_target_turns.add(target_turn)
         if records:
             self.thread_states.hydrate(records)
             for candidate, trigger in self.signals.hydrate(records):
@@ -455,6 +462,12 @@ class AppServerRecoveryLoop:
 
         if payload.get("intervention_id") == request_id:
             self._control_requests[request_id] = dict(payload)
+        if control_kind == "interrupt":
+            # Registered before the RPC: the boundary can be observed before the
+            # ack, and that is exactly the case the status lookup exists for.
+            target_turn = payload.get("target_turn_id")
+            if isinstance(target_turn, str) and target_turn:
+                self._interrupt_target_turns.add(target_turn)
         self._record_control_event("control_dispatch_started", target, payload)
         try:
             if control_kind == "steer":
@@ -973,10 +986,15 @@ class AppServerRecoveryLoop:
             self._observed_control_ids.add(control_id)
         if record.event.kind == "turn_completed":
             if record.event.identity is not None and record.event.identity.turn_id is not None:
-                status = record.event.payload.get("status")
-                self._terminal_turn_status[record.event.identity.turn_id.value] = (
-                    status if isinstance(status, str) else None
-                )
+                # Only turns an interrupt is waiting on. Remembering every turn a
+                # long-lived daemon ever observes would grow without bound to
+                # serve a lookup that a handful of in-flight interrupts need.
+                turn_value = record.event.identity.turn_id.value
+                if turn_value in self._interrupt_target_turns:
+                    status = record.event.payload.get("status")
+                    self._terminal_turn_status[turn_value] = (
+                        status if isinstance(status, str) else None
+                    )
             self._reconcile_unobserved_acceptances(
                 record.event, "target_completed_without_observed_input"
             )
@@ -1137,6 +1155,21 @@ class AppServerRecoveryLoop:
                 reason_code=reason_code,
             )
 
+    def _release_interrupt_target(self, target_turn: object) -> None:
+        """Forget a turn's terminal status once no interrupt is still waiting on it."""
+
+        if not isinstance(target_turn, str) or not target_turn:
+            return
+        if any(
+            payload.get("control_kind") == "interrupt"
+            and payload.get("target_turn_id") == target_turn
+            and control_id not in self._settled_interrupt_ids
+            for control_id, payload in self._accepted_controls.items()
+        ):
+            return
+        self._interrupt_target_turns.discard(target_turn)
+        self._terminal_turn_status.pop(target_turn, None)
+
     def _settle_interrupt(
         self,
         target: RuntimeControlTarget,
@@ -1154,6 +1187,7 @@ class AppServerRecoveryLoop:
         deadline = self._interrupt_deadlines.pop(control_id, None)
         if deadline is not None and not deadline.done():
             deadline.cancel()
+        self._release_interrupt_target(payload.get("target_turn_id"))
         self._record_control_event(
             "control_terminal",
             target,

--- a/tests/test_runtime_connection.py
+++ b/tests/test_runtime_connection.py
@@ -1613,3 +1613,104 @@ def test_restart_does_not_resettle_an_interrupt_that_already_terminated(tmp_path
             await recovered.close()
 
     asyncio.run(scenario())
+
+
+def test_uninterrupted_turns_leave_no_settlement_bookkeeping(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await _initialize(connection)
+            listed = await _receive(connection, "thread/list")
+            await _reply(connection, listed, {"data": [{"id": "thread-1"}], "nextCursor": None})
+            read = await _receive(connection, "thread/resume")
+            await _reply(
+                connection,
+                read,
+                {"thread": {"id": "thread-1", "turns": [{"id": "turn-1", "status": "active"}]}},
+            )
+            for number in range(1, 4):
+                await connection.send(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "turn/completed",
+                            "params": {
+                                "threadId": "thread-1",
+                                "turn": {"id": f"turn-{number}", "status": "completed"},
+                            },
+                        }
+                    )
+                )
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            recovery = AppServerRecoveryLoop(endpoint, tmp_path / "sessions", ThreadStateStore())
+            await recovery.start()
+            await _wait_until(
+                lambda: (
+                    sum(
+                        record.event.kind == "turn_completed"
+                        for record in recovery.ingestor.records()
+                    )
+                    >= 3
+                )
+            )
+
+            # Ordinary observation must not accumulate per-turn state: a daemon
+            # that watches turns for days would otherwise grow without bound to
+            # serve a lookup only in-flight interrupts ever read.
+            assert recovery._terminal_turn_status == {}
+            await recovery.close()
+
+    asyncio.run(scenario())
+
+
+def test_settled_interrupt_releases_its_target_turn_bookkeeping(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await _initialize(connection)
+            listed = await _receive(connection, "thread/list")
+            await _reply(connection, listed, {"data": [{"id": "thread-1"}], "nextCursor": None})
+            read = await _receive(connection, "thread/resume")
+            await _reply(
+                connection,
+                read,
+                {"thread": {"id": "thread-1", "turns": [{"id": "turn-1", "status": "active"}]}},
+            )
+            interrupt = await _receive(connection, "turn/interrupt")
+            await _reply(connection, interrupt, {"turnId": "turn-1"})
+            await connection.send(
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "method": "turn/completed",
+                        "params": {
+                            "threadId": "thread-1",
+                            "turn": {"id": "turn-1", "status": "interrupted"},
+                        },
+                    }
+                )
+            )
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            recovery = AppServerRecoveryLoop(endpoint, tmp_path / "sessions", ThreadStateStore())
+            await recovery.start()
+            await _wait_until(lambda: recovery.state == RecoveryState.READY)
+            state = recovery.thread_states.snapshots()[0]
+            target = RuntimeControlTarget(state.identity, state.connection_epoch or 0)
+
+            await recovery.interrupt(target, control_id="spotter:interrupt:bounded")
+            await _wait_until(
+                lambda: any(
+                    record.event.kind == "control_terminal"
+                    and record.event.payload.get("control_id") == "spotter:interrupt:bounded"
+                    for record in recovery.ingestor.records()
+                )
+            )
+            await recovery.flush_control_telemetry()
+
+            assert recovery._interrupt_target_turns == set()
+            assert recovery._terminal_turn_status == {}
+            await recovery.close()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Why

Auditing my own #324 change rather than the next feature. It introduced `_terminal_turn_status` so the post-ack settlement path could classify a turn that had already completed. It populates that map on **every** `turn_completed`, for every thread, and never removes an entry.

`spotterd` is a long-lived process whose whole job is watching turns. It therefore accumulates one permanent entry per turn it ever observes, to serve a lookup that only in-flight interrupts read — and interrupts are dispatched by nothing today and gated off by default when they are. The growth is small per entry and unbounded in duration, which is the combination that never shows up in a test run and does show up in a process that has been up for a week.

## What changed

- retain a turn's terminal status only while a dispatched interrupt is waiting on that turn
- register the target turn **before** the RPC, so the boundary-before-ack race #324's CI caught stays covered
- release the turn once no unsettled interrupt targets it
- re-register targets for interrupts resumed by #326's hydration, or a restart would leave the resumed interrupt watching a turn whose status is never recorded

## Notes on the shape

Release is guarded by a scan of `_accepted_controls` rather than a plain discard, because two interrupts can target the same turn and settling one must not drop the status the other still needs. That scan is over interrupts only, which are rare by construction.

`_settled_interrupt_ids` still grows for the life of the process. That is deliberate: it is what makes settlement idempotent, it is bounded by interrupts rather than turns, and it matches the existing `_control_request_ids` behavior.

## Validation

- `ruff format --check .`, `ruff check .`, `mypy src tests`
- full `pytest`: 1038 passed

Two new tests, both failing on `main`. The first is the one that states the bug plainly: three ordinary turns complete with no interrupt anywhere, and `_terminal_turn_status` must be empty — on `main` it holds all three.

Refs #26