### PR TITLE
fix: run the reviewer against the Codex setup verified

### DIFF
--- a/src/spotter/cli.py
+++ b/src/spotter/cli.py
@@ -1942,9 +1942,16 @@ def _integration_main(
             manifest = integration.setup()
             print(f"Codex integration: {manifest.state} ({integration.manifest_path})")
             if manifest.app_server_endpoint is None:
+                # "pending" reads as "fine for now". It is not: without an
+                # endpoint this install journals through hooks and nothing else,
+                # so say which capabilities are off rather than only how to fix it.
                 print(
-                    "App Server endpoint: pending; start a shared server and rerun setup with "
-                    "--endpoint ws://127.0.0.1:4500"
+                    "App Server endpoint: pending — hook journaling and deterministic "
+                    "gates work, but observation, signal detection, and live control "
+                    "stay off until an endpoint is set.\n"
+                    "  Set one up with:\n"
+                    "    codex app-server --listen ws://127.0.0.1:4500\n"
+                    "    spotter setup codex --endpoint ws://127.0.0.1:4500"
                 )
             else:
                 endpoint = display_app_server_endpoint(manifest.app_server_endpoint)

--- a/src/spotter/reviewer.py
+++ b/src/spotter/reviewer.py
@@ -167,10 +167,30 @@ async def _stop_process_group(process: asyncio.subprocess.Process) -> None:
         await process.wait()
 
 
+def _codex_executable() -> str:
+    """The Codex the integration was set up against, not whatever `PATH` says.
+
+    The reviewer runs from the daemon and from hooks, and neither inherits the
+    shell's `PATH`. Resolving by bare name failed every review on a machine whose
+    Codex is not in a system directory — 59 consecutive `[Errno 2] No such file
+    or directory: 'codex'`, silently, because a reviewer error is journaled and
+    not surfaced. The integration manifest already pins the exact path that setup
+    verified; use that, and keep the bare name only as a fallback.
+    """
+    with suppress(Exception):
+        from spotter.integration import IntegrationManifest
+        from spotter.paths import RuntimeLayout
+
+        manifest = IntegrationManifest.load(RuntimeLayout.discover().integration_manifest)
+        if manifest is not None and manifest.agent_path:
+            return manifest.agent_path
+    return "codex"
+
+
 def _codex_command(model: str, scratch: str, schema: Path, answer: Path, prompt: str) -> list[str]:
     model_args = [] if model in ("", "default") else ["-m", model]
     return [
-        "codex",
+        _codex_executable(),
         "exec",
         "-C",
         scratch,

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -166,3 +166,31 @@ def test_inflight_lock_skips_duplicate_review(
         assert main(["review", "--session", "busy"]) == 0
     assert called == []  # no duplicate model call
     assert "already in flight" in capsys.readouterr().err
+
+
+def test_reviewer_uses_the_codex_the_integration_was_set_up_against(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Neither the daemon nor a hook inherits the shell's PATH.
+
+    Resolving `codex` by bare name failed every review on a machine whose Codex
+    is not in a system directory — 59 consecutive `[Errno 2]`, journaled and
+    never surfaced. The manifest already pins the path setup verified.
+    """
+    from spotter import reviewer
+
+    monkeypatch.setattr(
+        reviewer, "_codex_executable", lambda: "/opt/homebrew/bin/codex", raising=True
+    )
+    command = reviewer._codex_command("default", str(tmp_path), tmp_path / "s", tmp_path / "a", "p")
+    assert command[0] == "/opt/homebrew/bin/codex"
+    assert command[1] == "exec"
+
+
+def test_reviewer_falls_back_to_the_bare_name_without_a_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from spotter import reviewer
+
+    monkeypatch.setenv("SPOTTER_HOME", str(tmp_path))  # no integration manifest here
+    assert reviewer._codex_executable() == "codex"


### PR DESCRIPTION
Found while checking whether enabling `reviewer.on_signals` had a visible cost. It did not — because no review has ever run.

## Every semantic review on this machine was failing

```
reviewer errors recorded: 59 (see ~/.spotter/logs)
```

All 59, identical:

```json
{"error": "[Errno 2] No such file or directory: 'codex'",
 "review_job_id": "proposal:25", "review_trigger": "periodic"}
```

The reviewer spawns `codex` by bare name, so it resolves through `PATH`. It runs **from the daemon and from hooks**, and neither inherits the shell's `PATH`. On any machine whose Codex is not in a system directory, that is every review — here, `~/.superset/bin/codex`.

## It failed silently, which is the worse half

A reviewer error is journaled, and `status` prints a count with no cause:

```
reviewer errors recorded: 59 (see /Users/youngjin/.spotter/logs)
```

So the semantic half of supervision can be entirely dead while every other line reads `[ok]`. It took enabling a feature and then going to look for its cost to notice.

## The fix

The integration manifest already pins the exact Codex path setup verified, and `spotter codex` already launches through it. The reviewer now does the same, with the bare name kept only as a fallback for an install with no manifest.

Verified on the affected machine, including with `PATH` emptied to reproduce the daemon's environment:

```
resolved: /Users/youngjin/.superset/bin/codex   exists: True
PATH emptied: same path, still resolves
```

## Also here: what a pending endpoint costs

`spotter setup codex` without `--endpoint` printed:

```
App Server endpoint: pending; start a shared server and rerun setup with --endpoint …
```

"pending" reads as "fine for now". It is not — without an endpoint the install journals through hooks and does nothing else. It now names what stays off:

```
App Server endpoint: pending — hook journaling and deterministic gates work, but
observation, signal detection, and live control stay off until an endpoint is set.
  Set one up with:
    codex app-server --listen ws://127.0.0.1:4500
    spotter setup codex --endpoint ws://127.0.0.1:4500
```

## How it was validated

`ruff format --check`, `ruff check`, `mypy src tests`, `pytest` (1056 passed), plus the live path resolution above.
