### PR TITLE
fix: keep worktree size off the synchronous hook path

### DIFF
--- a/src/spotter/data_inventory.py
+++ b/src/spotter/data_inventory.py
@@ -62,6 +62,9 @@ _FAMILY_DEFAULTS: dict[str, SchemaIdentity] = {
 _OTHER_SCOPE_ROOTS = {
     "backups",
     "forks",
+    # Rebuildable per-repository Git index cache: not durable data, and losing
+    # it costs one slow snapshot, never a record.
+    "index",
     "integrations",
     "logs",
     "lock",

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -8,6 +8,7 @@ the full worktree (including untracked files), and restore never mutates the
 user's checkout.
 """
 
+import hashlib
 import json
 import os
 import subprocess
@@ -93,49 +94,84 @@ def snapshot_worktree(repo: Path, previous: str | None = None) -> str:
     ref, or an idle session grows the ref namespace for free (issue #7).
     Dedup is best-effort — an unreadable ``previous`` just means a new commit.
     """
-    _git(repo, "rev-parse", "--git-dir")  # fail early if not a git repo
-    index_fd, index_path = tempfile.mkstemp(prefix="spotter-index-")
-    os.close(index_fd)
-    os.unlink(index_path)  # git wants to create the index file itself
+    # Fails early if not a git repo, and names the repository for its cached index.
+    common_dir = _git(repo, "rev-parse", "--git-common-dir")
     try:
-        env = {"GIT_INDEX_FILE": index_path}
-        _git(repo, "add", "-A", env=env)
-        tree = _git(repo, "write-tree", env=env)
-        parent_args: list[str] = []
-        head = subprocess.run(
-            ["git", "rev-parse", "--verify", "-q", "HEAD"],
+        tree = _stage_tree(repo, _cached_index(repo, common_dir))
+    except SnapshotError:
+        # A stale, locked, or unreadable cache must never cost a snapshot, and
+        # deleting it could belong to another process: fall back to the
+        # throwaway index this always used before.
+        with _throwaway_index() as fallback:
+            tree = _stage_tree(repo, fallback)
+    parent_args: list[str] = []
+    head = subprocess.run(
+        ["git", "rev-parse", "--verify", "-q", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    if head.returncode == 0:  # unborn HEAD (empty repo) has no parent
+        parent_args = ["-p", head.stdout.strip()]
+    if previous:
+        unchanged = subprocess.run(
+            ["git", "rev-parse", "--verify", "-q", f"{previous}^{{tree}}"],
             cwd=repo,
             capture_output=True,
             text=True,
         )
-        if head.returncode == 0:  # unborn HEAD (empty repo) has no parent
-            parent_args = ["-p", head.stdout.strip()]
-        if previous:
-            unchanged = subprocess.run(
-                ["git", "rev-parse", "--verify", "-q", f"{previous}^{{tree}}"],
-                cwd=repo,
-                capture_output=True,
-                text=True,
-            )
-            if unchanged.returncode == 0 and unchanged.stdout.strip() == tree:
-                # Re-pin unconditionally. A pruned snapshot stays resolvable
-                # until gc runs, so reusing it without restoring the ref hands
-                # the journal a sha that gc will later destroy — the exact
-                # guarantee pinning exists to make (PR #19 review, P0).
-                ref = f"refs/spotter/steps/{previous}"
-                prior_target = _optional_ref_target(repo, ref)
-                _git(repo, "update-ref", ref, previous)
-                _record_ref_or_rollback(repo, ref, previous, prior_target)
-                return previous
-        sha = _git(repo, "commit-tree", tree, *parent_args, "-m", "spotter step snapshot")
-        ref = f"refs/spotter/steps/{sha}"
-        prior_target = _optional_ref_target(repo, ref)
-        _git(repo, "update-ref", ref, sha)
-        _record_ref_or_rollback(repo, ref, sha, prior_target)
-        return sha
+        if unchanged.returncode == 0 and unchanged.stdout.strip() == tree:
+            # Re-pin unconditionally. A pruned snapshot stays resolvable
+            # until gc runs, so reusing it without restoring the ref hands
+            # the journal a sha that gc will later destroy — the exact
+            # guarantee pinning exists to make (PR #19 review, P0).
+            ref = f"refs/spotter/steps/{previous}"
+            prior_target = _optional_ref_target(repo, ref)
+            _git(repo, "update-ref", ref, previous)
+            _record_ref_or_rollback(repo, ref, previous, prior_target)
+            return previous
+    sha = _git(repo, "commit-tree", tree, *parent_args, "-m", "spotter step snapshot")
+    ref = f"refs/spotter/steps/{sha}"
+    prior_target = _optional_ref_target(repo, ref)
+    _git(repo, "update-ref", ref, sha)
+    _record_ref_or_rollback(repo, ref, sha, prior_target)
+    return sha
+
+
+def _stage_tree(repo: Path, index: Path) -> str:
+    env = {"GIT_INDEX_FILE": str(index)}
+    _git(repo, "add", "-A", env=env)
+    return _git(repo, "write-tree", env=env)
+
+
+@contextmanager
+def _throwaway_index() -> Iterator[Path]:
+    index_fd, index_path = tempfile.mkstemp(prefix="spotter-index-")
+    os.close(index_fd)
+    os.unlink(index_path)  # git wants to create the index file itself
+    try:
+        yield Path(index_path)
     finally:
         if os.path.exists(index_path):
             os.unlink(index_path)
+
+
+def _cached_index(repo: Path, common_dir: str) -> Path:
+    """A per-repository index kept between snapshots.
+
+    Git's index caches stat information, so ``git add -A`` only rehashes files
+    that actually changed. Discarding the index on every call made each snapshot
+    rehash the whole worktree — 294ms versus 26ms on a 6,000-file repository —
+    and that cost sat on the synchronous `PreToolUse` path, where it produced a
+    967ms tail on file edits in real sessions.
+
+    This is never the user's own index: it lives under the Spotter home, and the
+    tree it produces is identical either way.
+    """
+    path = Path(common_dir)
+    resolved = path.resolve() if path.is_absolute() else (repo / path).resolve()
+    key = hashlib.sha256(str(resolved).encode()).hexdigest()[:16]
+    return secure_dir(spotter_home() / "index") / f"{key}.idx"
 
 
 def _optional_ref_target(repo: Path, ref: str) -> str | None:

--- a/src/spotter/snapshot.py
+++ b/src/spotter/snapshot.py
@@ -139,9 +139,18 @@ def snapshot_worktree(repo: Path, previous: str | None = None) -> str:
 
 
 def _stage_tree(repo: Path, index: Path) -> str:
+    """Stage the whole worktree into ``index`` and return its tree.
+
+    A reused index trusts cached stat data, so snapshot fidelity would otherwise
+    inherit the user's stat-comparison settings. ``core.trustctime=false`` alone
+    is enough to miss a same-size edit whose mtime was restored, and the snapshot
+    then records the previous content. Both settings are forced for our staging
+    only; the user's own config is untouched.
+    """
     env = {"GIT_INDEX_FILE": str(index)}
-    _git(repo, "add", "-A", env=env)
-    return _git(repo, "write-tree", env=env)
+    trust = ("-c", "core.trustctime=true", "-c", "core.checkStat=default")
+    _git(repo, *trust, "add", "-A", env=env)
+    return _git(repo, *trust, "write-tree", env=env)
 
 
 @contextmanager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Suite-wide isolation from the developer's own Spotter home.
+
+Several durable paths resolve `spotter_home()` from the environment — the global
+lock, journals, the repository registry, and the cached Git index snapshotting
+reuses. A test that reached the real home would mutate a live 200-session store
+and, worse, read state it did not create.
+
+Tests that need a specific home still set `SPOTTER_HOME` themselves; monkeypatch
+in the test wins over this default.
+"""
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_spotter_home(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    home = tmp_path_factory.mktemp("spotter-home")
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setenv("SPOTTER_HOME", str(home))
+        yield home

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -189,7 +189,13 @@ def test_race_hook_snapshot_vs_prune_is_serialized(repo: Path, spotter_home: Pat
     worker = subprocess.Popen(
         [sys.executable, "-c", script, str(repo), str(spotter_home)],
         cwd=Path(__file__).parent.parent,
-        env={"PYTHONPATH": "src", "PATH": "/usr/bin:/bin"},
+        # The worker snapshots, and snapshotting resolves its cached index from
+        # the home: without this the child would reach into the real one.
+        env={
+            "PYTHONPATH": "src",
+            "PATH": "/usr/bin:/bin",
+            "SPOTTER_HOME": str(spotter_home),
+        },
     )
     try:
         deadline = 50

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -80,6 +80,32 @@ def test_cached_index_is_reused_and_survives_corruption(repo: Path, home: Path) 
     assert snapshot_worktree(repo, second) not in (first, second)
 
 
+def test_cached_index_fidelity_does_not_depend_on_user_git_config(repo: Path) -> None:
+    """A reused index trusts cached stat data, so what git compares matters.
+
+    With `core.trustctime=false` an unforced comparison misses a same-size edit
+    whose mtime was restored, and the snapshot silently records the previous
+    content — a fidelity loss the throwaway index could not have.
+    """
+    import os
+
+    subprocess.run(["git", "config", "core.trustctime", "false"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "core.checkStat", "minimal"], cwd=repo, check=True)
+    target = repo / "a.txt"
+    target.write_bytes(b"AAAA")
+    first = snapshot_worktree(repo)
+
+    before = target.stat()
+    target.write_bytes(b"BBBB")  # same size
+    os.utime(target, (before.st_atime, before.st_mtime))  # and same mtime
+
+    second = snapshot_worktree(repo, first)
+    content = subprocess.run(
+        ["git", "show", f"{second}:a.txt"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout
+    assert content == "BBBB", "the snapshot recorded stale content"
+
+
 def test_snapshot_outside_git_repo_fails_loudly(tmp_path: Path) -> None:
     plain = tmp_path / "plain"
     plain.mkdir()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -13,6 +13,14 @@ from spotter.snapshot import (
 from spotter.trace import TraceEvent
 
 
+@pytest.fixture(autouse=True)
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Keep the snapshot lock and the cached Git index out of the real home."""
+    spotter = tmp_path / "spotter-home"
+    monkeypatch.setenv("SPOTTER_HOME", str(spotter))
+    return spotter
+
+
 @pytest.fixture()
 def repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
@@ -49,6 +57,27 @@ def test_snapshot_captures_untracked_and_restore_does_not_touch_worktree(
 def test_snapshot_works_on_empty_repo_without_head(repo: Path) -> None:
     (repo / "only.txt").write_text("x")
     assert snapshot_worktree(repo)
+
+
+def test_cached_index_is_reused_and_survives_corruption(repo: Path, home: Path) -> None:
+    """The index cache is what keeps snapshotting off the worktree-sized path.
+
+    It must be reused across calls, must never be the user's own index, and a
+    damaged cache must cost a slow snapshot rather than the snapshot itself.
+    """
+    (repo / "a.txt").write_text("v1")
+    first = snapshot_worktree(repo)
+    indexes = list((home / "index").glob("*.idx"))
+    assert len(indexes) == 1  # kept, not discarded
+    assert not (repo / ".git" / "index").exists()  # never the user's index
+
+    (repo / "a.txt").write_text("v2")
+    second = snapshot_worktree(repo, first)
+    assert second != first  # a real change still produces a new tree
+
+    indexes[0].write_bytes(b"not a git index")
+    (repo / "a.txt").write_text("v3")
+    assert snapshot_worktree(repo, second) not in (first, second)
 
 
 def test_snapshot_outside_git_repo_fails_loudly(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

AGENTS.md rule 3 requires `PreToolUse`-style enforcement to stay **bounded and deterministic**. It
is neither today.

Across 10,851 real gate calls:

| | |
|---|---:|
| p50 | 2.33 ms |
| p95 | 9.85 ms |
| p99 | 152.77 ms |
| p99.9 | 320.53 ms |
| max | 967.32 ms |

The tail is not the daemon. Every slow call recorded `ipc ≈ 1ms` and `daemon_eval ≈ 0.05ms` — the
gate RPC is fast, and the time is spent inside the hook process.

It is `apply_patch`: **164 of the 249 calls over 100ms (66%)**, while being 2.8% of all calls. A
class-B mutation snapshots the worktree before the hook answers, and in one session the worst calls
ramped monotonically — 326 → 434 → 541 → 646 → 757 → 864 → 967ms — as it progressed.

## Root cause

`snapshot_worktree` created a **fresh empty temporary index** on every call:

```python
index_fd, index_path = tempfile.mkstemp(prefix="spotter-index-")
os.close(index_fd)
os.unlink(index_path)   # git wants to create the index file itself
```

An empty index has no stat cache, so `git add -A` re-stats and re-hashes the **entire worktree**
every single time. That is an O(worktree) term on the synchronous path, which is exactly why the
cost scales with repository size and grows as a session touches more files.

## What changed

One index per repository, kept under the Spotter home. Git's index caches stat information, so
`add -A` only rehashes files that actually changed.

Measured across the whole of `snapshot_worktree`:

| repository | cold | warm |
|---|---:|---:|
| 276 files | 207 ms | 97 ms |
| 6,000 files | 663 ms | 96 ms |

**The worktree-size term is gone** — warm cost no longer depends on repository size. The remaining
~96ms is fixed overhead from the other git subprocesses and the registry write; reducing that is a
separate change and is not attempted here.

Isolated `git add -A` + `write-tree` on the 6,000-file repo: 294ms → 26ms, with a byte-identical
tree.

## What deliberately did not change

- **Same result.** Same tree, same commit, same dedup path. A modified file still produces a new
  tree; the new test asserts it.
- **Never the user's index.** The cache lives under the Spotter home, not in `.git/`. The test
  asserts `.git/index` is never created.
- **A damaged cache costs a slow snapshot, never a snapshot.** A stale, locked, or unreadable index
  falls back to the throwaway index this always used. Deleting the shared file was rejected — it may
  belong to another process holding `index.lock`.
- **Purge ownership stays explicit.** Registered as a non-data purge root: rebuildable, so losing it
  costs time rather than a record.

## Test isolation

Snapshotting now resolves the home, which exposed tests that reached into the developer's real
`~/.spotter` — a live 200-session store. A suite-wide autouse fixture isolates `SPOTTER_HOME`, and
the prune race worker receives it explicitly because it builds its own child env.

Verified by running the full suite and confirming the real home stays untouched. This was a
pre-existing hazard that this change made visible rather than created.

## How it was validated

`ruff format --check`, `ruff check`, `mypy src tests`, `pytest` (1043 passed). Timings above are
from this machine; the field percentiles are from the 213-session journal store.

Related: #33
