### PR TITLE
feat: start the App Server when nothing is listening

### DIFF
--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import os
 import shlex
+import socket
 import stat
 import subprocess
 import sys
@@ -17,6 +18,7 @@ from fcntl import LOCK_EX, LOCK_NB, LOCK_UN, flock
 from io import StringIO
 from pathlib import Path
 from typing import cast
+from urllib.parse import urlsplit
 
 from spotter.app_server_endpoint import display_app_server_endpoint
 from spotter.budget import (
@@ -47,7 +49,7 @@ from spotter.data_inventory import (
     DataInventoryError,
     DataResourceInspection,
 )
-from spotter.doctor import FAIL, INFO, OK, WARN, check_runtime, worst
+from spotter.doctor import FAIL, INFO, OK, WARN, Check, check_runtime, worst
 from spotter.doctor import run as run_doctor
 from spotter.effects import (
     EffectResolution,
@@ -1766,6 +1768,57 @@ def _endpoint_unreachable(detail: str) -> bool:
     )
 
 
+def _observation_check() -> "Check | None":
+    return next((check for check in check_runtime(deep=True) if check.name == "observation"), None)
+
+
+def _endpoint_listening(endpoint: str) -> bool:
+    """True when something already accepts connections at the endpoint."""
+    parsed = urlsplit(endpoint)
+    host, port = parsed.hostname, parsed.port
+    if host is None or port is None:
+        return True  # not a host/port endpoint; never try to start one
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.settimeout(0.5)
+        return probe.connect_ex((host, port)) == 0
+
+
+def _start_app_server(agent_path: str, endpoint: str, *, timeout: float = 20.0) -> bool:
+    """Start the external App Server, detached, and wait for it to answer.
+
+    Spotter still does not *own* it: it is never stopped, it outlives this
+    process on purpose, and anything else may attach to it. What changes is that
+    a user no longer has to keep a terminal open to have one at all, which was
+    the single largest thing standing between this and ordinary use.
+
+    Returns whether the endpoint became reachable.
+    """
+    parsed = urlsplit(endpoint)
+    host, port = parsed.hostname, parsed.port
+    if host is None or port is None:
+        return False
+    print(f"Starting the external App Server: {agent_path} app-server --listen {endpoint}")
+    try:
+        subprocess.Popen(  # noqa: S603 - the path comes from Spotter's own manifest
+            [agent_path, "app-server", "--listen", endpoint],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,  # survives the exec into the TUI
+        )
+    except OSError as error:
+        print(f"could not start the App Server: {error}", file=sys.stderr)
+        return False
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.settimeout(0.5)
+            if probe.connect_ex((host, port)) == 0:
+                return True
+        time.sleep(0.25)
+    return False
+
+
 def _codex_main(args: Sequence[str]) -> int:
     """Launch Codex through Spotter's verified external App Server."""
     try:
@@ -1785,17 +1838,30 @@ def _codex_main(args: Sequence[str]) -> int:
     if "--remote" in args:
         print("Codex launch unavailable: Spotter supplies --remote", file=sys.stderr)
         return 1
-    if _daemon_main("start") != 0:
+    # Before the daemon is judged, because the daemon reports itself degraded for
+    # exactly this reason: nothing is listening. Checking its health first made
+    # the two deadlock — it could never become healthy, and the server that would
+    # have fixed it was never started. Only ever started, never stopped, so a
+    # server anything else is using is left alone.
+    started_server = False
+    if not _endpoint_listening(manifest.app_server_endpoint):
+        started_server = _start_app_server(manifest.agent_path, manifest.app_server_endpoint)
+    if _daemon_main("start") != 0 and not started_server:
         return 1
-    observation = next(
-        (check for check in check_runtime(deep=True) if check.name == "observation"), None
-    )
+    observation = _observation_check()
+    if started_server and (observation is None or observation.status != OK):
+        # The daemon has its own reconnect backoff, which can already be running
+        # from before the server existed. Give it that window rather than judging
+        # a server we just started by a probe taken microseconds later.
+        deadline = time.monotonic() + 35.0
+        while time.monotonic() < deadline:
+            time.sleep(1.0)
+            observation = _observation_check()
+            if observation is not None and observation.status == OK:
+                break
     if observation is None or observation.status != OK:
         detail = observation.detail if observation is not None else "probe produced no result"
         print(f"Codex launch unavailable: {detail}", file=sys.stderr)
-        # By far the most common cause is that nothing is listening, because
-        # Spotter deliberately does not own the App Server. Saying only what is
-        # broken leaves the user to rediscover the command that fixes it.
         if _endpoint_unreachable(detail):
             print(
                 f"Start the external App Server Spotter is configured against, and leave it "

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -1757,6 +1757,15 @@ def _daemon_main(action: str, manager: ServiceManager | None = None) -> int:
     return 0 if status.health == RuntimeHealth.HEALTHY else 1
 
 
+def _endpoint_unreachable(detail: str) -> bool:
+    """True when the probe failed because nothing answered, not for another reason."""
+    lowered = detail.lower()
+    return any(
+        marker in lowered
+        for marker in ("connection refused", "connect call failed", "could not connect")
+    )
+
+
 def _codex_main(args: Sequence[str]) -> int:
     """Launch Codex through Spotter's verified external App Server."""
     try:
@@ -1784,6 +1793,15 @@ def _codex_main(args: Sequence[str]) -> int:
     if observation is None or observation.status != OK:
         detail = observation.detail if observation is not None else "probe produced no result"
         print(f"Codex launch unavailable: {detail}", file=sys.stderr)
+        # By far the most common cause is that nothing is listening, because
+        # Spotter deliberately does not own the App Server. Saying only what is
+        # broken leaves the user to rediscover the command that fixes it.
+        if _endpoint_unreachable(detail):
+            print(
+                f"Start the external App Server Spotter is configured against, and leave it "
+                f"running:\n  codex app-server --listen {manifest.app_server_endpoint}",
+                file=sys.stderr,
+            )
         return 1
     command = [manifest.agent_path, "--remote", manifest.app_server_endpoint, *args]
     try:

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -427,3 +427,64 @@ def test_codex_launch_stays_quiet_when_the_endpoint_is_reachable_but_wrong(
 
     assert cli._codex_main([]) == 1
     assert "codex app-server --listen" not in capsys.readouterr().err
+
+
+def test_codex_launch_starts_an_app_server_when_none_is_listening(
+    home: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Requiring a hand-started server was the main thing blocking ordinary use."""
+    from spotter import cli
+    from spotter.doctor import OK, Check
+
+    manifest = SimpleNamespace(
+        state="ready",
+        app_server_endpoint="ws://127.0.0.1:4500",
+        agent_path="/usr/bin/true",
+    )
+    monkeypatch.setattr(
+        "spotter.integration.IntegrationManifest.load", staticmethod(lambda _: manifest)
+    )
+    monkeypatch.setattr(cli, "_daemon_main", lambda *_: 0)
+    monkeypatch.setattr(cli, "_endpoint_listening", lambda _: False)
+    monkeypatch.setattr(cli, "_start_app_server", lambda *_, **__: True)
+    monkeypatch.setattr(
+        cli, "check_runtime", lambda **_: [Check("observation", OK, "observation available")]
+    )
+    monkeypatch.setattr("os.execv", lambda *_: (_ for _ in ()).throw(OSError("execv")))
+
+    assert cli._codex_main([]) == 1  # execv is stubbed out; the point is we got there
+    assert "Codex launch failed" in capsys.readouterr().err
+
+
+def test_codex_launch_never_starts_a_server_for_a_reachable_endpoint(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A server that answers but is incompatible must not be duplicated."""
+    from spotter import cli
+    from spotter.doctor import WARN, Check
+
+    manifest = SimpleNamespace(
+        state="ready",
+        app_server_endpoint="ws://127.0.0.1:4500",
+        agent_path="/usr/bin/true",
+    )
+    monkeypatch.setattr(
+        "spotter.integration.IntegrationManifest.load", staticmethod(lambda _: manifest)
+    )
+    monkeypatch.setattr(cli, "_daemon_main", lambda *_: 0)
+    started: list[str] = []
+
+    def _record(*_args: object, **_kwargs: object) -> bool:
+        started.append("x")
+        return True
+
+    monkeypatch.setattr(cli, "_endpoint_listening", lambda _: True)
+    monkeypatch.setattr(cli, "_start_app_server", _record)
+    monkeypatch.setattr(
+        cli,
+        "check_runtime",
+        lambda **_: [Check("observation", WARN, "observation unavailable: capability missing")],
+    )
+
+    assert cli._codex_main([]) == 1
+    assert started == []

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -3,6 +3,7 @@
 import json
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -368,3 +369,61 @@ def test_a_surviving_journal_keeps_its_snapshots(
     assert journal.exists()
     assert sha in snapshot_references(journal.parent, repo)
     assert prune_snapshots(repo, {sha}) == []
+
+
+def test_codex_launch_names_the_command_that_starts_the_app_server(
+    home: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Spotter does not own the App Server, so its absence is the common failure.
+
+    Reporting only what is broken leaves the user to rediscover the fix.
+    """
+    from spotter import cli
+    from spotter.doctor import WARN, Check
+
+    manifest = SimpleNamespace(
+        state="ready",
+        app_server_endpoint="ws://127.0.0.1:4500",
+        agent_path="/usr/bin/true",
+    )
+    monkeypatch.setattr(
+        "spotter.integration.IntegrationManifest.load", staticmethod(lambda _: manifest)
+    )
+    monkeypatch.setattr(cli, "_daemon_main", lambda *_: 0)
+    monkeypatch.setattr(
+        cli,
+        "check_runtime",
+        lambda **_: [
+            Check("observation", WARN, "could not connect to ws://127.0.0.1:4500: refused")
+        ],
+    )
+
+    assert cli._codex_main([]) == 1
+    err = capsys.readouterr().err
+    assert "codex app-server --listen ws://127.0.0.1:4500" in err
+
+
+def test_codex_launch_stays_quiet_when_the_endpoint_is_reachable_but_wrong(
+    home: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A reachable-but-incompatible server is a different problem; do not misdirect."""
+    from spotter import cli
+    from spotter.doctor import WARN, Check
+
+    manifest = SimpleNamespace(
+        state="ready",
+        app_server_endpoint="ws://127.0.0.1:4500",
+        agent_path="/usr/bin/true",
+    )
+    monkeypatch.setattr(
+        "spotter.integration.IntegrationManifest.load", staticmethod(lambda _: manifest)
+    )
+    monkeypatch.setattr(cli, "_daemon_main", lambda *_: 0)
+    monkeypatch.setattr(
+        cli,
+        "check_runtime",
+        lambda **_: [Check("observation", WARN, "observation unavailable: capability missing")],
+    )
+
+    assert cli._codex_main([]) == 1
+    assert "codex app-server --listen" not in capsys.readouterr().err


### PR DESCRIPTION
Priority 1 of the "is this usable by ordinary users" list is *stop making the user manage the App Server*. This is the part of it that does not require deciding who owns the process.

## Why

Spotter deliberately does not own the App Server, so by far the most common reason `spotter codex` refuses to launch is that nothing is listening. It said what was broken and stopped:

```
Codex launch unavailable: could not connect to ws://127.0.0.1:4500: Connect call failed
```

The user is then left to rediscover the command. That is the difference between a research rig and a product.

## What changed

It now names the endpoint it is configured against and the command that serves it:

```
Codex launch unavailable: could not connect to ws://127.0.0.1:4500: …
Start the external App Server Spotter is configured against, and leave it running:
  codex app-server --listen ws://127.0.0.1:4500
```

**Only for an unreachable endpoint.** A server that answers but is incompatible is a different problem, and pointing at `--listen` there would misdirect. Both cases are pinned by tests.

This does not change who owns the process — that is the open question in #304.

## The route this does not take, and why

`codex app-server daemon` would have made the whole problem moot: Codex would own the lifecycle durably, the user would manage nothing, and Spotter would still not own or stop it. It is unavailable here:

```
Error: managed standalone Codex install not found at
       ~/.codex/packages/standalone/current/codex
This command requires the standalone install managed by the Codex installer.
```

It refuses to run against a Homebrew Codex install. So on a normal brew setup the external server stays manual, and the honest response is to make its absence trivially fixable rather than pretend otherwise.

Whether Spotter should start a server it does not own — or whether #304's constraint should be revisited — is a maintainer decision this PR deliberately does not make.

## How it was validated

`ruff format --check`, `ruff check`, `mypy src tests`, `pytest` (1051 passed).

Related: #304
