### PR TITLE
test: make the missing-bridge fail-open test independent of host state

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -824,7 +824,20 @@ def test_cached_hook_from_the_installed_old_build_fails_open_before_reconcile(
 def test_missing_packaged_bridge_command_is_bounded_and_fail_open(
     homes: tuple[Path, Path],
 ) -> None:
-    manager, _ = _manager(homes)
+    spotter_home, codex_home = homes
+    # A path guaranteed absent, not the real "/opt/homebrew/bin/spotter" that
+    # _manager() uses: on a contributor machine with Spotter installed via the
+    # supported Homebrew tap, that path *is* executable, so `[ -x ... ]` would
+    # pass and this would shell out to the real installed daemon-less binary
+    # instead of exercising the "packaged bridge missing" fail-open path -
+    # flaking under load once the real process misses the 1s budget below.
+    manager = IntegrationManager(
+        codex_home=codex_home,
+        codex=CodexInstall("/opt/homebrew/bin/codex", "codex 1.0", True, True),
+        service=FakeService(spotter_home / "service/spotterd"),
+        spotter_executable=str(spotter_home / "not-installed/bin/spotter"),
+        verifier=lambda _: True,
+    )
 
     result = subprocess.run(
         ["sh", "-c", manager._hook_command()],  # noqa: SLF001 - generated host contract


### PR DESCRIPTION
## Why

`test_missing_packaged_bridge_command_is_bounded_and_fail_open` builds its
`IntegrationManager` through the shared `_manager()` fixture, which hardcodes
`spotter_executable="/opt/homebrew/bin/spotter"` — the exact path the
supported Homebrew tap install (README.md, docs/lifecycle.md:
`brew install spotter-agent/spotter/spotter`) puts the binary at.

CI only runs on `ubuntu-latest`, where that path never exists, so the
generated `[ -x /opt/homebrew/bin/spotter ] && ... || true` hook command
always takes the "missing" branch there and the test is always meaningless-fast.
On a contributor's Apple Silicon Mac with Spotter actually installed via the
officially supported `brew install spotter-agent/spotter/spotter`, that same
path *is* executable: the test silently stops exercising the "packaged bridge
missing, fail open" contract it's named for, and instead shells out to the
real installed binary against a scratch `SPOTTER_HOME` with no daemon
running. That real process can miss the test's 1s subprocess timeout under
local CPU load, failing the test for a reason that has nothing to do with
what it claims to check — a false failure for exactly the contributors most
likely to be running this suite locally.

## What changed

`test_missing_packaged_bridge_command_is_bounded_and_fail_open` now builds
its own `IntegrationManager` with `spotter_executable` pointing under the
test's own `tmp_path` instead of the shared fixture's hardcoded system path.
`[ -x ... ]` is then guaranteed false regardless of what's installed on the
host, so the fail-open assertion is hermetic and deterministic everywhere,
not just on CI's Ubuntu runners.

No production code changed — this is a test-hermeticity fix.

## How this was validated

- Reproduced the failure locally on a macOS/Apple-Silicon machine with
  `spotter` installed via the Homebrew tap at `/opt/homebrew/bin/spotter`:
  running the full suite intermittently produced
  `subprocess.TimeoutExpired` on this test (real binary startup exceeding
  the 1s budget under load), while running the test in isolation passed —
  confirming it depends on ambient host state rather than test setup.
- With this change, the test passes both in isolation and repeatedly as
  part of the full suite.
- Full validation suite run clean:
  ```bash
  ruff format --check .
  ruff check .
  mypy src tests
  pytest
  ```