### PR TITLE
feat: let a multi-repo checkout be one workspace

### DIFF
--- a/spotter.example.toml
+++ b/spotter.example.toml
@@ -20,6 +20,9 @@ model = "default"
 
 [gates]
 forbidden_paths = []
+# Directories whose children are each a workspace. A multi-repo checkout is one
+# job: without this, editing a sibling repository reads as leaving the workspace.
+# workspace_roots = ["~/src"]
 block_dependency_changes = false
 
 # Exact server/tool metadata takes precedence over MCP name heuristics. Unknown

--- a/src/spotter/config.py
+++ b/src/spotter/config.py
@@ -70,7 +70,11 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "max_per_session": 20,
         "max_per_day": 100,
     },
-    "gates": {"forbidden_paths": [], "block_dependency_changes": False},
+    "gates": {
+        "forbidden_paths": [],
+        "workspace_roots": [],
+        "block_dependency_changes": False,
+    },
     "mcp_semantics": {},
 }
 
@@ -86,6 +90,7 @@ CONFIG_ACTIVATION_BOUNDARIES: Mapping[str, ActivationBoundary] = MappingProxyTyp
         "reviewer.max_per_session": ActivationBoundary.HOT,
         "reviewer.max_per_day": ActivationBoundary.HOT,
         "gates.forbidden_paths": ActivationBoundary.NEXT_TURN,
+        "gates.workspace_roots": ActivationBoundary.NEXT_TURN,
         "gates.block_dependency_changes": ActivationBoundary.NEXT_TURN,
         "observation_only": ActivationBoundary.NEXT_TURN,
         "snapshot_on_patch": ActivationBoundary.HOT,
@@ -159,6 +164,9 @@ class ReviewerConfig:
 @dataclass(frozen=True)
 class GatesConfig:
     forbidden_paths: tuple[str, ...] = ()
+    # Directories whose children are each a workspace. A multi-repo checkout is
+    # one job, not an escape from whichever repo the shell happens to sit in.
+    workspace_roots: tuple[str, ...] = ()
     block_dependency_changes: bool = False
 
 
@@ -219,6 +227,7 @@ class SpotterConfig:
             ),
             gates=GatesConfig(
                 forbidden_paths=_string_tuple(gates, "forbidden_paths"),
+                workspace_roots=_string_tuple(gates, "workspace_roots"),
                 block_dependency_changes=_bool(gates, "block_dependency_changes", False),
             ),
             mcp_semantics=_mcp_semantics(raw),
@@ -568,7 +577,7 @@ def _merge_repository_layer(effective: dict[str, Any], raw: Mapping[str, Any]) -
         gates = {}
         effective["gates"] = gates
     for key in repository_gates:
-        if key not in {"forbidden_paths", "block_dependency_changes"}:
+        if key not in {"forbidden_paths", "workspace_roots", "block_dependency_changes"}:
             ignored.append(f"gates.{key}")
 
     if "forbidden_paths" in repository_gates:

--- a/src/spotter/daemon.py
+++ b/src/spotter/daemon.py
@@ -413,6 +413,7 @@ class DaemonClient:
                 },
                 "gates": {
                     "forbidden_paths": list(gates.forbidden_paths),
+                    "workspace_roots": list(gates.workspace_roots),
                     "block_dependency_changes": gates.block_dependency_changes,
                 },
                 "root": root,
@@ -979,10 +980,15 @@ def _evaluate_gate(raw: object) -> dict[str, Any]:
     if not isinstance(proposal, dict) or not isinstance(gates, dict):
         raise DaemonProtocolError("gate proposal and config must be objects")
     forbidden_paths = gates.get("forbidden_paths")
+    # Absent on a peer that predates the field: an older client must not fail the
+    # gate, it just has no declared sibling workspaces.
+    workspace_roots = gates.get("workspace_roots", [])
     block_dependencies = gates.get("block_dependency_changes")
     if (
         not isinstance(forbidden_paths, list)
         or not all(isinstance(path, str) for path in forbidden_paths)
+        or not isinstance(workspace_roots, list)
+        or not all(isinstance(path, str) for path in workspace_roots)
         or not isinstance(block_dependencies, bool)
         or (root is not None and not isinstance(root, str))
         or not isinstance(config_generation, str)
@@ -1002,9 +1008,9 @@ def _evaluate_gate(raw: object) -> dict[str, Any]:
         evaluation_ms = 0.0
     else:
         started = time.perf_counter_ns()
-        decision = Gate(tuple(forbidden_paths), block_dependencies, root).check(
-            TraceEvent("tool_proposal", dict(proposal))
-        )
+        decision = Gate(
+            tuple(forbidden_paths), block_dependencies, root, tuple(workspace_roots)
+        ).check(TraceEvent("tool_proposal", dict(proposal)))
         evaluation_ms = (time.perf_counter_ns() - started) / 1_000_000
     return {
         "decision": {

--- a/src/spotter/gates.py
+++ b/src/spotter/gates.py
@@ -120,6 +120,13 @@ class Gate:
     forbidden_paths: tuple[str, ...] = ()
     block_dependency_changes: bool = False
     root: str | None = None  # absolute workspace root; enables absolute-path judgment
+    # Directories whose immediate children are each a workspace. Field data:
+    # every remaining `workspace_escape` on a real machine was one repository in
+    # a multi-repo checkout editing another, under prompts that asked for exactly
+    # that — an infra-wide OOM investigation touching twelve service repos, a
+    # cross-region deploy, cross-service feature work. The job was the checkout,
+    # not the directory the shell happened to start in.
+    workspace_roots: tuple[str, ...] = ()
 
     def check(self, event: TraceEvent) -> GateDecision:
         """Gate a pending action event. Non-action events always pass."""
@@ -192,6 +199,20 @@ class Gate:
                 return GateDecision(False, "dd_device", "writing to a raw device")
         return ALLOW
 
+    def _sibling_workspace(self, path: str) -> str | None:
+        """The declared workspace this absolute path belongs to, if any."""
+        for raw_root in self.workspace_roots:
+            parent = posixpath.normpath(
+                posixpath.expanduser(raw_root.replace("\\", "/")) if raw_root else raw_root
+            )
+            if not parent or not posixpath.isabs(parent) or not path.startswith(parent + "/"):
+                continue
+            remainder = path[len(parent) + 1 :]
+            project = remainder.split("/", 1)[0]
+            if project and "/" in remainder:  # a file inside a project, not the project itself
+                return posixpath.join(parent, project)
+        return None
+
     def check_paths(self, paths: Iterable[str]) -> GateDecision:
         uncertain: GateDecision | None = None
         for raw in paths:
@@ -212,8 +233,13 @@ class Gate:
                         True, "unknown_workspace", f"fail-open: cannot judge absolute path: {raw}"
                     )
                     continue
+                sibling = self._sibling_workspace(path)
                 if path == root or path.startswith(root + "/"):
                     path = posixpath.relpath(path, root)
+                elif sibling is not None:
+                    # Relative to that project, not to the shared parent, so a
+                    # `secrets/*` pattern still means the same thing there.
+                    path = posixpath.relpath(path, sibling)
                 elif _is_scratch(path):
                     # Ephemeral scratch, not an escape. The path stays absolute so
                     # forbidden_paths still applies to it.

--- a/src/spotter/hook.py
+++ b/src/spotter/hook.py
@@ -257,6 +257,7 @@ def run_hook(
     cwd = payload.get("cwd")
     gate = Gate(
         forbidden_paths=config.gates.forbidden_paths,
+        workspace_roots=config.gates.workspace_roots,
         block_dependency_changes=config.gates.block_dependency_changes,
         root=str(cwd) if isinstance(cwd, str) else None,
     )

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -129,3 +129,31 @@ def test_gate_only_inspects_tool_proposals() -> None:
     assert Gate().check(event).allowed  # a message about a command is not an action
     proposal = TraceEvent("tool_proposal", {"command": "rm -rf /"})
     assert not Gate().check(proposal).allowed
+
+
+def test_sibling_repositories_in_a_declared_workspace_are_not_an_escape() -> None:
+    """A multi-repo checkout is one job, not an escape from whichever repo cwd is.
+
+    Field data: 236 of 238 recorded `workspace_escape` flags on a real machine
+    were this, under prompts that asked for exactly it — an infra-wide OOM
+    investigation touching twelve service repos, a cross-region deploy, and
+    cross-service feature work.
+    """
+    gate = Gate(
+        forbidden_paths=("secrets/*",),
+        root="/checkouts/infra",
+        workspace_roots=("/checkouts",),
+    )
+    assert gate.check_paths(["/checkouts/analytics/app/services/run.py"]).allowed
+    assert gate.check_paths(["../analytics/app/services/run.py"]).allowed  # same write
+
+    # `forbidden_paths` is relative to that project, not the shared parent, so it
+    # still means the same thing inside a sibling.
+    assert not gate.check_paths(["/checkouts/analytics/secrets/key"]).allowed
+
+    # Outside the declared roots is still an escape, and so is the parent itself.
+    assert not gate.check_paths(["/somewhere/else/main.py"]).allowed
+    assert not gate.check_paths(["/checkouts/loose-file.txt"]).allowed
+    assert (
+        not Gate(root="/checkouts/infra").check_paths(["/checkouts/analytics/app/run.py"]).allowed
+    )  # undeclared: unchanged behaviour


### PR DESCRIPTION
Re-lands the second half of #343. That PR merged with only its first commit — the `workspace_roots` work reached the branch but not `main`, so the feature and the configuration that depends on it went out of sync. This carries the identical commit, cherry-picked onto current `main`.

## Why

`workspace_escape` assumed the workspace is whichever repository the shell started in. On a multi-repo checkout that is wrong, and it was wrong for nearly everything the rule has ever flagged.

Reading the prompts behind every remaining flag on a real machine — six sessions:

| Session | cwd repo | targets | flags | The task |
|---|---|---|---:|---|
| `019ff34e` | linq-infra | **12 repos** | 41 | Datadog OOM investigation across `linq-search-prod` |
| `01a0329f` | mcp-server | analytics-server | 8 | Linear tickets / graph explorer |
| `01a03c45` | mcp-server | rms-server-lin-716 | 4 | Linear 708 graph explorer |
| `01a0122f` | linq-infra | linq-workflow | 3 | Datadog monitor investigation |
| `019fff66` | unic | `~/.config/unic-maintainer/` | 2 | periodic PR review/merge bot |
| `019ffed7` | linq-workflow | linq-infra | 1 | cross-region deploy |

Every one was doing exactly what it was asked. Not one case of an agent wandering out of its workspace.

## What changed

`gates.workspace_roots` names directories whose immediate children are each a workspace. Replayed against every flag this machine has recorded, judged against each session's own cwd:

| | count |
|---|---:|
| recorded | 238 |
| still blocked | **2** |
| cleared | **236** |

The survivors are an agent writing its own launcher to `~/.local/bin` and its config to `~/.config` — outside every declared workspace. A gate surfacing *"something was installed onto your PATH"* is the gate earning its place.

## Preserved, and pinned by tests

- A sibling path is relative to **that project**, not the shared parent, so `secrets/*` still blocks `<parent>/<project>/secrets/key`.
- The parent directory itself is not a workspace.
- An undeclared root behaves exactly as before.
- The daemon accepts a peer that predates the field rather than failing its gate.

## Note on the machine this was measured on

Enforcement was switched on there while this was believed merged, and the mismatch meant sibling writes were briefly blocked for real. It has been returned to `observation_only = true` and the daemon reloaded; it stays there until this lands.

`ruff format --check`, `ruff check`, `mypy src tests`, `pytest` (1054 passed).

Related: #38
