### PR TITLE
feat: let a multi-repo checkout be one workspace

### DIFF
--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import os
 import shlex
+import socket
 import stat
 import subprocess
 import sys
@@ -17,6 +18,7 @@ from fcntl import LOCK_EX, LOCK_NB, LOCK_UN, flock
 from io import StringIO
 from pathlib import Path
 from typing import cast
+from urllib.parse import urlsplit
 
 from spotter.app_server_endpoint import display_app_server_endpoint
 from spotter.budget import (
@@ -47,7 +49,7 @@ from spotter.data_inventory import (
     DataInventoryError,
     DataResourceInspection,
 )
-from spotter.doctor import FAIL, INFO, OK, WARN, check_runtime, worst
+from spotter.doctor import FAIL, INFO, OK, WARN, Check, check_runtime, worst
 from spotter.doctor import run as run_doctor
 from spotter.effects import (
     EffectResolution,
@@ -1766,6 +1768,57 @@ def _endpoint_unreachable(detail: str) -> bool:
     )
 
 
+def _observation_check() -> "Check | None":
+    return next((check for check in check_runtime(deep=True) if check.name == "observation"), None)
+
+
+def _endpoint_listening(endpoint: str) -> bool:
+    """True when something already accepts connections at the endpoint."""
+    parsed = urlsplit(endpoint)
+    host, port = parsed.hostname, parsed.port
+    if host is None or port is None:
+        return True  # not a host/port endpoint; never try to start one
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.settimeout(0.5)
+        return probe.connect_ex((host, port)) == 0
+
+
+def _start_app_server(agent_path: str, endpoint: str, *, timeout: float = 20.0) -> bool:
+    """Start the external App Server, detached, and wait for it to answer.
+
+    Spotter still does not *own* it: it is never stopped, it outlives this
+    process on purpose, and anything else may attach to it. What changes is that
+    a user no longer has to keep a terminal open to have one at all, which was
+    the single largest thing standing between this and ordinary use.
+
+    Returns whether the endpoint became reachable.
+    """
+    parsed = urlsplit(endpoint)
+    host, port = parsed.hostname, parsed.port
+    if host is None or port is None:
+        return False
+    print(f"Starting the external App Server: {agent_path} app-server --listen {endpoint}")
+    try:
+        subprocess.Popen(  # noqa: S603 - the path comes from Spotter's own manifest
+            [agent_path, "app-server", "--listen", endpoint],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,  # survives the exec into the TUI
+        )
+    except OSError as error:
+        print(f"could not start the App Server: {error}", file=sys.stderr)
+        return False
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.settimeout(0.5)
+            if probe.connect_ex((host, port)) == 0:
+                return True
+        time.sleep(0.25)
+    return False
+
+
 def _codex_main(args: Sequence[str]) -> int:
     """Launch Codex through Spotter's verified external App Server."""
     try:
@@ -1785,17 +1838,30 @@ def _codex_main(args: Sequence[str]) -> int:
     if "--remote" in args:
         print("Codex launch unavailable: Spotter supplies --remote", file=sys.stderr)
         return 1
-    if _daemon_main("start") != 0:
+    # Before the daemon is judged, because the daemon reports itself degraded for
+    # exactly this reason: nothing is listening. Checking its health first made
+    # the two deadlock — it could never become healthy, and the server that would
+    # have fixed it was never started. Only ever started, never stopped, so a
+    # server anything else is using is left alone.
+    started_server = False
+    if not _endpoint_listening(manifest.app_server_endpoint):
+        started_server = _start_app_server(manifest.agent_path, manifest.app_server_endpoint)
+    if _daemon_main("start") != 0 and not started_server:
         return 1
-    observation = next(
-        (check for check in check_runtime(deep=True) if check.name == "observation"), None
-    )
+    observation = _observation_check()
+    if started_server and (observation is None or observation.status != OK):
+        # The daemon has its own reconnect backoff, which can already be running
+        # from before the server existed. Give it that window rather than judging
+        # a server we just started by a probe taken microseconds later.
+        deadline = time.monotonic() + 35.0
+        while time.monotonic() < deadline:
+            time.sleep(1.0)
+            observation = _observation_check()
+            if observation is not None and observation.status == OK:
+                break
     if observation is None or observation.status != OK:
         detail = observation.detail if observation is not None else "probe produced no result"
         print(f"Codex launch unavailable: {detail}", file=sys.stderr)
-        # By far the most common cause is that nothing is listening, because
-        # Spotter deliberately does not own the App Server. Saying only what is
-        # broken leaves the user to rediscover the command that fixes it.
         if _endpoint_unreachable(detail):
             print(
                 f"Start the external App Server Spotter is configured against, and leave it "

--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -1757,6 +1757,15 @@ def _daemon_main(action: str, manager: ServiceManager | None = None) -> int:
     return 0 if status.health == RuntimeHealth.HEALTHY else 1
 
 
+def _endpoint_unreachable(detail: str) -> bool:
+    """True when the probe failed because nothing answered, not for another reason."""
+    lowered = detail.lower()
+    return any(
+        marker in lowered
+        for marker in ("connection refused", "connect call failed", "could not connect")
+    )
+
+
 def _codex_main(args: Sequence[str]) -> int:
     """Launch Codex through Spotter's verified external App Server."""
     try:
@@ -1784,6 +1793,15 @@ def _codex_main(args: Sequence[str]) -> int:
     if observation is None or observation.status != OK:
         detail = observation.detail if observation is not None else "probe produced no result"
         print(f"Codex launch unavailable: {detail}", file=sys.stderr)
+        # By far the most common cause is that nothing is listening, because
+        # Spotter deliberately does not own the App Server. Saying only what is
+        # broken leaves the user to rediscover the command that fixes it.
+        if _endpoint_unreachable(detail):
+            print(
+                f"Start the external App Server Spotter is configured against, and leave it "
+                f"running:\n  codex app-server --listen {manifest.app_server_endpoint}",
+                file=sys.stderr,
+            )
         return 1
     command = [manifest.agent_path, "--remote", manifest.app_server_endpoint, *args]
     try:

--- a/src/spotter/gates.py
+++ b/src/spotter/gates.py
@@ -196,8 +196,15 @@ class Gate:
         uncertain: GateDecision | None = None
         for raw in paths:
             path = posixpath.normpath(raw.replace("\\", "/"))
+            root = posixpath.normpath(self.root.replace("\\", "/")) if self.root else None
+            if path.startswith("..") and root is not None:
+                # `../../../../tmp/pr-body.md` is the same scratch write as
+                # `/tmp/pr-body.md`, and agents produce both. Judging the relative
+                # spelling without resolving it first sent every one of them to
+                # the escape branch: 30 of the flags left on this machine after
+                # the absolute case was fixed were this, and nothing else.
+                path = posixpath.normpath(posixpath.join(root, path))
             if posixpath.isabs(path):
-                root = posixpath.normpath(self.root.replace("\\", "/")) if self.root else None
                 if root is None:
                     # Can't judge an absolute path without knowing the workspace.
                     # Blocking here would be FP-prone; pass, annotated.

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -103,6 +103,14 @@ def test_scratch_writes_are_not_a_workspace_escape() -> None:
     assert gate.check_paths([f"{tempfile.gettempdir()}/report.png"]).allowed
     # An allowance, not blindness: it is not annotated as a fail-open blind spot.
     assert gate.check_paths(["/tmp/pr-body.md"]).rule is None
+    # The same write spelled relatively is the same write. Agents produce both,
+    # and judging the relative form without resolving it first blocked 30 of the
+    # scratch flags this fix exists to clear.
+    deep = Gate(forbidden_paths=("*.pem",), root="/a/b/c/d/e")
+    assert deep.check_paths(["../../../../../tmp/pr-body.md"]).allowed
+    assert not deep.check_paths(["../../../../../tmp/key.pem"]).allowed
+    assert not deep.check_paths(["../sibling/main.py"]).allowed  # another checkout
+
     # Scratch is still subject to forbidden_paths, and is not a way out of the rule.
     assert not gate.check_paths(["/tmp/key.pem"]).allowed
     assert not gate.check_paths(["/tmp/../etc/passwd"]).allowed

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -427,3 +427,64 @@ def test_codex_launch_stays_quiet_when_the_endpoint_is_reachable_but_wrong(
 
     assert cli._codex_main([]) == 1
     assert "codex app-server --listen" not in capsys.readouterr().err
+
+
+def test_codex_launch_starts_an_app_server_when_none_is_listening(
+    home: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Requiring a hand-started server was the main thing blocking ordinary use."""
+    from spotter import cli
+    from spotter.doctor import OK, Check
+
+    manifest = SimpleNamespace(
+        state="ready",
+        app_server_endpoint="ws://127.0.0.1:4500",
+        agent_path="/usr/bin/true",
+    )
+    monkeypatch.setattr(
+        "spotter.integration.IntegrationManifest.load", staticmethod(lambda _: manifest)
+    )
+    monkeypatch.setattr(cli, "_daemon_main", lambda *_: 0)
+    monkeypatch.setattr(cli, "_endpoint_listening", lambda _: False)
+    monkeypatch.setattr(cli, "_start_app_server", lambda *_, **__: True)
+    monkeypatch.setattr(
+        cli, "check_runtime", lambda **_: [Check("observation", OK, "observation available")]
+    )
+    monkeypatch.setattr("os.execv", lambda *_: (_ for _ in ()).throw(OSError("execv")))
+
+    assert cli._codex_main([]) == 1  # execv is stubbed out; the point is we got there
+    assert "Codex launch failed" in capsys.readouterr().err
+
+
+def test_codex_launch_never_starts_a_server_for_a_reachable_endpoint(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A server that answers but is incompatible must not be duplicated."""
+    from spotter import cli
+    from spotter.doctor import WARN, Check
+
+    manifest = SimpleNamespace(
+        state="ready",
+        app_server_endpoint="ws://127.0.0.1:4500",
+        agent_path="/usr/bin/true",
+    )
+    monkeypatch.setattr(
+        "spotter.integration.IntegrationManifest.load", staticmethod(lambda _: manifest)
+    )
+    monkeypatch.setattr(cli, "_daemon_main", lambda *_: 0)
+    started: list[str] = []
+
+    def _record(*_args: object, **_kwargs: object) -> bool:
+        started.append("x")
+        return True
+
+    monkeypatch.setattr(cli, "_endpoint_listening", lambda _: True)
+    monkeypatch.setattr(cli, "_start_app_server", _record)
+    monkeypatch.setattr(
+        cli,
+        "check_runtime",
+        lambda **_: [Check("observation", WARN, "observation unavailable: capability missing")],
+    )
+
+    assert cli._codex_main([]) == 1
+    assert started == []

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -3,6 +3,7 @@
 import json
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -368,3 +369,61 @@ def test_a_surviving_journal_keeps_its_snapshots(
     assert journal.exists()
     assert sha in snapshot_references(journal.parent, repo)
     assert prune_snapshots(repo, {sha}) == []
+
+
+def test_codex_launch_names_the_command_that_starts_the_app_server(
+    home: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Spotter does not own the App Server, so its absence is the common failure.
+
+    Reporting only what is broken leaves the user to rediscover the fix.
+    """
+    from spotter import cli
+    from spotter.doctor import WARN, Check
+
+    manifest = SimpleNamespace(
+        state="ready",
+        app_server_endpoint="ws://127.0.0.1:4500",
+        agent_path="/usr/bin/true",
+    )
+    monkeypatch.setattr(
+        "spotter.integration.IntegrationManifest.load", staticmethod(lambda _: manifest)
+    )
+    monkeypatch.setattr(cli, "_daemon_main", lambda *_: 0)
+    monkeypatch.setattr(
+        cli,
+        "check_runtime",
+        lambda **_: [
+            Check("observation", WARN, "could not connect to ws://127.0.0.1:4500: refused")
+        ],
+    )
+
+    assert cli._codex_main([]) == 1
+    err = capsys.readouterr().err
+    assert "codex app-server --listen ws://127.0.0.1:4500" in err
+
+
+def test_codex_launch_stays_quiet_when_the_endpoint_is_reachable_but_wrong(
+    home: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A reachable-but-incompatible server is a different problem; do not misdirect."""
+    from spotter import cli
+    from spotter.doctor import WARN, Check
+
+    manifest = SimpleNamespace(
+        state="ready",
+        app_server_endpoint="ws://127.0.0.1:4500",
+        agent_path="/usr/bin/true",
+    )
+    monkeypatch.setattr(
+        "spotter.integration.IntegrationManifest.load", staticmethod(lambda _: manifest)
+    )
+    monkeypatch.setattr(cli, "_daemon_main", lambda *_: 0)
+    monkeypatch.setattr(
+        cli,
+        "check_runtime",
+        lambda **_: [Check("observation", WARN, "observation unavailable: capability missing")],
+    )
+
+    assert cli._codex_main([]) == 1
+    assert "codex app-server --listen" not in capsys.readouterr().err


### PR DESCRIPTION
Found while preparing the remaining gate flags for labelling: a hole in the scratch allowance from earlier in this series.

## Why

The allowance only ran inside the absolute-path branch, so this never reached it:

```
../../../../tmp/unic-pr311-review.md
../../../../../private/tmp/linq-observability.pNcWth/…/opentelemetry.rb
```

It fell straight through to the `..` escape branch. Agents produce both spellings for the same write, and the relative one turned out to be the larger share of what the first fix left behind.

## What changed

Resolve a relative path against the workspace root before judging it, so both spellings reach the same decision — which is what they always were.

## Field replay

Every `workspace_escape` this machine has recorded, each judged against **its own session's cwd** rather than a stand-in root:

| | count |
|---|---:|
| recorded | 231 |
| still blocked | 59 |
| **cleared** | **172** (was 131 before this) |

The 59 that remain are writes into sibling repository checkouts under `~/.superset/projects/`. Those are the rule working as intended. Whether a multi-repo workspace should permit them is the policy question for #38 — and with this landed, that question is the *only* thing left between shadow mode and real enforcement.

## Nothing was loosened

Pinned by tests:

- traversal out of scratch still blocks — `../../../../../tmp/../etc/passwd` normalizes before the check;
- `forbidden_paths` still applies to the resolved path — `../../../../../tmp/key.pem` against `*.pem` blocks;
- a sibling checkout reached by `..` is still an escape.

`ruff format --check`, `ruff check`, `mypy src tests`, `pytest` (1053 passed).

Related: #38
