### PR TITLE
fix: explain a failed preflight instead of naming only the phase

### DIFF
--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -652,6 +652,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         for result in preflight_results:
             print(f"  {result.task_id}: {result.classification}")
+            if result.classification == PreflightClassification.READY:
+                continue
+            # A bare classification cannot be acted on: it names which phase
+            # refused, never why. The failing command already holds the reason.
+            for line in _preflight_failure_lines(result):
+                print(f"    {line}")
         if any(
             result.classification != PreflightClassification.READY for result in preflight_results
         ):
@@ -1192,6 +1198,36 @@ def _effects_main(
         return 1
     print(f"recorded {resolution} resolution for {effect_id}")
     return 0
+
+
+def _preflight_failure_lines(result: TaskPreflight) -> list[str]:
+    """Explain a non-READY preflight from the command that actually refused."""
+
+    failed = next(
+        (
+            command
+            for command in reversed(result.commands)
+            if command.timed_out or command.returncode != 0
+        ),
+        result.commands[-1] if result.commands else None,
+    )
+    if failed is None:
+        return ["no command output was captured"]
+    if failed.timed_out:
+        outcome = "timed out"
+    elif failed.returncode is None:
+        outcome = "rejected"
+    else:
+        outcome = f"exit {failed.returncode}"
+    lines = [f"{failed.phase}: {outcome}"]
+    # The tail is where a failing command says why; the head is usually progress.
+    for stream, text in (("stderr", failed.stderr), ("stdout", failed.stdout)):
+        body = text.strip()
+        if not body:
+            continue
+        tail = body.splitlines()[-5:]
+        lines.extend(f"{stream}: {line[:300]}" for line in tail)
+    return lines
 
 
 def _intervention_history() -> tuple[InterventionSummary, ...]:

--- a/tests/test_task_corpus.py
+++ b/tests/test_task_corpus.py
@@ -1078,3 +1078,27 @@ def test_task_batch_cli_requires_paid_run_opt_in(
     assert captured["capture_replay_sources"] is True
     assert captured["reasoning_effort"] == "low"
     assert f"results written to {output}" in capsys.readouterr().out
+
+
+def test_cli_preflight_failure_names_the_command_that_refused(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _corpus(tmp_path)
+    task = tmp_path / "tasks" / "parser.toml"
+    text = task.read_text()
+    text = text.replace(
+        '[setup]\ncommand = "python3 -m compileall ."',
+        "[setup]\ncommand = \"python3 -c 'raise SystemExit(3)' "
+        "&& echo unreachable || (echo 'missing toolchain' >&2; exit 3)\"",
+    )
+    task.write_text(text)
+    _refreeze_task(tmp_path, path)
+
+    assert main(["tasks", "preflight", str(path)]) == 1
+
+    printed = capsys.readouterr().out
+    assert "SETUP_FAIL" in printed
+    # A classification alone names which phase refused, never why. Without the
+    # failing command's own words the operator cannot act on it.
+    assert "setup: exit 3" in printed
+    assert "missing toolchain" in printed


### PR DESCRIPTION
## Why

I ran the frozen #42 cohort. Two of four tasks came back `UNJUDGEABLE` and the command printed exactly that — four task IDs and four classifications, nothing else. `TaskPreflight` already carries every `CommandResult`, including the stdout and stderr of the command that refused; the CLI threw all of it away.

Diagnosing the run meant writing a throwaway script to reach output the run had already captured and discarded. That is the "fail visibly, not silently" rule in AGENTS.md: a classification names *which phase* refused and never *why*, and #42 is precisely the issue where an operator has to tell an instrument defect apart from a task outcome.

## What changed

Non-READY results now print the failing command's phase, its exit code or timeout, and the tail of its stderr and stdout. READY output is unchanged.

The tail rather than the head: a failing command states its reason at the end, while the beginning is usually progress. Five lines per stream, 300 characters per line — enough for a compiler error or a pytest summary without pasting a container build log into the terminal.

The reported command is the last one that failed, falling back to the last command overall. `_preflight_task` returns as soon as a phase refuses, so the failing command is normally last — but `UNJUDGEABLE` is reached by *completing* every phase with the wrong result, and there the search matters.

## What it produced immediately

Rerunning the same cohort with this change turned an unexplained `UNJUDGEABLE` into a diagnosis:

```
swebench/verified/pytest-dev__pytest-10356: UNJUDGEABLE
  positive:swebench-resolution: exit 4
  stderr: ERROR: /testbed/pyproject.toml: 'minversion' requires pytest-2.0,
          actual pytest-0.1.dev1+g3c1534944.d20260821
```

That is not a task failure. `_materialize_task_source` fetches with `--no-tags --depth=1`, so `setuptools_scm` cannot derive a version, and pytest's own `minversion` gate then refuses to run its own test suite. An environment-fidelity defect in the instrument, which is the category #42 exists to separate from task outcomes — and it was invisible before this change.

I am reporting that separately rather than folding a fix into this PR. The frozen protocol states that no row may be reweighted after preflight outcomes, so the instrument fix and the frame it invalidates need to be handled deliberately, not quietly.

## Validation

- `ruff format --check .`, `ruff check .`, `mypy src tests`
- full `pytest`: 1039 passed

One new test drives a task whose setup exits non-zero and asserts the CLI names both the phase and the command's own message.

Refs #42