### PR TITLE
fix: count credential exposure where the redactor actually writes

### DIFF
--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -119,7 +119,7 @@ from spotter.provenance import (
     summarize_blocks,
     summarize_interventions,
 )
-from spotter.redact import scan_text
+from spotter.redact import redact
 from spotter.replay import (
     ReplayError,
     branch_coverage,
@@ -1918,6 +1918,7 @@ def _status_main() -> int:
     unreadable = 0
     reviewer_errors = 0
     exposed = 0
+    exposed_sessions: list[str] = []
     for journal in journals:
         try:
             records = StepJournal.load(journal)
@@ -1926,9 +1927,14 @@ def _status_main() -> int:
             unreadable += 1
             continue
         reviewer_errors += sum(1 for r in records if r.event.kind == "reviewer_error")
-        exposed += sum(
-            1 for line in journal.read_text(errors="replace").splitlines() if scan_text(line)
-        )
+        # Scan the same domain the redactor writes: parsed payload values. Scanning
+        # the serialized JSONL line instead matched adjacent and structural text the
+        # redactor never sees as one string, so records this journal had already
+        # redacted were still reported and no migration could have cleared them.
+        journal_exposed = sum(1 for record in records if redact(dict(record.event.payload))[1])
+        if journal_exposed:
+            exposed += journal_exposed
+            exposed_sessions.append(journal.stem)
     if reviewer_errors:
         warned = True
         print(f"reviewer errors recorded: {reviewer_errors} (see {home / 'logs'})")
@@ -1944,9 +1950,12 @@ def _status_main() -> int:
             print(f"reviews today: {totals['day']}  |  tokens recorded: {totals['tokens']}")
     if exposed:
         warned = True
+        shown = ", ".join(exposed_sessions[:3])
+        more = f" (+{len(exposed_sessions) - 3} more)" if len(exposed_sessions) > 3 else ""
         print(
-            f"WARNING: {exposed} pre-redaction lines match credential patterns; "
-            "these journals predate redaction"
+            f"WARNING: {exposed} record(s) in {len(exposed_sessions)} session(s) still hold "
+            f"credential-shaped values; these predate redaction and are not rewritten in place: "
+            f"{shown}{more}"
         )
     verdict = worst(runtime_checks)
     if verdict == FAIL or unreadable or ledger_broken:

--- a/src/spotter/gates.py
+++ b/src/spotter/gates.py
@@ -11,9 +11,11 @@ patch to this very file) no longer trips the gate. First shadow-mode field
 data showed 6/6 false positives from exactly that raw-string matching.
 """
 
+import os
 import posixpath
 import re
 import shlex
+import tempfile
 from collections.abc import Iterable
 from dataclasses import dataclass
 from fnmatch import fnmatch
@@ -63,6 +65,27 @@ _DEPENDENCY_MANIFESTS = frozenset(
         "Gemfile.lock",
     }
 )
+
+
+def _scratch_roots() -> frozenset[str]:
+    """Ephemeral directories an agent legitimately writes outside the workspace.
+
+    Shadow-mode field data over 213 sessions: ``workspace_escape`` produced 218
+    of 230 gate flags, and 131 of those 218 were scratch writes such as
+    ``/tmp/pr-body.md``. Confining an agent to its workspace was never meant to
+    forbid a temp file, and enforcing that rule as written would block ordinary
+    work. The other 87 were writes into sibling repository checkouts, which this
+    allowance deliberately still blocks.
+
+    Both spellings are kept because macOS resolves ``/tmp`` and ``$TMPDIR``
+    through ``/private`` and agents produce either form.
+    """
+    declared = {"/tmp", "/var/tmp", tempfile.gettempdir()}
+    resolved = {os.path.realpath(root) for root in declared}
+    return frozenset(posixpath.normpath(root.replace("\\", "/")) for root in declared | resolved)
+
+
+_SCRATCH_ROOTS = _scratch_roots()
 
 _SHELLS = frozenset({"sh", "bash", "zsh", "dash"})
 _CHAIN_SEPARATORS = frozenset({";", "&", "&&", "||", "(", ")"})
@@ -184,6 +207,10 @@ class Gate:
                     continue
                 if path == root or path.startswith(root + "/"):
                     path = posixpath.relpath(path, root)
+                elif _is_scratch(path):
+                    # Ephemeral scratch, not an escape. The path stays absolute so
+                    # forbidden_paths still applies to it.
+                    pass
                 else:
                     return GateDecision(False, "workspace_escape", f"path leaves workspace: {raw}")
             if path.startswith(".."):
@@ -194,6 +221,11 @@ class Gate:
                 if fnmatch(path, pattern):
                     return GateDecision(False, "forbidden_path", f"{path} matches {pattern}")
         return uncertain or ALLOW
+
+
+def _is_scratch(path: str) -> bool:
+    """True for a normalized absolute path inside an ephemeral scratch root."""
+    return any(path == root or path.startswith(root + "/") for root in _SCRATCH_ROOTS)
 
 
 def _rm_hits_catastrophic_target(rest: list[str]) -> bool:

--- a/src/spotter/redact.py
+++ b/src/spotter/redact.py
@@ -103,12 +103,3 @@ def redact(value: object) -> tuple[object, list[str]]:
             fired.extend(hits)
         return out_list, fired
     return value, []
-
-
-def scan_text(text: str) -> list[str]:
-    """Rules that would fire, without producing the redacted text.
-
-    Used to report that an existing journal contains credentials without
-    printing them back to the terminal.
-    """
-    return [name for name, pattern, _ in _PATTERNS if pattern.search(text)]

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -1,3 +1,5 @@
+import tempfile
+
 import pytest
 
 from spotter.gates import Gate
@@ -92,6 +94,19 @@ def test_absolute_paths_relativized_against_root() -> None:
     # Without a root we cannot judge absolute paths: fail open, not fail wrong.
     unknown = Gate(forbidden_paths=("secrets/*",)).check_paths(["/repo/secrets/key.pem"])
     assert unknown.allowed and unknown.rule == "unknown_workspace"
+
+
+def test_scratch_writes_are_not_a_workspace_escape() -> None:
+    # 219 of 230 shadow-mode gate flags were scratch writes like this one.
+    gate = Gate(forbidden_paths=("*.pem",), root="/repo")
+    assert gate.check_paths(["/tmp/pr-body.md"]).allowed
+    assert gate.check_paths([f"{tempfile.gettempdir()}/report.png"]).allowed
+    # An allowance, not blindness: it is not annotated as a fail-open blind spot.
+    assert gate.check_paths(["/tmp/pr-body.md"]).rule is None
+    # Scratch is still subject to forbidden_paths, and is not a way out of the rule.
+    assert not gate.check_paths(["/tmp/key.pem"]).allowed
+    assert not gate.check_paths(["/tmp/../etc/passwd"]).allowed
+    assert not gate.check_paths(["/etc/passwd"]).allowed
 
 
 def test_blocks_dependency_manifest_when_configured() -> None:

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -131,7 +131,10 @@ def test_status_warns_about_pre_redaction_credentials(
     }
     journal.write_text(json.dumps(record) + "\n")
     assert main(["status"]) == 1
-    assert "match credential patterns" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "credential-shaped values" in out
+    assert "leaked12345" not in out  # reported, never echoed back
+    assert "legacy" in out  # names the session so the warning can be acted on
 
 
 def test_snapshots_are_pruned_once_after_journals_go(

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -6,7 +6,7 @@ import pytest
 
 from spotter.gates import Gate
 from spotter.hook import journal_path, run_hook
-from spotter.redact import PLACEHOLDER, redact, redact_text, scan_text
+from spotter.redact import PLACEHOLDER, redact, redact_text
 from spotter.snapshot import StepJournal
 from spotter.trace import TraceEvent
 
@@ -104,7 +104,20 @@ def test_spotter_directories_are_owner_only(home: Path) -> None:
     assert (journal_path({"session_id": "perm"}).stat().st_mode & 0o077) == 0
 
 
-def test_scan_reports_without_revealing() -> None:
-    names = scan_text("export API_KEY=stillsecret")
-    assert names == ["assignment", "env_export"]  # scan reports every rule that would fire
-    assert "stillsecret" not in " ".join(names)
+def test_a_redacted_record_is_not_reported_as_still_exposed() -> None:
+    """`status`/`doctor` count exposure over parsed payloads, as the writer redacts.
+
+    Counting over the serialized line instead reported records the journal had
+    already redacted, so the warning could never be cleared by any migration.
+    """
+    path = journal_path({"session_id": "s3"})
+    journal = StepJournal(path)
+    journal.record(TraceEvent("tool_proposal", {"command": "export API_KEY=stillsecret"}))
+    record = StepJournal.load(path)[0]
+
+    # `assignment` runs first and takes the value, so `env_export` has nothing left
+    # to match — a scan that reports every rule that *would* fire overcounts here.
+    assert record.event.payload["redacted"] == ["assignment"]
+    assert "stillsecret" not in path.read_text()
+    # What the diagnostic counts: nothing is left for the redactor to remove.
+    assert redact(dict(record.event.payload))[1] == []


### PR DESCRIPTION
## Why

`spotter status` and `spotter doctor` warned:

```
WARNING: 85 pre-redaction lines match credential patterns; these journals predate redaction
```

Both halves of that sentence were wrong on a real 213-session store.

The journal redacts **parsed payload values** before a record reaches disk
(`snapshot.py`, `redact(dict(event.payload))`). The diagnostic scanned the **raw serialized JSONL
line**. Those are different domains, and the line form matched adjacent and structural text that the
redactor never sees as a single string.

The consequence is not just an inflated number. Probing the store found records that carry a
`redacted: ["assignment"]` marker and still trip the warning, while re-running `redact()` on the same
payload fires nothing:

```
kind=tool_result scan=['assignment'] redacted마커=['assignment'] 재redact발화=[]
```

So the warning was **unclearable by construction** — no migration could ever drive it to zero — and
it pinned `doctor` to a non-zero exit permanently. A diagnostic that always warns stops being a
signal.

## What changed

Count over parsed payloads, the same domain the writer redacts. On the real store:

| | count | |
|---|---:|---|
| serialized-line scan (before) | 85 | includes already-redacted records |
| parsed-payload scan (after) | 41 | in 5 sessions, all 2026-08-11..14 |

Every one of the 41 is genuinely pre-redaction legacy data, from before redaction was wired in. The
warning's "predate redaction" claim is now true.

The message also names the sessions, so it can be acted on rather than only alarming:

```
WARNING: 41 record(s) in 5 session(s) still hold credential-shaped values; these predate
redaction and are not rewritten in place: 019fee58-…, 019fee8e-…, 019feea7-… (+2 more)
```

`scan_text` had exactly one caller — the defect above — so it is removed rather than left as a
second, disagreeing definition of the same question.

## A real difference the fix exposes

Scanning and redacting differ in more than input. A scan reports every rule that *would* fire;
redaction is sequential, so an earlier rule that consumes the value leaves later rules nothing to
match. `export API_KEY=…` scans as `["assignment", "env_export"]` but redacts as `["assignment"]`.
The new test pins that, so the two are not silently conflated again.

## Not included

The 41 legacy records are **not** rewritten. In-place journal rewriting touches the durable path
covered by the SIGKILL crash-durability tests, and it is not obviously the right remedy: all 5
sessions are from the first four days of the store, so deleting them may be the cheaper answer. That
is a separate decision, and this PR deliberately does not make it.

## How it was validated

`ruff format --check`, `ruff check`, `mypy src tests`, and `pytest` (1043 passed). The existing
housekeeping test still asserts a true positive is reported, and now also asserts the value is never
echoed back and the session is named.
