### PR TITLE
fix: stop reconciliation loading every thread on disk

### DIFF
--- a/src/spotter/runtime_connection.py
+++ b/src/spotter/runtime_connection.py
@@ -11,7 +11,7 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass, replace
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from uuid import uuid4
 
 from spotter.app_server import (
@@ -837,7 +837,18 @@ class AppServerRecoveryLoop:
         }
         capabilities = _available_capabilities(client.capabilities)
         ended_at = time.time()
+        unloaded: list[str] = []
         for external_thread_id in sorted(discovered):
+            if _thread_status(discovered[external_thread_id]) == "notLoaded":
+                # `thread/resume` rejoins a *running* thread, but for one that is
+                # not loaded it reads the thread in from disk instead. Walking
+                # the whole history therefore opened every thread the server knew
+                # about: it ran out of file descriptors, `thread/list` began
+                # failing with EMFILE, and that took the connection down with it.
+                # A thread nobody is running has nothing live to observe. Wait for
+                # its status notification, which is what says it started.
+                unloaded.append(external_thread_id)
+                continue
             subscribed = True
             subscription_error: str | None = None
             try:
@@ -892,6 +903,24 @@ class AppServerRecoveryLoop:
                     occurred_at=ended_at,
                     identity=identity,
                     provenance=TraceProvenance("spotterd", "runtime_reconciled"),
+                    connection_epoch=epoch,
+                )
+            )
+
+        if unloaded:
+            # One record, not one per thread: this is the shape of the store, and
+            # a reader needs the count to know what reconciliation did not cover.
+            self._record(
+                TraceEvent(
+                    "runtime_threads_unloaded",
+                    {
+                        "runtime_attachment_id": attachment_id,
+                        "count": len(unloaded),
+                        "discovered": len(discovered),
+                    },
+                    event_id=f"spotter:unloaded:{attachment_id}:{epoch}",
+                    occurred_at=ended_at,
+                    provenance=TraceProvenance("spotterd", "runtime_threads_unloaded"),
                     connection_epoch=epoch,
                 )
             )
@@ -1521,6 +1550,14 @@ def _active_turn_id(thread: Mapping[str, Any]) -> str | None:
             turn_id = turn.get("id")
             if status in {"active", "inProgress", "running"} and isinstance(turn_id, str):
                 return turn_id
+    return None
+
+
+def _thread_status(summary: Mapping[str, Any]) -> str | None:
+    """The server's own load state for a thread, or None when it does not say."""
+    status = summary.get("status")
+    if isinstance(status, Mapping) and isinstance(status.get("type"), str):
+        return cast(str, status["type"])
     return None
 
 

--- a/tests/test_runtime_connection.py
+++ b/tests/test_runtime_connection.py
@@ -1714,3 +1714,48 @@ def test_settled_interrupt_releases_its_target_turn_bookkeeping(tmp_path: Path) 
             await recovery.close()
 
     asyncio.run(scenario())
+
+
+def test_reconciliation_does_not_load_threads_nobody_is_running(tmp_path: Path) -> None:
+    """`thread/resume` on a `notLoaded` thread reads it in from disk.
+
+    Doing that for every thread the server knows opened the whole history: a real
+    server ran out of file descriptors, `thread/list` began failing with EMFILE,
+    and the connection went down with it. Only threads the server already has
+    loaded are worth subscribing to; the rest announce themselves when they start.
+    """
+
+    async def scenario() -> None:
+        resumed: list[str] = []
+
+        async def handler(connection: ServerConnection) -> None:
+            await _initialize(connection)
+            listed = await _receive(connection, "thread/list")
+            await _reply(
+                connection,
+                listed,
+                {
+                    "data": [
+                        {"id": "cold-1", "status": {"type": "notLoaded"}},
+                        {"id": "cold-2", "status": {"type": "notLoaded"}},
+                        {"id": "live-1", "status": {"type": "active", "activeFlags": []}},
+                        {"id": "idle-1", "status": {"type": "idle"}},
+                    ],
+                    "nextCursor": None,
+                },
+            )
+            for _ in range(2):
+                request = await _receive(connection, "thread/resume")
+                resumed.append(request["params"]["threadId"])
+                await _reply(connection, request, {"thread": {"id": request["params"]["threadId"]}})
+            await connection.wait_closed()
+
+        async with _server(handler) as endpoint:
+            store = ThreadStateStore()
+            recovery = AppServerRecoveryLoop(endpoint, tmp_path / "sessions", store)
+            await recovery.start()
+            await _wait_until(lambda: len(resumed) == 2)
+            assert sorted(resumed) == ["idle-1", "live-1"]
+            await recovery.close()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Why

Reconciliation `thread/resume`d **every** thread `thread/list` returned. The protocol documents resume as rejoining a *running* thread — but for a `notLoaded` one it reads the thread in from disk instead. So walking the history opened all of it.

A real App Server ran out of file descriptors doing this. 271 open against a 256 soft limit, and then:

```
thread/list failed (-32603): failed to list threads:
thread-store internal error: Too many open files (os error 24)
```

That took the connection down, the reconnect walked the same history again, and the server eventually could not complete a WebSocket handshake at all. `spotter status` showed `backing_off` at epoch 50.

## What changed

`thread/list` reports each thread's status as one of `notLoaded`, `idle`, `active`, `systemError`. Reconciliation now skips `notLoaded`.

A thread nobody is running has nothing live to observe, and it announces itself through a status notification when it starts — the existing single-thread subscribe path already handles that. Threads a TUI has open are `active` or `idle`, so the case #304 actually needs is unaffected.

Skipped threads are recorded **once per reconciliation with their count**, not once each. What a reader needs is what reconciliation did not cover, not 215 individual non-events.

## This is the deferred question, answered

[#338](https://github.com/spotter-agent/spotter/pull/338) explicitly left this open:

> Whether reconciliation should resume every historical thread at all is a separate design question, and one that can now be asked with data.

The data arrived, in the form of an App Server that stopped accepting connections. Resuming every historical thread is not viable at this store's size, and the protocol gives an exact, cheap discriminator for which ones matter.

## How it was validated

`ruff format --check`, `ruff check`, `mypy src tests`, `pytest` (1049 passed), including a new test that a mixed `notLoaded`/`notLoaded`/`active`/`idle` listing resumes exactly the loaded two.

The EMFILE reproduction is from a live `codex app-server --listen` on Codex 0.149.1 against a 215-session store.

Related: #304
