### PR TITLE
fix: stop flagging scratch writes as a workspace escape

### DIFF
--- a/src/spotter/gates.py
+++ b/src/spotter/gates.py
@@ -11,9 +11,11 @@ patch to this very file) no longer trips the gate. First shadow-mode field
 data showed 6/6 false positives from exactly that raw-string matching.
 """
 
+import os
 import posixpath
 import re
 import shlex
+import tempfile
 from collections.abc import Iterable
 from dataclasses import dataclass
 from fnmatch import fnmatch
@@ -63,6 +65,27 @@ _DEPENDENCY_MANIFESTS = frozenset(
         "Gemfile.lock",
     }
 )
+
+
+def _scratch_roots() -> frozenset[str]:
+    """Ephemeral directories an agent legitimately writes outside the workspace.
+
+    Shadow-mode field data over 213 sessions: ``workspace_escape`` produced 218
+    of 230 gate flags, and 131 of those 218 were scratch writes such as
+    ``/tmp/pr-body.md``. Confining an agent to its workspace was never meant to
+    forbid a temp file, and enforcing that rule as written would block ordinary
+    work. The other 87 were writes into sibling repository checkouts, which this
+    allowance deliberately still blocks.
+
+    Both spellings are kept because macOS resolves ``/tmp`` and ``$TMPDIR``
+    through ``/private`` and agents produce either form.
+    """
+    declared = {"/tmp", "/var/tmp", tempfile.gettempdir()}
+    resolved = {os.path.realpath(root) for root in declared}
+    return frozenset(posixpath.normpath(root.replace("\\", "/")) for root in declared | resolved)
+
+
+_SCRATCH_ROOTS = _scratch_roots()
 
 _SHELLS = frozenset({"sh", "bash", "zsh", "dash"})
 _CHAIN_SEPARATORS = frozenset({";", "&", "&&", "||", "(", ")"})
@@ -184,6 +207,10 @@ class Gate:
                     continue
                 if path == root or path.startswith(root + "/"):
                     path = posixpath.relpath(path, root)
+                elif _is_scratch(path):
+                    # Ephemeral scratch, not an escape. The path stays absolute so
+                    # forbidden_paths still applies to it.
+                    pass
                 else:
                     return GateDecision(False, "workspace_escape", f"path leaves workspace: {raw}")
             if path.startswith(".."):
@@ -194,6 +221,11 @@ class Gate:
                 if fnmatch(path, pattern):
                     return GateDecision(False, "forbidden_path", f"{path} matches {pattern}")
         return uncertain or ALLOW
+
+
+def _is_scratch(path: str) -> bool:
+    """True for a normalized absolute path inside an ephemeral scratch root."""
+    return any(path == root or path.startswith(root + "/") for root in _SCRATCH_ROOTS)
 
 
 def _rm_hits_catastrophic_target(rest: list[str]) -> bool:

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -1,3 +1,5 @@
+import tempfile
+
 import pytest
 
 from spotter.gates import Gate
@@ -92,6 +94,19 @@ def test_absolute_paths_relativized_against_root() -> None:
     # Without a root we cannot judge absolute paths: fail open, not fail wrong.
     unknown = Gate(forbidden_paths=("secrets/*",)).check_paths(["/repo/secrets/key.pem"])
     assert unknown.allowed and unknown.rule == "unknown_workspace"
+
+
+def test_scratch_writes_are_not_a_workspace_escape() -> None:
+    # 219 of 230 shadow-mode gate flags were scratch writes like this one.
+    gate = Gate(forbidden_paths=("*.pem",), root="/repo")
+    assert gate.check_paths(["/tmp/pr-body.md"]).allowed
+    assert gate.check_paths([f"{tempfile.gettempdir()}/report.png"]).allowed
+    # An allowance, not blindness: it is not annotated as a fail-open blind spot.
+    assert gate.check_paths(["/tmp/pr-body.md"]).rule is None
+    # Scratch is still subject to forbidden_paths, and is not a way out of the rule.
+    assert not gate.check_paths(["/tmp/key.pem"]).allowed
+    assert not gate.check_paths(["/tmp/../etc/passwd"]).allowed
+    assert not gate.check_paths(["/etc/passwd"]).allowed
 
 
 def test_blocks_dependency_manifest_when_configured() -> None:


### PR DESCRIPTION
## Why

`workspace_escape` is the dominant gate rule in practice, and most of what it catches is not an
escape. Across 213 shadow-mode sessions on a real machine:

- `workspace_escape` produced **218 of 230** gate flags;
- **131** of those 218 were writes to ephemeral scratch paths — `/tmp/pr-body.md`,
  `/tmp/report.png`, and similar;
- **0** of 218 had ever been labeled, which is why this was invisible until now.

The rule is only survivable because `observation_only` defaults to `true`. Flipping it — the
documented next step for the one capability marked ✅ and actually running — would have blocked
ordinary agent work continuously.

`gates.py`'s own module contract says false positives are the most expensive failure and every
pattern errs toward allowing. The scratch class violated that contract.

## What changed

An absolute path under `/tmp`, `/var/tmp`, or `$TMPDIR` is no longer a workspace escape. Both the
declared and `realpath` spellings are covered, because macOS resolves those through `/private` and
agents produce either form.

Three properties are deliberately preserved:

- **`forbidden_paths` still applies inside scratch.** The path stays absolute rather than
  short-circuiting the loop, so `/tmp/key.pem` against a `*.pem` pattern still blocks.
- **Traversal still blocks.** `normpath` runs before the scratch test, so `/tmp/../etc/passwd`
  resolves to `/etc/passwd` and is rejected.
- **The allowance is not annotated as a fail-open.** It is a policy decision, not an inability to
  judge. Annotating it would record 131 events as blind spots in the gate's own coverage metric and
  misreport the rule's measured blindness.

## How it was validated

The 218 recorded field paths were extracted from the journals and replayed through the corrected
gate:

```
기록된 workspace_escape 경로: 218
수정 후에도 차단되는 건수: 87
해소된 오탐: 131
```

The remaining 87 are writes into sibling repository checkouts under another project root. Those stay
blocked — that is the rule working as intended. Whether a multi-repo workspace should permit them is
a separate policy question, and a good first labeling target for #38.

`ruff format --check`, `ruff check`, `mypy src tests`, and `pytest` (1043 passed) all pass. The new
test covers the allowance, the non-annotation, and both preserved block paths.

Related: #38
